### PR TITLE
ci: add commit message lint rules

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      ["feat", "fix", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "test", "types", "style"]
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@babel/plugin-transform-object-assign": "^7.12.1",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
+    "@commitlint/cli": "^11.0.0",
+    "@commitlint/config-conventional": "^11.0.0",
     "@oasis-engine/typedoc-theme": "^0.0.2",
     "@rollup/plugin-babel": "^5.2.2",
     "@rollup/plugin-commonjs": "^17.0.0",
@@ -64,7 +66,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
- Add commit message lint rules.

if the commit message doesn't meet the standard. The cli tool will throw an error:

![image](https://user-images.githubusercontent.com/6926263/106565663-1d73d000-656a-11eb-992f-8947be531781.png)
