### PR TITLE
fix: parse components after the entity is mounted to the scene.

### DIFF
--- a/packages/loader/src/scene-loader/Oasis.ts
+++ b/packages/loader/src/scene-loader/Oasis.ts
@@ -51,9 +51,9 @@ export class Oasis extends EventDispatcher {
     return this.loadResources().then(() => {
       this.bindResources();
       this.parseEntities();
-      this.parseNodeAbilities();
       this.attach();
       this.nodeManager.addRootEntity();
+      this.parseNodeAbilities();
       this.pluginManager.boot(this);
     });
   }


### PR DESCRIPTION
compatable with oasis editor