### PR TITLE
fix: delete particle legacy

### DIFF
--- a/packages/loader/src/scene-loader/AbilityManager.ts
+++ b/packages/loader/src/scene-loader/AbilityManager.ts
@@ -29,7 +29,7 @@ export class AbilityManager {
       ability.enabled = enabled;
     }
 
-    if (type === "Model" || type === "GLTFModel" || type === "ParticleRenderer") {
+    if (type === "Model" || type === "GLTFModel") {
       // TODO
       (ability as any).init(abilityProps);
     } else {


### PR DESCRIPTION
The particle system has been reconstructed，so delete `init` api in scene-loader