### PR TITLE
fix:  enable variable macro will generate duplicate definition error in shader

### DIFF
--- a/packages/core/src/shader/ShaderData.ts
+++ b/packages/core/src/shader/ShaderData.ts
@@ -619,7 +619,7 @@ export class ShaderData implements IRefObject, IClone {
     const variableMacro = this._variableMacros;
     const variableValue = variableMacro[name];
     if (variableValue !== value) {
-      variableValue && this._disableVariableMacro(name, value);
+      variableValue && this._disableVariableMacro(name, variableValue);
 
       const macro = Shader.getMacroByName(`${name} ${value}`);
       this._macroCollection.enable(macro);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
Variable macro in shader will generate duplicate definition error.
### What is the new behavior (if this is a feature change)?
Delete original variable macro.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: