### PR TITLE
fix: Ensure writable before clearing the canvas buffer

### DIFF
--- a/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
+++ b/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
@@ -39,7 +39,7 @@ export class BasicRenderPipeline {
     this.addRenderPass(this._defaultPass);
 
     // TODO: remove in next version.
-    const material = this._defaultSpriteMaterial = new Material(camera.engine, Shader.find("Sprite"));
+    const material = (this._defaultSpriteMaterial = new Material(camera.engine, Shader.find("Sprite")));
     const target = material.renderState.blendState.targetBlendState;
     target.sourceColorBlendFactor = target.sourceAlphaBlendFactor = BlendFactor.SourceAlpha;
     target.destinationColorBlendFactor = target.destinationAlphaBlendFactor = BlendFactor.OneMinusSourceAlpha;
@@ -166,7 +166,7 @@ export class BasicRenderPipeline {
       const renderTarget = camera.renderTarget || pass.renderTarget;
       rhi.activeRenderTarget(renderTarget, camera);
       rhi.setRenderTargetFace(renderTarget, cubeFace);
-      rhi.clearRenderTarget(pass.clearMode, pass.clearParam);
+      rhi.clearRenderTarget(camera.engine, pass.clearMode, pass.clearParam);
 
       if (pass.renderOverride) {
         pass.render(camera, this.queue);

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -182,9 +182,6 @@ export class WebGLRenderer implements HardwareRenderer {
         gl.clearColor(clearParam.x, clearParam.y, clearParam.z, clearParam.w);
         clearColor = clearDepth = clearStencil = true;
         break;
-
-      case ClearMode.DONT_CLEAR:
-        break;
     }
 
     if (clearColor && colorWriteMask !== ColorWriteMask.All) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
Canvas buffer can't be cleared if the last material render state is not writable. 
eg. if the last material is transparent, engine will execute `gl.depthMask(false)` , then the canvas depth buffer in next render pass cannot be cleared cause of the depthMask state with `false`.
### What is the new behavior (if this is a feature change)?
Ensure all is writable before clearing the canvas buffer.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: