### PR TITLE
chore: remove version parameter of npm run doc cli

### DIFF
--- a/tools/typedoc/typedoc.js
+++ b/tools/typedoc/typedoc.js
@@ -1,9 +1,7 @@
-const VERSION = process.env.v;
-
 module.exports = {
   name: "Oasis Engine",
   mode: "modules",
-  out: `doc/${VERSION}`,
+  out: `api/`,
   theme: "./node_modules/@oasis-engine/typedoc-theme/bin/default",
   ignoreCompilerErrors: true,
   preserveConstEnums: true,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Update:  remove version parameter of `npm run doc` cli.

### What is the current behavior? (You can also link to an open issue here)
`npm run doc` generates a fold named `undefined` if you didn't pass a version parameter.

### What is the new behavior (if this is a feature change)?
No version fold any more, directly generated in `api` folder.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: