### PR TITLE
build: windows can't use rm command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "b:miniprogram": "cross-env NODE_ENV=MINI rollup -c",
     "b:all": "npm run b:types && npm run build-all",
     "clean": "lerna exec -- rm -rf dist && lerna clean",
-    "doc": "rm -rf doc && typedoc --options tools/typedoc/typedoc.js"
+    "doc": "typedoc --options tools/typedoc/typedoc.js"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/tools/typedoc/typedoc.js
+++ b/tools/typedoc/typedoc.js
@@ -1,3 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+
+fs.rmdirSync(path.join(process.cwd(), "api"), { recursive: true });
+
 module.exports = {
   name: "Oasis Engine",
   mode: "modules",
@@ -17,5 +22,5 @@ module.exports = {
     "packages/**/shaderLib/global.d.ts",
     "scripts/**/*"
   ],
-  plugin: ["@strictsoftware/typedoc-plugin-monorepo", 'typedoc-plugin-remove-references']
+  plugin: ["@strictsoftware/typedoc-plugin-monorepo", "typedoc-plugin-remove-references"]
 };


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

bug fix.

### What is the current behavior? (You can also link to an open issue here)

#50 

### What is the new behavior (if this is a feature change)?

Use node cross-platform api instead of `rm -rf`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.