### PR TITLE
fix(material): ambient light is not working with diffuse

### DIFF
--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -2,10 +2,6 @@
     vec4 emission = u_emissiveColor;
     vec4 diffuse = u_diffuseColor;
     vec4 specular = u_specularColor;
-      
-    #ifdef O3_HAS_AMBIENT_LIGHT
-        ambient += vec4(u_ambientLightColor, 1.0);
-    #endif
 
     #ifdef O3_EMISSIVE_TEXTURE
 
@@ -22,5 +18,11 @@
     #ifdef O3_SPECULAR_TEXTURE
 
         specular *= texture2D(u_specularTexture, v_uv);
+
+    #endif
+
+    #ifdef O3_HAS_AMBIENT_LIGHT
+
+        ambient = vec4(u_ambientLightColor, 1.0) * diffuse;
 
     #endif


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

### What is the current behavior? (You can also link to an open issue here)

With ambient light whose color is rgb(255, 255, 255) and intensity is 1.0, material diffuse color is rgba(126, 115, 212, 255):

![image](https://user-images.githubusercontent.com/6926263/109407549-aa207b00-79bc-11eb-94c9-9c2262d01f0e.png)

### What is the new behavior (if this is a feature change)?

With the same properties, the result is: 
![image](https://user-images.githubusercontent.com/6926263/109407681-c96bd800-79bd-11eb-9317-52710b18a713.png)




