### PR TITLE
fix: prevent TypeError: Cannot read property '_target' of undefined while 'maxJoints' is too small

### DIFF
--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -136,9 +136,6 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       if (joints.length > maxJoints) {
         if (rhi.canIUseMoreJoints) {
           this._useJointTexture = true;
-          this.createJointTexture();
-          shaderData.enableMacro("O3_USE_JOINT_TEXTURE");
-          shaderData.setTexture(SkinnedMeshRenderer._jointSamplerProperty, this.jointTexture);
         } else {
           Logger.error(
             `component's joints count(${joints}) greater than device's MAX_VERTEX_UNIFORM_VECTORS number ${maxAttribUniformVec4}, and don't support jointTexture in this device. suggest joint count less than ${maxJoints}.`,
@@ -224,5 +221,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       this.jointTexture.filterMode = TextureFilterMode.Point;
     }
     this.jointTexture.setPixelBuffer(this.matrixPalette);
+    this.shaderData.enableMacro("O3_USE_JOINT_TEXTURE");
+    this.shaderData.setTexture(SkinnedMeshRenderer._jointSamplerProperty, this.jointTexture);
   }
 }

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -136,6 +136,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       if (joints.length > maxJoints) {
         if (rhi.canIUseMoreJoints) {
           this._useJointTexture = true;
+          this.createJointTexture();
           shaderData.enableMacro("O3_USE_JOINT_TEXTURE");
           shaderData.setTexture(SkinnedMeshRenderer._jointSamplerProperty, this.jointTexture);
         } else {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

修复官方「骨骼动画」demo 在有些平台抛出的 TypeError 异常

### What is the current behavior? (You can also link to an open issue here)


### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information: