### PR TITLE
fix: prevent gl throw error when `clearFlag` is undefined

### DIFF
--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -193,7 +193,7 @@ export class WebGLRenderer implements HardwareRenderer {
       stencilState.writeMask = 0xff;
     }
 
-    gl.clear(clearFlag);
+    clearFlag && gl.clear(clearFlag);
   }
 
   drawPrimitive(primitive: Primitive, subPrimitive: SubPrimitive, shaderProgram: any) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
gl will throw error when `clearFlag` is undefined
### What is the new behavior (if this is a feature change)?
Fixed.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: