### PR TITLE
Feat[Long term]: use spherical harmonic instead of irradiance cube map.

### DIFF
--- a/packages/baker/package.json
+++ b/packages/baker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@oasis-engine/baker",
+  "version": "0.2.1",
+  "license": "MIT",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "types/index.d.ts",
+  "scripts": {
+    "b:types": "tsc"
+  },
+  "files": [
+    "dist/**/*",
+    "types/**/*"
+  ],
+  "dependencies": {
+    "@oasis-engine/core": "0.2.1",
+    "@oasis-engine/math": "0.2.1"
+  }
+}

--- a/packages/baker/src/SphericalHarmonics3Baker.ts
+++ b/packages/baker/src/SphericalHarmonics3Baker.ts
@@ -1,0 +1,76 @@
+import { TextureCubeFace, TextureCubeMap } from "@oasis-engine/core";
+import { Color, SphericalHarmonics3, Vector3 } from "@oasis-engine/math";
+
+/**
+ * Bake irradiance into spherical harmonics3.
+ * @remarks
+ * http://www.ppsloan.org/publications/StupidSH36.pdf
+ */
+export class SphericalHarmonics3Baker {
+  private static _tempColor: Color = new Color();
+  private static _tempVector: Vector3 = new Vector3();
+
+  /**
+   * Bake from Cube texture.
+   * @param texture - Cube texture
+   * @param out - SH3 for output
+   */
+  static fromTextureCubeMap(texture: TextureCubeMap, out: SphericalHarmonics3): void {
+    out.clear();
+
+    const channelLength = 4;
+    const textureSize = texture.width;
+    const data = new Uint8Array(textureSize * textureSize * channelLength); // read pixel always return rgba
+    const color = SphericalHarmonics3Baker._tempColor;
+    const direction = SphericalHarmonics3Baker._tempVector;
+    const texelSize = 2 / textureSize; // convolution is in the space of [-1, 1]
+
+    let solidAngleSum = 0; // ideal value is 4 * pi
+
+    for (let faceIndex = 0; faceIndex < 6; faceIndex++) {
+      texture.getPixelBuffer(TextureCubeFace.PositiveX + faceIndex, 0, 0, textureSize, textureSize, data);
+      let v = texelSize * 0.5 - 1;
+      for (let y = 0; y < textureSize; y++) {
+        let u = texelSize * 0.5 - 1;
+        for (let x = 0; x < textureSize; x++) {
+          const dataOffset = y * textureSize * channelLength + x * channelLength;
+          // @todo: float, sRGB, HDR, gamma
+          // @todo: alpha is invalid, maybe Color3 needed ?
+          color.setValue(data[dataOffset], data[dataOffset + 1], data[dataOffset + 2], 0).scale(1 / 255);
+
+          switch (faceIndex) {
+            case TextureCubeFace.PositiveX:
+              direction.setValue(1, -v, -u);
+              break;
+            case TextureCubeFace.NegativeX:
+              direction.setValue(-1, -v, u);
+              break;
+            case TextureCubeFace.PositiveY:
+              direction.setValue(u, 1, v);
+              break;
+            case TextureCubeFace.NegativeY:
+              direction.setValue(u, -1, -v);
+              break;
+            case TextureCubeFace.PositiveZ:
+              direction.setValue(u, -v, 1);
+              break;
+            case TextureCubeFace.NegativeZ:
+              direction.setValue(-u, -v, -1);
+              break;
+          }
+          /**
+           * dA = cos = S / r = 4 / r
+           * dw =  dA / r2 = 4 / r / r2
+           */
+          const solidAngle = 4 / (direction.length() * direction.lengthSquared());
+          solidAngleSum += solidAngle;
+          out.addRadiance(color, direction.normalize(), solidAngle);
+          u += texelSize;
+        }
+        v += texelSize;
+      }
+    }
+
+    out.scale((4 * Math.PI) / solidAngleSum);
+  }
+}

--- a/packages/baker/src/index.ts
+++ b/packages/baker/src/index.ts
@@ -1,0 +1,1 @@
+export { SphericalHarmonics3Baker } from "./SphericalHarmonics3Baker";

--- a/packages/baker/tsconfig.json
+++ b/packages/baker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "declaration": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": true,
+    "stripInternal": true,
+    "sourceMap": true,
+    "strict": false,
+    "incremental": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/src/lighting/EnvironmentMapLight.ts
+++ b/packages/core/src/lighting/EnvironmentMapLight.ts
@@ -92,6 +92,7 @@ export class EnvironmentMapLight extends Light {
 
   /**
    * Diffuse intensity.
+   * @remarks Only take effect when `diffuseSphericalHarmonics` is set.
    */
   get diffuseIntensity(): number {
     return this._diffuseIntensity;

--- a/packages/core/src/lighting/EnvironmentMapLight.ts
+++ b/packages/core/src/lighting/EnvironmentMapLight.ts
@@ -1,4 +1,4 @@
-import { Color } from "@oasis-engine/math";
+import { Color, SphericalHarmonics3 } from "@oasis-engine/math";
 import { Entity } from "../Entity";
 import { Shader } from "../shader";
 import { ShaderData } from "../shader/ShaderData";
@@ -13,10 +13,9 @@ import { Light } from "./Light";
 export class EnvironmentMapLight extends Light {
   private static _diffuseMacro: ShaderMacro = Shader.getMacroByName("O3_USE_DIFFUSE_ENV");
   private static _specularMacro: ShaderMacro = Shader.getMacroByName("O3_USE_SPECULAR_ENV");
-  private static _diffuseTextureProperty: ShaderProperty = Shader.getPropertyByName("u_env_diffuseSampler");
+  private static _diffuseSHProperty: ShaderProperty = Shader.getPropertyByName("u_env_sh");
   private static _specularTextureProperty: ShaderProperty = Shader.getPropertyByName("u_env_specularSampler");
   private static _mipLevelProperty: ShaderProperty = Shader.getPropertyByName("u_envMapLight.mipMapLevel");
-  private static _diffuseColorProperty: ShaderProperty = Shader.getPropertyByName("u_envMapLight.diffuse");
   private static _specularColorProperty: ShaderProperty = Shader.getPropertyByName("u_envMapLight.specular");
   private static _diffuseIntensityProperty: ShaderProperty = Shader.getPropertyByName("u_envMapLight.diffuseIntensity");
   private static _specularIntensityProperty: ShaderProperty = Shader.getPropertyByName(
@@ -33,19 +32,25 @@ export class EnvironmentMapLight extends Light {
     shaderData.setMatrix(EnvironmentMapLight._transformMatrixProperty, transformMatrix);
   }
 
+  private _diffuseSphericalHarmonics: SphericalHarmonics3;
+  private _specularTexture: TextureCubeMap;
+  private _specularColor: Color = new Color(0.5, 0.5, 0.5, 1);
+  private _diffuseIntensity: number = 1;
+  private _specularIntensity: number = 1;
+
   /**
    * Diffuse cube texture.
    */
-  get diffuseTexture(): TextureCubeMap {
-    return this._diffuseTexture;
+  get diffuseSphericalHarmonics(): SphericalHarmonics3 {
+    return this._diffuseSphericalHarmonics;
   }
 
-  set diffuseTexture(value: TextureCubeMap) {
-    this._diffuseTexture = value;
+  set diffuseSphericalHarmonics(sh: SphericalHarmonics3) {
+    this._diffuseSphericalHarmonics = sh;
     const shaderData = this.scene.shaderData;
 
-    if (value) {
-      shaderData.setTexture(EnvironmentMapLight._diffuseTextureProperty, value);
+    if (sh) {
+      shaderData.setFloatArray(EnvironmentMapLight._diffuseSHProperty, sh.preScaledCoefficients);
       shaderData.enableMacro(EnvironmentMapLight._diffuseMacro);
     } else {
       shaderData.disableMacro(EnvironmentMapLight._diffuseMacro);
@@ -70,19 +75,6 @@ export class EnvironmentMapLight extends Light {
     } else {
       shaderData.disableMacro(EnvironmentMapLight._specularMacro);
     }
-  }
-
-  /**
-   * Diffuse color.
-   */
-  get diffuseColor(): Color {
-    return this._diffuseColor;
-  }
-
-  set diffuseColor(value: Color) {
-    this._diffuseColor = value;
-
-    this.scene.shaderData.setColor(EnvironmentMapLight._diffuseColorProperty, value);
   }
 
   /**
@@ -124,16 +116,8 @@ export class EnvironmentMapLight extends Light {
     this.scene.shaderData.setFloat(EnvironmentMapLight._specularIntensityProperty, value);
   }
 
-  private _diffuseTexture: TextureCubeMap;
-  private _specularTexture: TextureCubeMap;
-  private _diffuseColor: Color = new Color(0.3, 0.3, 0.3, 1);
-  private _specularColor: Color = new Color(0.5, 0.5, 0.5, 1);
-  private _diffuseIntensity: number = 1;
-  private _specularIntensity: number = 1;
-
   constructor(entity: Entity) {
     super(entity);
-    this.diffuseColor = this._diffuseColor;
     this.specularColor = this._specularColor;
     this.diffuseIntensity = this._diffuseIntensity;
     this.specularIntensity = this._specularIntensity;

--- a/packages/core/src/shaderlib/pbr/envmap_light_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/envmap_light_frag_define.glsl
@@ -1,7 +1,6 @@
 #ifdef O3_HAS_ENVMAP_LIGHT
 
 struct EnvMapLight {
-    vec3 diffuse;
     vec3 specular;
     float mipMapLevel;
     float diffuseIntensity;
@@ -13,7 +12,7 @@ struct EnvMapLight {
 uniform EnvMapLight u_envMapLight;
 
 #ifdef O3_USE_DIFFUSE_ENV
-    uniform samplerCube u_env_diffuseSampler;
+    uniform vec3 u_env_sh[9];
 #endif
 
 #ifdef O3_USE_SPECULAR_ENV

--- a/packages/core/src/shaderlib/pbr/ibl_diffuse_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_diffuse_frag.glsl
@@ -1,25 +1,11 @@
-#if defined(RE_IndirectDiffuse)
+#ifdef RE_IndirectDiffuse
 
     vec3 irradiance = vec3(0);
 
-    #if defined(O3_HAS_AMBIENT_LIGHT)
+    #ifdef O3_USE_DIFFUSE_ENV
+        irradiance += getLightProbeIrradiance(u_env_sh, normal) * u_envMapLight.diffuseIntensity;;
+    #elif defined(O3_HAS_AMBIENT_LIGHT)
         irradiance += getAmbientLightIrradiance(u_ambientLightColor);
-    #endif
-
-    #if defined(O3_HAS_ENVMAP_LIGHT)
-
-        #ifdef O3_USE_DIFFUSE_ENV
-            vec3 lightMapIrradiance = textureCube(u_env_diffuseSampler, geometry.normal).rgb * u_envMapLight.diffuseIntensity;
-        #else
-            vec3 lightMapIrradiance = u_envMapLight.diffuse * u_envMapLight.diffuseIntensity;
-        #endif
-
-        #ifndef PHYSICALLY_CORRECT_LIGHTS
-            lightMapIrradiance *= PI;
-        #endif
-
-        irradiance += lightMapIrradiance;
-
     #endif
 
     RE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );

--- a/packages/core/src/shaderlib/pbr/ibl_diffuse_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_diffuse_frag.glsl
@@ -2,7 +2,7 @@
 
     vec3 irradiance = vec3(0);
 
-    #ifdef O3_USE_DIFFUSE_ENV
+    #if defined(O3_HAS_ENVMAP_LIGHT) && defined(O3_USE_DIFFUSE_ENV)
         irradiance += getLightProbeIrradiance(u_env_sh, normal) * u_envMapLight.diffuseIntensity;;
     #elif defined(O3_HAS_AMBIENT_LIGHT)
         irradiance += getAmbientLightIrradiance(u_ambientLightColor);

--- a/packages/core/src/shaderlib/pbr/ibl_diffuse_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/ibl_diffuse_frag_define.glsl
@@ -21,3 +21,21 @@ vec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {
 }
 
 #endif
+
+// sh need be pre-scaled in CPU.
+vec3 getLightProbeIrradiance(vec3 sh[9], vec3 normal){
+      vec3 result = sh[0] +
+
+            sh[1] * (normal.y) +
+            sh[2] * (normal.z) +
+            sh[3] * (normal.x) +
+
+            sh[4] * (normal.y * normal.x) +
+            sh[5] * (normal.y * normal.z) +
+            sh[6] * (3.0 * normal.z * normal.z - 1.0) +
+            sh[7] * (normal.z * normal.x) +
+            sh[8] * (normal.x * normal.x - normal.y * normal.y);
+    
+    return max(result, vec3(0.0));
+
+}

--- a/packages/math/src/Color.ts
+++ b/packages/math/src/Color.ts
@@ -50,6 +50,38 @@ export class Color implements IClone {
     );
   }
 
+  /**
+   * Determines the sum of two colors.
+   * @param left - The first color to add
+   * @param right - The second color to add
+   * @param out - The sum of two colors
+   * @returns Added color
+   */
+  static add(left: Color, right: Color, out: Color): Color {
+    out.r = left.r + right.r;
+    out.g = left.g + right.g;
+    out.b = left.b + right.b;
+    out.a = left.a + right.a;
+
+    return out;
+  }
+
+  /**
+   * Scale a color by the given value.
+   * @param left - The color to scale
+   * @param scale - The amount by which to scale the color
+   * @param out - The scaled color
+   * @returns Scaled color
+   */
+  static scale(left: Color, s: number, out: Color): Color {
+    out.r = left.r * s;
+    out.g = left.g * s;
+    out.b = left.b * s;
+    out.a = left.a * s;
+
+    return out;
+  }
+
   /** The red component of the color, 0~1. */
   public r: number;
   /** The green component of the color, 0~1. */
@@ -86,6 +118,34 @@ export class Color implements IClone {
     this.g = g;
     this.b = b;
     this.a = a;
+    return this;
+  }
+
+  /**
+   * Determines the sum of this color and the specified color.
+   * @param color - The specified color
+   * @returns This color
+   */
+  add(color: Color): Color {
+    this.r += color.r;
+    this.g += color.g;
+    this.b += color.b;
+    this.a += color.a;
+
+    return this;
+  }
+
+  /**
+   * Scale this color by the given value.
+   * @param s - The amount by which to scale the color
+   * @returns This color
+   */
+  scale(s: number): Color {
+    this.r *= s;
+    this.g *= s;
+    this.b *= s;
+    this.a *= s;
+
     return this;
   }
 

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -135,6 +135,21 @@ export class SphericalHarmonics3 implements IClone {
   }
 
   /**
+   * Scale the coefficients.
+   */
+  scale(value: number) {
+    this.y00.scale(value);
+    this.y1_1.scale(value);
+    this.y10.scale(value);
+    this.y11.scale(value);
+    this.y2_2.scale(value);
+    this.y2_1.scale(value);
+    this.y20.scale(value);
+    this.y21.scale(value);
+    this.y22.scale(value);
+  }
+
+  /**
    * Clear SH3 to zero.
    */
   clear(): void {

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -62,7 +62,7 @@ export class SphericalHarmonics3 implements IClone {
   get preScaledCoefficients(): Float32Array {
     const kernel = SphericalHarmonics3._convolutionKernel;
     const basis = SphericalHarmonics3._basisFunction;
-    const arrayBuffer = this._coefficients;
+    const data = this._coefficients;
 
     /**
      * 1.  L -> E
@@ -70,39 +70,39 @@ export class SphericalHarmonics3 implements IClone {
      */
 
     // l0
-    arrayBuffer[0] = this.y00.r * kernel[0] * basis[0];
-    arrayBuffer[1] = this.y00.g * kernel[0] * basis[0];
-    arrayBuffer[2] = this.y00.b * kernel[0] * basis[0];
+    data[0] = this.y00.r * kernel[0] * basis[0];
+    data[1] = this.y00.g * kernel[0] * basis[0];
+    data[2] = this.y00.b * kernel[0] * basis[0];
 
     // l1
-    arrayBuffer[3] = this.y1_1.r * kernel[1] * basis[1];
-    arrayBuffer[4] = this.y1_1.g * kernel[1] * basis[1];
-    arrayBuffer[5] = this.y1_1.b * kernel[1] * basis[1];
-    arrayBuffer[6] = this.y10.r * kernel[1] * basis[2];
-    arrayBuffer[7] = this.y10.g * kernel[1] * basis[2];
-    arrayBuffer[8] = this.y10.b * kernel[1] * basis[2];
-    arrayBuffer[9] = this.y11.r * kernel[1] * basis[3];
-    arrayBuffer[10] = this.y11.g * kernel[1] * basis[3];
-    arrayBuffer[11] = this.y11.b * kernel[1] * basis[3];
+    data[3] = this.y1_1.r * kernel[1] * basis[1];
+    data[4] = this.y1_1.g * kernel[1] * basis[1];
+    data[5] = this.y1_1.b * kernel[1] * basis[1];
+    data[6] = this.y10.r * kernel[1] * basis[2];
+    data[7] = this.y10.g * kernel[1] * basis[2];
+    data[8] = this.y10.b * kernel[1] * basis[2];
+    data[9] = this.y11.r * kernel[1] * basis[3];
+    data[10] = this.y11.g * kernel[1] * basis[3];
+    data[11] = this.y11.b * kernel[1] * basis[3];
 
     // l2
-    arrayBuffer[12] = this.y2_2.r * kernel[2] * basis[4];
-    arrayBuffer[13] = this.y2_2.g * kernel[2] * basis[4];
-    arrayBuffer[14] = this.y2_2.b * kernel[2] * basis[4];
-    arrayBuffer[15] = this.y2_1.r * kernel[2] * basis[5];
-    arrayBuffer[16] = this.y2_1.g * kernel[2] * basis[5];
-    arrayBuffer[17] = this.y2_1.b * kernel[2] * basis[5];
-    arrayBuffer[18] = this.y20.r * kernel[2] * basis[6];
-    arrayBuffer[19] = this.y20.g * kernel[2] * basis[6];
-    arrayBuffer[20] = this.y20.b * kernel[2] * basis[6];
-    arrayBuffer[21] = this.y21.r * kernel[2] * basis[7];
-    arrayBuffer[22] = this.y21.g * kernel[2] * basis[7];
-    arrayBuffer[23] = this.y21.b * kernel[2] * basis[7];
-    arrayBuffer[24] = this.y22.r * kernel[2] * basis[8];
-    arrayBuffer[25] = this.y22.g * kernel[2] * basis[8];
-    arrayBuffer[26] = this.y22.b * kernel[2] * basis[8];
+    data[12] = this.y2_2.r * kernel[2] * basis[4];
+    data[13] = this.y2_2.g * kernel[2] * basis[4];
+    data[14] = this.y2_2.b * kernel[2] * basis[4];
+    data[15] = this.y2_1.r * kernel[2] * basis[5];
+    data[16] = this.y2_1.g * kernel[2] * basis[5];
+    data[17] = this.y2_1.b * kernel[2] * basis[5];
+    data[18] = this.y20.r * kernel[2] * basis[6];
+    data[19] = this.y20.g * kernel[2] * basis[6];
+    data[20] = this.y20.b * kernel[2] * basis[6];
+    data[21] = this.y21.r * kernel[2] * basis[7];
+    data[22] = this.y21.g * kernel[2] * basis[7];
+    data[23] = this.y21.b * kernel[2] * basis[7];
+    data[24] = this.y22.r * kernel[2] * basis[8];
+    data[25] = this.y22.g * kernel[2] * basis[8];
+    data[26] = this.y22.b * kernel[2] * basis[8];
 
-    return arrayBuffer;
+    return data;
   }
 
   /**

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -176,15 +176,15 @@ export class SphericalHarmonics3 implements IClone {
    * @override
    */
   cloneTo(out: SphericalHarmonics3): SphericalHarmonics3 {
-    out.y00 = this.y00;
-    out.y1_1 = this.y1_1;
-    out.y10 = this.y10;
-    out.y11 = this.y11;
-    out.y2_2 = this.y2_2;
-    out.y2_1 = this.y2_1;
-    out.y20 = this.y20;
-    out.y21 = this.y21;
-    out.y22 = this.y22;
+    this.y00.cloneTo(out.y00);
+    this.y1_1.cloneTo(out.y1_1);
+    this.y10.cloneTo(out.y10);
+    this.y11.cloneTo(out.y11);
+    this.y2_2.cloneTo(out.y2_2);
+    this.y2_1.cloneTo(out.y2_1);
+    this.y20.cloneTo(out.y20);
+    this.y21.cloneTo(out.y21);
+    this.y22.cloneTo(out.y22);
     return out;
   }
 }

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -110,13 +110,16 @@ export class SphericalHarmonics3 implements IClone {
    * @remarks
    * Implements `EvalSHBasis` from [Projection from Cube maps] in http://www.ppsloan.org/publications/StupidSH36.pdf.
    *
-   * @param color - radiance color
-   * @param direction - radiance direction
+   * @param color - Radiance color
+   * @param direction - Radiance direction
+   * @param solidAngle - Radiance solid angle, dA / (r^2)
    */
-  addRadiance(color: Color, direction: Vector3): void {
+  addRadiance(color: Color, direction: Vector3, solidAngle: number): void {
     const basis = SphericalHarmonics3._basisFunction;
     const tempColor = SphericalHarmonics3._tempColor;
     const { x, y, z } = direction;
+
+    color.scale(solidAngle);
 
     this.y00.add(Color.scale(color, basis[0], tempColor));
 

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -1,0 +1,172 @@
+import { IClone } from "@oasis-engine/design";
+import { Color } from "./Color";
+import { Vector3 } from "./Vector3";
+
+/**
+ * Use SH3 to represent irradiance environment maps efficiently, allowing for interactive rendering of diffuse objects under distant illumination.
+ * @remarks
+ * https://graphics.stanford.edu/papers/envmap/envmap.pdf
+ * http://www.ppsloan.org/publications/StupidSH36.pdf
+ * https://google.github.io/filament/Filament.md.html#annex/sphericalharmonics
+ */
+export class SphericalHarmonics3 implements IClone {
+  private static _basisFunction = [
+    0.282095, //  1/2 * Math.sqrt(1 / PI)
+
+    -0.488603, // -1/2 * Math.sqrt(3 / PI)
+    0.488603, //  1/2 * Math.sqrt(3 / PI)
+    -0.488603, // -1/2 * Math.sqrt(3 / PI)
+
+    1.092548, //  1/2 * Math.sqrt(15 / PI)
+    -1.092548, // -1/2 * Math.sqrt(15 / PI)
+    0.315392, //  1/4 * Math.sqrt(5 / PI)
+    -1.092548, // -1/2 * Math.sqrt(15 / PI)
+    0.546274 //  1/4 * Math.sqrt(15 / PI)
+  ];
+
+  private static _convolutionKernel = [
+    3.141593, //  PI
+    2.094395, // (2 * PI) / 3,
+    0.785398 //   PI / 4
+  ];
+
+  private static _tempColor = new Color();
+
+  /**  The Y(0, 0) coefficient of the SH3. */
+  y00: Color = new Color(0, 0, 0, 0);
+  /**  The Y(1, -1) coefficient of the SH3. */
+  y1_1: Color = new Color(0, 0, 0, 0);
+  /**  The Y(1, 0) coefficient of the SH3. */
+  y10: Color = new Color(0, 0, 0, 0);
+  /**  The Y(1, 1) coefficient of the SH3. */
+  y11: Color = new Color(0, 0, 0, 0);
+  /**  The Y(2, -2) coefficient of the SH3. */
+  y2_2: Color = new Color(0, 0, 0, 0);
+  /**  The Y(2, -1) coefficient of the SH3. */
+  y2_1: Color = new Color(0, 0, 0, 0);
+  /**  The Y(2, 0) coefficient of the SH3. */
+  y20: Color = new Color(0, 0, 0, 0);
+  /**  The Y(2, 1) coefficient of the SH3. */
+  y21: Color = new Color(0, 0, 0, 0);
+  /**  The Y(2, 2) coefficient of the SH3. */
+  y22: Color = new Color(0, 0, 0, 0);
+
+  private _coefficients: Float32Array = new Float32Array(27);
+
+  /**
+   * Get pre-scaled coefficients used in shader.
+   * @remarks
+   * Convert radiance to irradiance with the A_l which is convoluted by the cosine lobe and pre-scale the basis function.
+   * Reference equation [4,5,6,7,8,9] from https://graphics.stanford.edu/papers/envmap/envmap.pdf
+   */
+  get preScaledCoefficients(): Float32Array {
+    const kernel = SphericalHarmonics3._convolutionKernel;
+    const basis = SphericalHarmonics3._basisFunction;
+    const arrayBuffer = this._coefficients;
+
+    /**
+     * 1.  L -> E
+     * 2.  E * basis
+     */
+
+    // l0
+    arrayBuffer[0] = this.y00.r * kernel[0] * basis[0];
+    arrayBuffer[1] = this.y00.g * kernel[0] * basis[0];
+    arrayBuffer[2] = this.y00.b * kernel[0] * basis[0];
+
+    // l1
+    arrayBuffer[3] = this.y1_1.r * kernel[1] * basis[1];
+    arrayBuffer[4] = this.y1_1.g * kernel[1] * basis[1];
+    arrayBuffer[5] = this.y1_1.b * kernel[1] * basis[1];
+    arrayBuffer[6] = this.y10.r * kernel[1] * basis[2];
+    arrayBuffer[7] = this.y10.g * kernel[1] * basis[2];
+    arrayBuffer[8] = this.y10.b * kernel[1] * basis[2];
+    arrayBuffer[9] = this.y11.r * kernel[1] * basis[3];
+    arrayBuffer[10] = this.y11.g * kernel[1] * basis[3];
+    arrayBuffer[11] = this.y11.b * kernel[1] * basis[3];
+
+    // l2
+    arrayBuffer[12] = this.y2_2.r * kernel[2] * basis[4];
+    arrayBuffer[13] = this.y2_2.g * kernel[2] * basis[4];
+    arrayBuffer[14] = this.y2_2.b * kernel[2] * basis[4];
+    arrayBuffer[15] = this.y2_1.r * kernel[2] * basis[5];
+    arrayBuffer[16] = this.y2_1.g * kernel[2] * basis[5];
+    arrayBuffer[17] = this.y2_1.b * kernel[2] * basis[5];
+    arrayBuffer[18] = this.y20.r * kernel[2] * basis[6];
+    arrayBuffer[19] = this.y20.g * kernel[2] * basis[6];
+    arrayBuffer[20] = this.y20.b * kernel[2] * basis[6];
+    arrayBuffer[21] = this.y21.r * kernel[2] * basis[7];
+    arrayBuffer[22] = this.y21.g * kernel[2] * basis[7];
+    arrayBuffer[23] = this.y21.b * kernel[2] * basis[7];
+    arrayBuffer[24] = this.y22.r * kernel[2] * basis[8];
+    arrayBuffer[25] = this.y22.g * kernel[2] * basis[8];
+    arrayBuffer[26] = this.y22.b * kernel[2] * basis[8];
+
+    return arrayBuffer;
+  }
+
+  /**
+   * Add radiance to the SH3 in specified direction.
+   * @remarks
+   * Implements `EvalSHBasis` from [Projection from Cube maps] in http://www.ppsloan.org/publications/StupidSH36.pdf.
+   *
+   * @param color - radiance color
+   * @param direction - radiance direction
+   */
+  addRadiance(color: Color, direction: Vector3): void {
+    const basis = SphericalHarmonics3._basisFunction;
+    const tempColor = SphericalHarmonics3._tempColor;
+    const { x, y, z } = direction;
+
+    this.y00.add(Color.scale(color, basis[0], tempColor));
+
+    this.y1_1.add(Color.scale(color, basis[1] * y, tempColor));
+    this.y10.add(Color.scale(color, basis[2] * z, tempColor));
+    this.y11.add(Color.scale(color, basis[3] * x, tempColor));
+
+    this.y2_2.add(Color.scale(color, basis[4] * x * y, tempColor));
+    this.y2_1.add(Color.scale(color, basis[5] * y * z, tempColor));
+    this.y20.add(Color.scale(color, basis[6] * (3 * z * z - 1), tempColor));
+    this.y21.add(Color.scale(color, basis[7] * x * z, tempColor));
+    this.y22.add(Color.scale(color, basis[8] * (x * x - y * y), tempColor));
+  }
+
+  /**
+   * Clear SH3 to zero.
+   */
+  clear(): void {
+    this.y00.setValue(0, 0, 0, 0);
+    this.y1_1.setValue(0, 0, 0, 0);
+    this.y10.setValue(0, 0, 0, 0);
+    this.y11.setValue(0, 0, 0, 0);
+    this.y2_2.setValue(0, 0, 0, 0);
+    this.y2_1.setValue(0, 0, 0, 0);
+    this.y20.setValue(0, 0, 0, 0);
+    this.y21.setValue(0, 0, 0, 0);
+    this.y22.setValue(0, 0, 0, 0);
+  }
+
+  /**
+   * @override
+   */
+  clone(): SphericalHarmonics3 {
+    const v = new SphericalHarmonics3();
+    return this.cloneTo(v);
+  }
+
+  /**
+   * @override
+   */
+  cloneTo(out: SphericalHarmonics3): SphericalHarmonics3 {
+    out.y00 = this.y00;
+    out.y1_1 = this.y1_1;
+    out.y10 = this.y10;
+    out.y11 = this.y11;
+    out.y2_2 = this.y2_2;
+    out.y2_1 = this.y2_1;
+    out.y20 = this.y20;
+    out.y21 = this.y21;
+    out.y22 = this.y22;
+    return out;
+  }
+}

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -14,3 +14,4 @@ export { Vector3 } from "./Vector3";
 export { Vector4 } from "./Vector4";
 export { Plane } from "./Plane";
 export { Color } from "./Color";
+export { SphericalHarmonics3 } from "./SphericalHarmonics3";


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
feature.

### What is the current behavior? (You can also link to an open issue here)
Use irradiancee cube map to calculate indirect diffuse radiance.

### What is the new behavior (if this is a feature change)?
Use spherical harmonics3 to store light irradiance, and calculate indirect diffuse radiance by parsing sh.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Yes.
* delete `EnvironmentMapLight.diffuseTexture`
* add `EnvironmentMapLight.diffuseSphericalHarmonics`

### Other information: