### PR TITLE
fix: set default active texture unit

### DIFF
--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -69,7 +69,7 @@ export class WebGLRenderer implements IHardwareRenderer {
   private _capability: GLCapability;
   private _isWebGL2: boolean;
 
-  private _activedTextureID: number;
+  private _activedTextureID: number = WebGLRenderingContext.TEXTURE0;
   private _activeTextures: GLTexture[] = new Array(32);
 
   get isWebGL2() {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
store NaN when bind texture first.
### What is the new behavior (if this is a feature change)?
store gl.TEXTURE0