### PR TITLE
Fix: point/spot light have some bugs.

### DIFF
--- a/packages/core/src/lighting/PointLight.ts
+++ b/packages/core/src/lighting/PointLight.ts
@@ -11,13 +11,11 @@ export class PointLight extends Light {
   private static _colorProperty: ShaderProperty = Shader.getPropertyByName("u_pointLightColor");
   private static _positionProperty: ShaderProperty = Shader.getPropertyByName("u_pointLightPosition");
   private static _distanceProperty: ShaderProperty = Shader.getPropertyByName("u_pointLightDistance");
-  private static _decayProperty: ShaderProperty = Shader.getPropertyByName("u_pointLightDecay");
 
   private static _combinedData = {
     color: new Float32Array(3 * Light._maxLight),
     position: new Float32Array(3 * Light._maxLight),
-    distance: new Float32Array(Light._maxLight),
-    decay: new Float32Array(Light._maxLight)
+    distance: new Float32Array(Light._maxLight)
   };
 
   /**
@@ -29,13 +27,11 @@ export class PointLight extends Light {
     shaderData.setFloatArray(PointLight._colorProperty, data.color);
     shaderData.setFloatArray(PointLight._positionProperty, data.position);
     shaderData.setFloatArray(PointLight._distanceProperty, data.distance);
-    shaderData.setFloatArray(PointLight._decayProperty, data.decay);
   }
 
   color: Color = new Color(1, 1, 1, 1);
   intensity: number = 1.0;
   distance: number = 100;
-  decay: number = 0;
 
   private _lightColor: Color = new Color(1, 1, 1, 1);
 
@@ -64,7 +60,6 @@ export class PointLight extends Light {
     const colorStart = lightIndex * 3;
     const positionStart = lightIndex * 3;
     const distanceStart = lightIndex;
-    const decayStart = lightIndex;
 
     const lightColor = this.lightColor;
     const lightPosition = this.position;
@@ -78,6 +73,5 @@ export class PointLight extends Light {
     data.position[positionStart + 1] = lightPosition.y;
     data.position[positionStart + 2] = lightPosition.z;
     data.distance[distanceStart] = this.distance;
-    data.decay[decayStart] = this.decay;
   }
 }

--- a/packages/core/src/lighting/PointLight.ts
+++ b/packages/core/src/lighting/PointLight.ts
@@ -28,9 +28,11 @@ export class PointLight extends Light {
     shaderData.setFloatArray(PointLight._positionProperty, data.position);
     shaderData.setFloatArray(PointLight._distanceProperty, data.distance);
   }
-
+  /** Light color. */
   color: Color = new Color(1, 1, 1, 1);
+  /** Light intensity. */
   intensity: number = 1.0;
+  /** Defines a distance cutoff at which the light's intensity must be considered zero. */
   distance: number = 100;
 
   private _lightColor: Color = new Color(1, 1, 1, 1);

--- a/packages/core/src/lighting/SpotLight.ts
+++ b/packages/core/src/lighting/SpotLight.ts
@@ -12,22 +12,16 @@ export class SpotLight extends Light {
   private static _positionProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightPosition");
   private static _directionProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightDirection");
   private static _distanceProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightDistance");
-  private static _decayProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightDecay");
-  private static _angleProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightAngle");
-  private static _penumbraProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightPenumbra");
+  private static _angleCosProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightAngleCos");
   private static _penumbraCosProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightPenumbraCos");
-  private static _coneCosProperty: ShaderProperty = Shader.getPropertyByName("u_spotLightConeCos");
 
   private static _combinedData = {
     color: new Float32Array(3 * Light._maxLight),
     position: new Float32Array(3 * Light._maxLight),
     direction: new Float32Array(3 * Light._maxLight),
     distance: new Float32Array(Light._maxLight),
-    decay: new Float32Array(Light._maxLight),
-    angle: new Float32Array(Light._maxLight),
-    penumbra: new Float32Array(Light._maxLight),
-    penumbraCos: new Float32Array(Light._maxLight),
-    coneCos: new Float32Array(Light._maxLight)
+    angleCos: new Float32Array(Light._maxLight),
+    penumbraCos: new Float32Array(Light._maxLight)
   };
 
   /**
@@ -40,19 +34,20 @@ export class SpotLight extends Light {
     shaderData.setFloatArray(SpotLight._positionProperty, data.position);
     shaderData.setFloatArray(SpotLight._directionProperty, data.direction);
     shaderData.setFloatArray(SpotLight._distanceProperty, data.distance);
-    shaderData.setFloatArray(SpotLight._decayProperty, data.decay);
-    shaderData.setFloatArray(SpotLight._angleProperty, data.angle);
-    shaderData.setFloatArray(SpotLight._penumbraProperty, data.penumbra);
+    shaderData.setFloatArray(SpotLight._angleCosProperty, data.angleCos);
     shaderData.setFloatArray(SpotLight._penumbraCosProperty, data.penumbraCos);
-    shaderData.setFloatArray(SpotLight._coneCosProperty, data.coneCos);
   }
 
+  /** Light color. */
   color: Color = new Color(1, 1, 1, 1);
-  penumbra: number = 0.2;
-  distance: number = 100;
+  /** Light intensity. */
   intensity: number = 1.0;
-  decay: number = 0;
+  /** Defines a distance cutoff at which the light's intensity must be considered zero. */
+  distance: number = 100;
+  /** Angle, in radians, from centre of spotlight where falloff begins. */
   angle: number = Math.PI / 6;
+  /** Angle, in radians, from falloff begins to ends. */
+  penumbra: number = Math.PI / 12;
 
   private _forward: Vector3 = new Vector3();
   private _lightColor: Color = new Color(1, 1, 1, 1);
@@ -100,11 +95,8 @@ export class SpotLight extends Light {
     const positionStart = lightIndex * 3;
     const directionStart = lightIndex * 3;
     const distanceStart = lightIndex;
-    const decayStart = lightIndex;
-    const angleStart = lightIndex;
-    const penumbraStart = lightIndex;
     const penumbraCosStart = lightIndex;
-    const coneCosStart = lightIndex;
+    const angleCosStart = lightIndex;
 
     const color = this.lightColor;
     const position = this.position;
@@ -122,10 +114,7 @@ export class SpotLight extends Light {
     data.direction[directionStart + 1] = direction.y;
     data.direction[directionStart + 2] = direction.z;
     data.distance[distanceStart] = this.distance;
-    data.decay[decayStart] = this.decay;
-    data.angle[angleStart] = this.angle;
-    data.penumbra[penumbraStart] = this.penumbra;
-    data.penumbraCos[penumbraCosStart] = Math.cos(this.angle * (1 - this.penumbra));
-    data.coneCos[coneCosStart] = Math.cos(this.angle);
+    data.angleCos[angleCosStart] = Math.cos(this.angle);
+    data.penumbraCos[penumbraCosStart] = Math.cos(this.angle + this.penumbra);
   }
 }

--- a/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
@@ -54,24 +54,21 @@
         lgt.position = u_spotLightPosition[i];
         lgt.direction = u_spotLightDirection[i];
         lgt.distance = u_spotLightDistance[i];
-        lgt.decay = u_spotLightDecay[i];
-        lgt.angle = u_spotLightAngle[i];
-        lgt.penumbra = u_spotLightPenumbra[i];
+        lgt.angleCos = u_spotLightAngleCos[i];
+        lgt.penumbraCos = u_spotLightPenumbraCos[i];
 
-        vec3 direction = v_pos - lgt.position;
-        float angle = acos( dot( normalize( direction ), normalize( lgt.direction ) ) );
-        float dist = length( direction );
-        direction /= dist;
-        float decay = clamp(1.0 - pow(dist/lgt.distance, 4.0), 0.0, 1.0);
-
-        float hasLight = step( angle, lgt.angle );
-        float hasPenumbra = step( lgt.angle, angle ) * step( angle, lgt.angle * ( 1.0 + lgt.penumbra ) );
-        float penumbra = hasPenumbra * ( 1.0 - ( angle - lgt.angle ) / ( lgt.angle * lgt.penumbra ) );
-        float d = max( dot( N, -direction ), 0.0 )  * decay * ( penumbra + hasLight );
+        vec3 direction = lgt.position - v_pos;
+        float lightDistance = length( direction );
+        direction/ = lightDistance;
+        float angleCos = dot( direction, -lgt.direction );
+        float decay = clamp(1.0 - pow(lightDistance/lgt.distance, 4.0), 0.0, 1.0);
+        float spotEffect = smoothstep( lgt.penumbraCos, lgt.angleCos, angleCos );
+        float decayTotal = decay * spotEffect;
+        float d = max( dot( N, direction ), 0.0 )  * decayTotal;
         lightDiffuse += lgt.color * d;
 
-        vec3 halfDir = normalize( V - direction );
-        float s = pow( clamp( dot( N, halfDir ), 0.0, 1.0 ), u_shininess ) * decay * ( penumbra + hasLight );
+        vec3 halfDir = normalize( V + direction );
+        float s = pow( clamp( dot( N, halfDir ), 0.0, 1.0 ), u_shininess ) * decayTotal;
         lightSpecular += lgt.color * s;
 
     }

--- a/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
+++ b/packages/core/src/shaderlib/mobile_blinnphong_frag.glsl
@@ -28,12 +28,11 @@
         lgt.color = u_pointLightColor[i];
         lgt.position = u_pointLightPosition[i];
         lgt.distance = u_pointLightDistance[i];
-        lgt.decay = u_pointLightDecay[i];
 
         vec3 direction = v_pos - lgt.position;
         float dist = length( direction );
         direction /= dist;
-        float decay = pow( max( 0.0, 1.0-dist / lgt.distance ), 2.0 );
+        float decay = clamp(1.0 - pow(dist/lgt.distance, 4.0), 0.0, 1.0);
 
         float d =  max( dot( N, -direction ), 0.0 ) * decay;
         lightDiffuse += lgt.color * d;
@@ -63,7 +62,7 @@
         float angle = acos( dot( normalize( direction ), normalize( lgt.direction ) ) );
         float dist = length( direction );
         direction /= dist;
-        float decay = pow( max( 0.0, 1.0 - dist / lgt.distance ), 2.0 );
+        float decay = clamp(1.0 - pow(dist/lgt.distance, 4.0), 0.0, 1.0);
 
         float hasLight = step( angle, lgt.angle );
         float hasPenumbra = step( lgt.angle, angle ) * step( angle, lgt.angle * ( 1.0 + lgt.penumbra ) );

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag.glsl
@@ -24,7 +24,6 @@
                 pointLight.color = u_pointLightColor[i];
                 pointLight.position = u_pointLightPosition[i];
                 pointLight.distance = u_pointLightDistance[i];
-                pointLight.decay = u_pointLightDecay[i];
 
                 getPointDirectLightIrradiance( pointLight, geometry, directLight );
 

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag.glsl
@@ -43,11 +43,8 @@
                 spotLight.position = u_spotLightPosition[i];
                 spotLight.direction = u_spotLightDirection[i];
                 spotLight.distance = u_spotLightDistance[i];
-                spotLight.decay = u_spotLightDecay[i];
-                spotLight.angle = u_spotLightAngle[i];
-                spotLight.penumbra = u_spotLightPenumbra[i];
+                spotLight.angleCos = u_spotLightAngleCos[i];
                 spotLight.penumbraCos = u_spotLightPenumbraCos[i];
-                spotLight.coneCos = u_spotLightConeCos[i];
 
                 getSpotDirectLightIrradiance( spotLight, geometry, directLight );
 

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -59,12 +59,13 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 		float lightDistance = length( lVector );
 		float angleCos = dot( directLight.direction, -spotLight.direction );
 
-		if ( angleCos > spotLight.coneCos ) {
+		if ( angleCos > spotLight.penumbraCos ) {
 
-			float spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );
+			float spotEffect = smoothstep( spotLight.penumbraCos, spotLight.angleCos, angleCos );
+			float decayEffect = clamp(1.0 - pow(lightDistance/spotLight.distance, 4.0), 0.0, 1.0);
 
 			directLight.color = spotLight.color;
-			directLight.color *= spotEffect * clamp(1.0 - pow(lightDistance/spotLight.distance, 4.0), 0.0, 1.0);
+			directLight.color *= spotEffect * decayEffect;
 			directLight.visible = true;
 
 		} else {

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -41,7 +41,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 		float lightDistance = length( lVector );
 
 		directLight.color = pointLight.color;
-		directLight.color *= punctualLightIntensityToIrradianceFactor( lightDistance, pointLight.distance, pointLight.decay );
+		directLight.color *= clamp(1.0 - pow(lightDistance/pointLight.distance, 4.0), 0.0, 1.0);
 		directLight.visible = ( directLight.color != vec3( 0.0 ) );
 
 	}
@@ -64,7 +64,7 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 			float spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );
 
 			directLight.color = spotLight.color;
-			directLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );
+			directLight.color *= spotEffect * clamp(1.0 - pow(lightDistance/spotLight.distance, 4.0), 0.0, 1.0);
 			directLight.visible = true;
 
 		} else {

--- a/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/direct_irradiance_frag_define.glsl
@@ -25,7 +25,6 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
     void getDirectionalDirectLightIrradiance( const in DirectLight directionalLight, const in GeometricContext geometry, out IncidentLight directLight ) {
         directLight.color = directionalLight.color;
         directLight.direction = -directionalLight.direction;
-        directLight.visible = true;
     }
 
 #endif
@@ -42,7 +41,6 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 
 		directLight.color = pointLight.color;
 		directLight.color *= clamp(1.0 - pow(lightDistance/pointLight.distance, 4.0), 0.0, 1.0);
-		directLight.visible = ( directLight.color != vec3( 0.0 ) );
 
 	}
 
@@ -59,21 +57,12 @@ void RE_Direct_Physical( const in IncidentLight directLight, const in GeometricC
 		float lightDistance = length( lVector );
 		float angleCos = dot( directLight.direction, -spotLight.direction );
 
-		if ( angleCos > spotLight.penumbraCos ) {
+		float spotEffect = smoothstep( spotLight.penumbraCos, spotLight.angleCos, angleCos );
+		float decayEffect = clamp(1.0 - pow(lightDistance/spotLight.distance, 4.0), 0.0, 1.0);
 
-			float spotEffect = smoothstep( spotLight.penumbraCos, spotLight.angleCos, angleCos );
-			float decayEffect = clamp(1.0 - pow(lightDistance/spotLight.distance, 4.0), 0.0, 1.0);
-
-			directLight.color = spotLight.color;
-			directLight.color *= spotEffect * decayEffect;
-			directLight.visible = true;
-
-		} else {
-
-			directLight.color = vec3( 0.0 );
-			directLight.visible = false;
-
-		}
+		directLight.color = spotLight.color;
+		directLight.color *= spotEffect * decayEffect;
+		
 	}
 
 

--- a/packages/core/src/shaderlib/pbr/runtime_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/runtime_frag_define.glsl
@@ -1,7 +1,6 @@
 struct IncidentLight {
     vec3 color;
     vec3 direction;
-    bool visible;
 };
 struct ReflectedLight {
     vec3 directDiffuse;

--- a/packages/core/src/shaderlib/pbr/util_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/util_frag_define.glsl
@@ -29,34 +29,6 @@ vec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {
     return normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );
 }
 
-// todo: enhance
-float punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {
-
-    if( decayExponent > 0.0 ) {
-
-        #if defined ( PHYSICALLY_CORRECT_LIGHTS )
-
-        // based upon Frostbite 3 Moving to Physically-based Rendering
-        // page 32, equation 26: E[window1]
-        // https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
-        // this is intended to be used on spot and point lights who are represented as luminous intensity
-        // but who must be converted to luminous irradiance for surface lighting calculation
-        float distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );
-        float maxDistanceCutoffFactor = pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );
-        return distanceFalloff * maxDistanceCutoffFactor;
-
-        #else
-
-        return pow( saturate( -lightDistance / cutoffDistance + 1.0 ), decayExponent );
-
-        #endif
-
-    }
-
-    return 1.0;
-
-}
-
 vec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {
 
 	return RECIPROCAL_PI * diffuseColor;

--- a/packages/core/src/shaderlib/point_light_frag.glsl
+++ b/packages/core/src/shaderlib/point_light_frag.glsl
@@ -4,11 +4,9 @@ struct PointLight {
     vec3 color;
     vec3 position;
     float distance;
-    float decay;
 };
 uniform vec3 u_pointLightColor[ O3_POINT_LIGHT_COUNT ];
 uniform vec3 u_pointLightPosition[ O3_POINT_LIGHT_COUNT ];
 uniform float u_pointLightDistance[ O3_POINT_LIGHT_COUNT ];
-uniform float u_pointLightDecay[ O3_POINT_LIGHT_COUNT ];
 
 #endif

--- a/packages/core/src/shaderlib/spot_light_frag.glsl
+++ b/packages/core/src/shaderlib/spot_light_frag.glsl
@@ -5,21 +5,15 @@ struct SpotLight {
     vec3 position;
     vec3 direction;
     float distance;
-    float decay;
-    float angle;
-    float penumbra;
+    float angleCos;
     float penumbraCos;
-    float coneCos;
 };
 
 uniform vec3 u_spotLightColor[ O3_SPOT_LIGHT_COUNT ];
 uniform vec3 u_spotLightPosition[ O3_SPOT_LIGHT_COUNT ];
 uniform vec3 u_spotLightDirection[ O3_SPOT_LIGHT_COUNT ];
 uniform float u_spotLightDistance[ O3_SPOT_LIGHT_COUNT ];
-uniform float u_spotLightDecay[ O3_SPOT_LIGHT_COUNT ];
-uniform float u_spotLightAngle[ O3_SPOT_LIGHT_COUNT ];
-uniform float u_spotLightPenumbra[ O3_SPOT_LIGHT_COUNT ];
+uniform float u_spotLightAngleCos[ O3_SPOT_LIGHT_COUNT ];
 uniform float u_spotLightPenumbraCos[ O3_SPOT_LIGHT_COUNT ];
-uniform float u_spotLightConeCos[ O3_SPOT_LIGHT_COUNT ];
 
 #endif


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix,enhancement
### What is the current behavior? (You can also link to an open issue here)
* `decay` in light is not used.
* `decay` attenuation is not correct.
* `angle` and `penumbra` is not correct in effect.
* `u_spotLightConeCos` and `u_spotLightPenumbraCos` is not used in `BlinnPhongMaterial`
### What is the new behavior (if this is a feature change)?
* delete `decay` in `PointLight` and `SpotLight`.
* light attenuation use `1- x^4` instead of `(1-x)^2`.
* `angle`  define the radians from centre of spotlight where falloff begins, `penumbra` define the radians from falloff begins to ends.
* enhance spotlight shader in `BlinnPhong` and `PBR` .

![image](https://user-images.githubusercontent.com/17639043/118111488-58fa2200-b416-11eb-937f-ec869a22e358.png)
![image](https://user-images.githubusercontent.com/17639043/118112899-30732780-b418-11eb-8b6d-ef720351120c.png)




### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Yes.
* delete `decay` in `PointLight` and `SpotLight`.
* change `penumbra` to radians from falloff begins to ends.
### Other information: