### PR TITLE
fix: don't switch macro after setting diffuseTexture

### DIFF
--- a/packages/core/src/lighting/AmbientLight.ts
+++ b/packages/core/src/lighting/AmbientLight.ts
@@ -126,13 +126,6 @@ export class AmbientLight {
 
   set diffuseTexture(value: TextureCubeMap) {
     this._diffuseTexture = value;
-    const shaderData = this._scene.shaderData;
-
-    if (value) {
-      shaderData.setTexture(AmbientLight._diffuseTextureProperty, value);
-      shaderData.enableMacro(AmbientLight._diffuseMacro);
-    } else {
-      shaderData.disableMacro(AmbientLight._diffuseMacro);
-    }
+    this._scene.shaderData.setTexture(AmbientLight._diffuseTextureProperty, value);
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
macro will changed after setting diffuseTexture
### What is the new behavior (if this is a feature change)?
Fixed.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: