### PR TITLE
feat: RenderColorTexture can be written by pixelbuffer and image

### DIFF
--- a/packages/core/src/renderingHardwareInterface/IPlatformRenderColorTexture.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformRenderColorTexture.ts
@@ -22,4 +22,44 @@ export interface IPlatformRenderColorTexture extends IPlatformTexture {
     height: number,
     out: ArrayBufferView
   ): void;
+
+  /**
+   * Setting pixels data through cube face,color buffer data, designated area and texture mipmapping level.
+   * @param face - You can choose which cube face to write if it's cube texture
+   * @param colorBuffer - Color buffer data
+   * @param mipLevel - Texture mipmapping level
+   * @param x - X coordinate of area start
+   * @param y -  Y coordinate of area start
+   * @param width - Data width.if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
+   * @param height - Data height.if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   */
+  setPixelBuffer(
+    face: TextureCubeFace | null,
+    colorBuffer: ArrayBufferView,
+    mipLevel?: number,
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+  ): void;
+
+  /**
+   * Setting pixels data through cube face, TexImageSource, designated area and texture mipmapping level.
+   * @param face - You can choose which cube face to write if it's cube texture
+   * @param imageSource - The source of texture
+   * @param mipLevel - Texture mipmapping level
+   * @param flipY - Whether to flip the Y axis
+   * @param premultipltAlpha - Whether to premultiply the transparent channel
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   */
+  setImageSource(
+    face: TextureCubeFace | null,
+    imageSource: TexImageSource,
+    mipLevel?: number,
+    flipY?: boolean,
+    premultiplyAlpha?: boolean,
+    x?: number,
+    y?: number
+  ): void;
 }

--- a/packages/core/src/texture/RenderColorTexture.ts
+++ b/packages/core/src/texture/RenderColorTexture.ts
@@ -90,4 +90,64 @@ export class RenderColorTexture extends Texture {
   ): void {
     (this._platformTexture as IPlatformRenderColorTexture).getPixelBuffer(face, x, y, width, height, out);
   }
+
+  /**
+   * Setting pixels data through cube face,color buffer data, designated area and texture mipmapping level.
+   * @param face - You can choose which cube face to write if it's cube texture
+   * @param colorBuffer - Color buffer data
+   * @param mipLevel - Texture mipmapping level
+   * @param x - X coordinate of area start
+   * @param y -  Y coordinate of area start
+   * @param width - Data width.if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
+   * @param height - Data height.if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   */
+  setPixelBuffer(
+    face: TextureCubeFace | null,
+    colorBuffer: ArrayBufferView,
+    mipLevel: number = 0,
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+  ): void {
+    (this._platformTexture as IPlatformRenderColorTexture).setPixelBuffer(
+      face,
+      colorBuffer,
+      mipLevel,
+      x,
+      y,
+      width,
+      height
+    );
+  }
+
+  /**
+   * Setting pixels data through cube face, TexImageSource, designated area and texture mipmapping level.
+   * @param face - You can choose which cube face to write if it's cube texture
+   * @param imageSource - The source of texture
+   * @param mipLevel - Texture mipmapping level
+   * @param flipY - Whether to flip the Y axis
+   * @param premultipltAlpha - Whether to premultiply the transparent channel
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   */
+  setImageSource(
+    face: TextureCubeFace | null,
+    imageSource: TexImageSource,
+    mipLevel: number = 0,
+    flipY: boolean = false,
+    premultiplyAlpha: boolean = false,
+    x?: number,
+    y?: number
+  ): void {
+    (this._platformTexture as IPlatformRenderColorTexture).setImageSource(
+      face,
+      imageSource,
+      mipLevel,
+      flipY,
+      premultiplyAlpha,
+      x,
+      y
+    );
+  }
 }

--- a/packages/rhi-webgl/src/GLRenderColorTexture.ts
+++ b/packages/rhi-webgl/src/GLRenderColorTexture.ts
@@ -65,4 +65,96 @@ export class GLRenderColorTexture extends GLTexture implements IPlatformRenderCo
   ): void {
     super._getPixelBuffer(face, x, y, width, height, out);
   }
+
+  /**
+   * Setting pixels data through cube face,color buffer data, designated area and texture mipmapping level.
+   * @param face - You can choose which cube face to write if it's cube texture
+   * @param colorBuffer - Color buffer data
+   * @param mipLevel - Texture mipmapping level
+   * @param x - X coordinate of area start
+   * @param y -  Y coordinate of area start
+   * @param width - Data width.if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
+   * @param height - Data height.if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   */
+  setPixelBuffer(
+    face: TextureCubeFace | null,
+    colorBuffer: ArrayBufferView,
+    mipLevel?: number,
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+  ): void {
+    const gl = this._gl;
+    const { baseFormat, dataType } = this._formatDetail;
+    const mipSize = Math.max(1, this._texture.width >> mipLevel);
+
+    x = x || 0;
+    y = y || 0;
+    width = width || mipSize - x;
+    height = height || mipSize - y;
+
+    this._bind();
+
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
+
+    if (face == null) {
+      gl.texSubImage2D(this._target, mipLevel, x, y, width, height, baseFormat, dataType, colorBuffer);
+    } else {
+      gl.texSubImage2D(
+        gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
+        mipLevel,
+        x,
+        y,
+        width,
+        height,
+        baseFormat,
+        dataType,
+        colorBuffer
+      );
+    }
+  }
+
+  /**
+   * Setting pixels data through cube face, TexImageSource, designated area and texture mipmapping level.
+   * @param face - You can choose which cube face to write if it's cube texture
+   * @param imageSource - The source of texture
+   * @param mipLevel - Texture mipmapping level
+   * @param flipY - Whether to flip the Y axis
+   * @param premultipltAlpha - Whether to premultiply the transparent channel
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   */
+  setImageSource(
+    face: TextureCubeFace | null,
+    imageSource: TexImageSource,
+    mipLevel?: number,
+    flipY?: boolean,
+    premultiplyAlpha?: boolean,
+    x?: number,
+    y?: number
+  ): void {
+    const gl = this._gl;
+    const { baseFormat, dataType } = this._formatDetail;
+
+    this._bind();
+
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, +flipY);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, +premultiplyAlpha);
+
+    if (face == null) {
+      gl.texSubImage2D(this._target, mipLevel, x || 0, y || 0, baseFormat, dataType, imageSource);
+    } else {
+      gl.texSubImage2D(
+        gl.TEXTURE_CUBE_MAP_POSITIVE_X + face,
+        mipLevel,
+        x || 0,
+        y || 0,
+        baseFormat,
+        dataType,
+        imageSource
+      );
+    }
+  }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
feature.
### What is the current behavior? (You can also link to an open issue here)
`RenderColorTexture` can only writen by frame buffer.
### What is the new behavior (if this is a feature change)?
Can writen by pixelBuffer and image.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: