### PR TITLE
feat: add LuminanceAlpha format to support ar frame buffer data

### DIFF
--- a/packages/core/src/texture/enums/TextureFormat.ts
+++ b/packages/core/src/texture/enums/TextureFormat.ts
@@ -14,6 +14,8 @@ export enum TextureFormat {
   R5G6B5,
   /** Transparent format,8 bits. */
   Alpha8,
+  /** Luminance/alpha in RGB channel, alpha in A channel. */
+  LuminanceAlpha,
   /** RGBA format,32 bits per channel. */
   R32G32B32A32,
   /** RGB compressed format。*/

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -518,7 +518,7 @@ export class GLTexture implements IPlatformTexture {
 
     this._bind();
 
-    if (isWebGL2) {
+    if (isWebGL2 && !(baseFormat === gl.LUMINANCE_ALPHA || baseFormat === gl.ALPHA)) {
       gl.texStorage2D(this._target, mipmapCount, internalFormat, width, height);
     } else {
       // In WebGL 1, internalformat must be the same as baseFormat

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -77,6 +77,13 @@ export class GLTexture implements IPlatformTexture {
           dataType: gl.UNSIGNED_BYTE,
           isCompressed: false
         };
+      case TextureFormat.LuminanceAlpha:
+        return {
+          internalFormat: gl.LUMINANCE_ALPHA,
+          baseFormat: gl.LUMINANCE_ALPHA,
+          dataType: gl.UNSIGNED_BYTE,
+          isCompressed: false
+        };
       case TextureFormat.R32G32B32A32:
         return {
           internalFormat: gl.RGBA32F,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature.
### What is the current behavior? (You can also link to an open issue here)
YUV data in [ar frame](https://yuque.antfin-inc.com/tiny-tmp/component/oez5hi#1YkSX) need `LUMINANCE_ALPHA` format
### What is the new behavior (if this is a feature change)?
Support.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: