### PR TITLE
fix: set interpolation with `linear` by default

### DIFF
--- a/packages/loader/src/gltf/parser/AnimationParser.ts
+++ b/packages/loader/src/gltf/parser/AnimationParser.ts
@@ -53,6 +53,7 @@ export class AnimationParser extends Parser {
             samplerInterpolation = InterpolationType.Step;
             break;
           case AnimationSamplerInterpolation.Linear:
+          default:
             samplerInterpolation = InterpolationType.Linear;
             break;
         }

--- a/packages/loader/src/gltf/parser/AnimationParser.ts
+++ b/packages/loader/src/gltf/parser/AnimationParser.ts
@@ -44,8 +44,9 @@ export class AnimationParser extends Parser {
         const output = GLTFUtil.getAccessorData(gltf, outputAccessor, buffers);
         const outputAccessorSize = output.length / input.length;
 
+        const interpolation = gltfSampler.interpolation ?? AnimationSamplerInterpolation.Linear;
         let samplerInterpolation: InterpolationType;
-        switch (gltfSampler.interpolation) {
+        switch (interpolation) {
           case AnimationSamplerInterpolation.CubicSpine:
             samplerInterpolation = InterpolationType.CubicSpine;
             break;
@@ -53,7 +54,6 @@ export class AnimationParser extends Parser {
             samplerInterpolation = InterpolationType.Step;
             break;
           case AnimationSamplerInterpolation.Linear:
-          default:
             samplerInterpolation = InterpolationType.Linear;
             break;
         }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
Throw error in some channels without interpolation.
### What is the new behavior (if this is a feature change)?
Fix.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information: