### PR TITLE
feat: support vertex color for Blinnphone

### DIFF
--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -18,7 +18,6 @@ export class MeshRenderer extends Renderer implements ICustomClone {
   private static _normalMacro = Shader.getMacroByName("O3_HAS_NORMAL");
   private static _tangentMacro = Shader.getMacroByName("O3_HAS_TANGENT");
   private static _vertexColorMacro = Shader.getMacroByName("O3_HAS_VERTEXCOLOR");
-  private static _vertexAlphaMacro = Shader.getMacroByName("O3_HAS_VERTEXALPHA");
 
   @ignoreClone
   private _mesh: Mesh;
@@ -68,10 +67,9 @@ export class MeshRenderer extends Renderer implements ICustomClone {
         shaderData.disableMacro(MeshRenderer._normalMacro);
         shaderData.disableMacro(MeshRenderer._tangentMacro);
         shaderData.disableMacro(MeshRenderer._vertexColorMacro);
-        shaderData.disableMacro(MeshRenderer._vertexAlphaMacro);
 
         for (let i = 0, n = vertexElements.length; i < n; i++) {
-          const { semantic, format } = vertexElements[i];
+          const { semantic } = vertexElements[i];
           switch (semantic) {
             case "TEXCOORD_0":
               shaderData.enableMacro(MeshRenderer._uvMacro);
@@ -84,9 +82,6 @@ export class MeshRenderer extends Renderer implements ICustomClone {
               break;
             case "COLOR_0":
               shaderData.enableMacro(MeshRenderer._vertexColorMacro);
-              if (format === VertexElementFormat.Vector4) {
-                shaderData.enableMacro(MeshRenderer._vertexAlphaMacro);
-              }
               break;
           }
         }

--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -17,6 +17,12 @@
 
     #endif
 
+     #ifdef O3_HAS_VERTEXCOLOR
+
+        diffuse.rgb *= v_color.rgb;
+
+    #endif
+
     #ifdef O3_SPECULAR_TEXTURE
 
         specular *= texture2D(u_specularTexture, v_uv);

--- a/packages/core/src/shaderlib/begin_mobile_frag.glsl
+++ b/packages/core/src/shaderlib/begin_mobile_frag.glsl
@@ -19,7 +19,7 @@
 
      #ifdef O3_HAS_VERTEXCOLOR
 
-        diffuse.rgb *= v_color.rgb;
+        diffuse *= v_color;
 
     #endif
 

--- a/packages/core/src/shaderlib/extra/blinn-phong.fs.glsl
+++ b/packages/core/src/shaderlib/extra/blinn-phong.fs.glsl
@@ -3,6 +3,7 @@
 
 #include <uv_share>
 #include <normal_share>
+#include <color_share>
 #include <worldpos_share>
 
 #include <pbr_envmap_light_frag_define>

--- a/packages/core/src/shaderlib/extra/blinn-phong.vs.glsl
+++ b/packages/core/src/shaderlib/extra/blinn-phong.vs.glsl
@@ -2,6 +2,7 @@
 #include <common_vert>
 #include <blendShape_input>
 #include <uv_share>
+#include <color_share>
 #include <normal_share>
 #include <worldpos_share>
 #include <shadow_share>
@@ -15,6 +16,7 @@ void main() {
     #include <blendShape_vert>
     #include <skinning_vert>
     #include <uv_vert>
+    #include <color_vert>
     #include <normal_vert>
     #include <worldpos_vert>
     #include <shadow_vert>

--- a/packages/core/src/shaderlib/pbr/begin_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/begin_frag.glsl
@@ -20,15 +20,7 @@
     #endif
 
     #ifdef O3_HAS_VERTEXCOLOR
-
-        diffuseColor.rgb *= v_color.rgb;
-
-        #ifdef O3_HAS_VERTEXALPHA
-
-            diffuseColor.a *= v_color.a;
-
-        #endif
-
+        diffuseColor *= v_color;
     #endif
 
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

- `PBR` support vertex color, but `BlinnPhone` dosen't support vertex color, so i add this feat.
- I remove `O3_HAS_VERTEXALPHA` macro, because `O3_HAS_VERTEXCOLOR` is enough, it already contains alpha.
