### PR TITLE
Asset Type of Resource Loader Use String

### DIFF
--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -12,19 +12,19 @@ import { ObjectValues } from "../base/Util";
 export class ResourceManager {
   /** Loader collection. */
   private static _loaders: { [key: number]: Loader<any> } = {};
-  private static _extTypeMapping: { [key: string]: AssetType } = {};
+  private static _extTypeMapping: { [key: string]: string } = {};
 
   /**
    * @internal
    */
-  static _addLoader(type: AssetType, loader: Loader<any>, extnames: string[]) {
+  static _addLoader(type: string, loader: Loader<any>, extnames: string[]) {
     this._loaders[type] = loader;
     for (let i = 0, len = extnames.length; i < len; i++) {
       this._extTypeMapping[extnames[i]] = type;
     }
   }
 
-  private static _getTypeByUrl(url: string): AssetType {
+  private static _getTypeByUrl(url: string): string {
     const path = url.split("?")[0];
     return this._extTypeMapping[path.substring(path.lastIndexOf(".") + 1)];
   }
@@ -219,7 +219,7 @@ export class ResourceManager {
  * @param assetType - Type of asset
  * @param extnames - Name of file extension
  */
-export function resourceLoader(assetType: AssetType, extnames: string[], useCache: boolean = true) {
+export function resourceLoader(assetType: string, extnames: string[], useCache: boolean = true) {
   return <T extends Loader<any>>(Target: { new (useCache: boolean): T }) => {
     const loader = new Target(useCache);
     ResourceManager._addLoader(assetType, loader, extnames);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
use `string` replace `AssetType` to extend easily.