### PR TITLE
Fix: Sprite add clone function.

### DIFF
--- a/packages/core/src/2d/atlas/SpriteAtlas.ts
+++ b/packages/core/src/2d/atlas/SpriteAtlas.ts
@@ -19,21 +19,21 @@ export class SpriteAtlas extends RefObject {
   /**
    * Get the last sprite named 'name' from the atlas.
    * @param name - The name of the sprite you want to find
-   * @returns The sprite you want to find (clone)
+   * @returns The sprite you want to find
    */
   getSprite(name: string): Sprite {
     const sprite = this._sprites[this._spriteNamesToIndex[name]];
     if (!sprite) {
       console.warn("There is no sprite named " + name + " in the atlas.");
     }
-    return sprite.clone();
+    return sprite;
   }
 
   /**
    * Get all the sprite named 'name' from the atlas.
    * @param name - The name of the sprites you want to find
    * @param outSprites - This array holds the sprites found
-   * @returns The sprites you want to find (clone)
+   * @returns The sprites you want to find
    */
   getSprites(name: string, outSprites: Sprite[]): Sprite[] {
     outSprites.length = 0;
@@ -42,7 +42,7 @@ export class SpriteAtlas extends RefObject {
       const { _sprites } = this;
       for (; i >= 0; i--) {
         const sprite = _sprites[i];
-        sprite.name === name && outSprites.push(sprite.clone());
+        sprite.name === name && outSprites.push(sprite);
       }
     } else {
       console.warn("The name of the sprite you want to find is not exit in SpriteAtlas.");


### PR DESCRIPTION
- Return to the clone of the sprite in the SpriteAtlas.
- The pivot of the sprite is frequently set in Lottie, so the Pivot interface of Sprite is optimized.
 ![image](https://user-images.githubusercontent.com/7768919/136694146-3f268c20-d058-40f6-980d-ba8c10fd99b8.png)