### PR TITLE
fix: get pixel buffer use mip level should right shift

### DIFF
--- a/packages/core/src/texture/Texture2D.ts
+++ b/packages/core/src/texture/Texture2D.ts
@@ -143,8 +143,8 @@ export class Texture2D extends Texture {
       (this._platformTexture as IPlatformTexture2D).getPixelBuffer(
         0,
         0,
-        this._width,
-        this._height,
+        this._width >> <number>xOrMipLevelOrOut,
+        this._height >> <number>xOrMipLevelOrOut,
         <number>xOrMipLevelOrOut,
         <ArrayBufferView>yOrMipLevel
       );

--- a/packages/core/src/texture/TextureCubeMap.ts
+++ b/packages/core/src/texture/TextureCubeMap.ts
@@ -168,8 +168,8 @@ export class TextureCubeMap extends Texture {
         face,
         0,
         0,
-        this._width,
-        this._height,
+        this._width >> <number>xOrMipLevelOrOut,
+        this._height >> <number>xOrMipLevelOrOut,
         <number>xOrMipLevelOrOut,
         <ArrayBufferView>yOrMipLevel
       );


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

### What is the current behavior? (You can also link to an open issue here)
Has bug in get pixel buffer

### What is the new behavior (if this is a feature change)?
Calculate correct width and height.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
