### PR TITLE
fix: resize max uniform vector count

### DIFF
--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -123,7 +123,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     const rhi = this.entity.engine._hardwareRenderer;
     if (!rhi) return;
     const maxAttribUniformVec4 = rhi.renderStates.getParameter(rhi.gl.MAX_VERTEX_UNIFORM_VECTORS);
-    const maxJoints = Math.floor((maxAttribUniformVec4 - 24) / 4);
+    const maxJoints = Math.floor((maxAttribUniformVec4 - 30) / 4);
     const shaderData = this.shaderData;
     const jointCount = jointNodes.length;
 

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -123,23 +123,24 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     const rhi = this.entity.engine._hardwareRenderer;
     if (!rhi) return;
     const maxAttribUniformVec4 = rhi.renderStates.getParameter(rhi.gl.MAX_VERTEX_UNIFORM_VECTORS);
-    const maxJoints = Math.floor((maxAttribUniformVec4 - 20) / 4);
+    const maxJoints = Math.floor((maxAttribUniformVec4 - 24) / 4);
     const shaderData = this.shaderData;
-    const jointCount = this.jointNodes?.length;
+    const jointCount = jointNodes.length;
+
     if (jointCount) {
       shaderData.enableMacro("O3_HAS_SKIN");
       shaderData.setInt(SkinnedMeshRenderer._jointCountProperty, jointCount);
-      if (joints.length > maxJoints) {
+      if (jointCount > maxJoints) {
         if (rhi.canIUseMoreJoints) {
           this._useJointTexture = true;
         } else {
           Logger.error(
-            `component's joints count(${joints}) greater than device's MAX_VERTEX_UNIFORM_VECTORS number ${maxAttribUniformVec4}, and don't support jointTexture in this device. suggest joint count less than ${maxJoints}.`,
+            `component's joints count(${jointCount}) greater than device's MAX_VERTEX_UNIFORM_VECTORS number ${maxAttribUniformVec4}, and don't support jointTexture in this device. suggest joint count less than ${maxJoints}.`,
             this
           );
         }
       } else {
-        const maxJoints = Math.max(SkinnedMeshRenderer._maxJoints, joints.length);
+        const maxJoints = Math.max(SkinnedMeshRenderer._maxJoints, jointCount);
         SkinnedMeshRenderer._maxJoints = maxJoints;
         shaderData.disableMacro("O3_USE_JOINT_TEXTURE");
         shaderData.enableMacro("O3_JOINTS_NUM", maxJoints.toString());


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
as we know, `MAX_VERTEX_UNIFORM_VECTORS` decide the max uniform vector count, so the joint matrix count must less than the other uniform count.

### What is the new behavior (if this is a feature change)?
use `30` instead of `20`

### Other information:
to calculate the true vector count, for example:

![image](https://user-images.githubusercontent.com/17639043/154885256-4c208863-8b5e-47a3-b633-ebb92cc9e52e.png)
