### PR TITLE
refactor: remove Promise.finally

### DIFF
--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -218,7 +218,7 @@ export class ResourceManager {
       .catch((err: Error) => {
         Promise.reject(err)
         delete this._loadingPromises[url];
-      })
+      });
     return promise;
   }
 

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -213,11 +213,12 @@ export class ResourceManager {
     promise
       .then((res: EngineObject) => {
         if (loader.useCache) this._addAsset(url, res);
-      })
-      .catch((err: Error) => Promise.reject(err))
-      .finally(() => {
         delete this._loadingPromises[url];
-      });
+      })
+      .catch((err: Error) => {
+        Promise.reject(err)
+        delete this._loadingPromises[url];
+      })
     return promise;
   }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Fix some devices are incompatible `Promise.prototype.finally`, like `ios 11.2.x`, `Android 8.1.x with Chrome mobile webview 62`.

### What is the current behavior? (You can also link to an open issue here)
![image](https://user-images.githubusercontent.com/4132185/156497246-ad2e5abf-8c9f-4383-ae85-35a2c7007e15.png)
![image](https://user-images.githubusercontent.com/4132185/156497382-e1712b63-8693-4515-a2f9-d9eb30f79301.png)

![image](https://user-images.githubusercontent.com/4132185/156509915-b8ad39ce-6c52-4d95-b2c5-46445e66f11e.png)


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Users do not need to make any changes

### Other information:
This project is only one place where is using `Promise.prototype.finally`
