### PR TITLE
fix: color space correction in gltf

### DIFF
--- a/packages/core/src/shaderlib/pbr/pbr_helper.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_helper.glsl
@@ -51,6 +51,9 @@ PhysicalMaterial getPhysicalMaterial(
 
         #ifdef HAS_SPECULARGLOSSINESSMAP
             vec4 specularGlossinessColor = texture2D(u_specularGlossinessSampler, v_uv );
+            #ifndef OASIS_COLORSPACE_GAMMA
+                specularGlossinessColor = gammaToLinear(specularGlossinessColor);
+            #endif
             specularColor *= specularGlossinessColor.rgb;
             glossiness *= specularGlossinessColor.a;
         #endif

--- a/packages/loader/src/gltf/extensions/KHR_materials_pbrSpecularGlossiness.ts
+++ b/packages/loader/src/gltf/extensions/KHR_materials_pbrSpecularGlossiness.ts
@@ -14,7 +14,12 @@ class KHR_materials_pbrSpecularGlossiness extends ExtensionParser {
     const { diffuseFactor, diffuseTexture, specularFactor, glossinessFactor, specularGlossinessTexture } = schema;
 
     if (diffuseFactor) {
-      material.baseColor = new Color(...diffuseFactor);
+      material.baseColor = new Color(
+        Color.linearToGammaSpace(diffuseFactor[0]),
+        Color.linearToGammaSpace(diffuseFactor[1]),
+        Color.linearToGammaSpace(diffuseFactor[2]),
+        diffuseFactor[3]
+      );
     }
 
     if (diffuseTexture) {
@@ -23,7 +28,11 @@ class KHR_materials_pbrSpecularGlossiness extends ExtensionParser {
     }
 
     if (specularFactor) {
-      material.specularColor = new Color(...specularFactor);
+      material.specularColor = new Color(
+        Color.linearToGammaSpace(specularFactor[0]),
+        Color.linearToGammaSpace(specularFactor[1]),
+        Color.linearToGammaSpace(specularFactor[2])
+      );
     }
 
     if (glossinessFactor !== undefined) {

--- a/packages/loader/src/gltf/parser/MaterialParser.ts
+++ b/packages/loader/src/gltf/parser/MaterialParser.ts
@@ -58,7 +58,12 @@ export class MaterialParser extends Parser {
           pbrMetallicRoughness;
 
         if (baseColorFactor) {
-          material.baseColor = new Color(...baseColorFactor);
+          material.baseColor = new Color(
+            Color.linearToGammaSpace(baseColorFactor[0]),
+            Color.linearToGammaSpace(baseColorFactor[1]),
+            Color.linearToGammaSpace(baseColorFactor[2]),
+            baseColorFactor[3]
+          );
         }
         if (baseColorTexture) {
           material.baseTexture = textures[baseColorTexture.index];
@@ -85,7 +90,11 @@ export class MaterialParser extends Parser {
         }
 
         if (emissiveFactor) {
-          m.emissiveColor = new Color(...emissiveFactor);
+          m.emissiveColor = new Color(
+            Color.linearToGammaSpace(emissiveFactor[0]),
+            Color.linearToGammaSpace(emissiveFactor[1]),
+            Color.linearToGammaSpace(emissiveFactor[2])
+          );
         }
 
         if (normalTexture) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
use sRGB color space in gltf.
### What is the new behavior (if this is a feature change)?
should use linear color space in gltf.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Comparation
* Unlit
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/17639043/156561681-66b200a6-a423-4199-9a87-174a4524b408.png">

* PBR
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/17639043/156561796-8e114fb6-a5ec-4552-8d1b-4bc02265f3d6.png">

* Specular
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/17639043/156561857-22a66eca-2e49-47f4-8c63-fe7160fe6a51.png">

