### PR TITLE
Feat: support multi-uv and occlusion texture coordinate

### DIFF
--- a/packages/core/src/material/PBRBaseMaterial.ts
+++ b/packages/core/src/material/PBRBaseMaterial.ts
@@ -1,8 +1,10 @@
 import { Color, Vector4 } from "@oasis-engine/math";
+import { Logger } from "..";
 import { Engine } from "../Engine";
 import { Shader } from "../shader/Shader";
 import { Texture2D } from "../texture/Texture2D";
 import { BaseMaterial } from "./BaseMaterial";
+import { TextureCoordinate } from "./enums/TextureCoordinate";
 
 /**
  * PBR (Physically-Based Rendering) Material.
@@ -15,7 +17,7 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   private static _normalTextureProp = Shader.getPropertyByName("u_normalTexture");
   private static _normalTextureIntensityProp = Shader.getPropertyByName("u_normalIntensity");
   private static _occlusionTextureIntensityProp = Shader.getPropertyByName("u_occlusionStrength");
-
+  private static _occlusionTextureCoordProp = Shader.getPropertyByName("u_occlusionTextureCoord");
   private static _emissiveTextureProp = Shader.getPropertyByName("u_emissiveSampler");
   private static _occlusionTextureProp = Shader.getPropertyByName("u_occlusionSampler");
 
@@ -74,7 +76,6 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
 
   set normalTextureIntensity(value: number) {
     this.shaderData.setFloat(PBRBaseMaterial._normalTextureIntensityProp, value);
-    this.shaderData.setFloat("u_normalIntensity", value);
   }
 
   /**
@@ -135,6 +136,21 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   }
 
   /**
+   * Occlusion texture uv coordinate.
+   * @remark Must be UV0 or UV1.
+   */
+  get occlusionTextureCoord(): number {
+    return this.shaderData.getFloat(PBRBaseMaterial._occlusionTextureCoordProp);
+  }
+
+  set occlusionTextureCoord(value: TextureCoordinate) {
+    if (value > TextureCoordinate.UV1) {
+      Logger.warn("Occlusion texture uv coordinate must be UV0 or UV1.");
+    }
+    this.shaderData.setFloat(PBRBaseMaterial._occlusionTextureCoordProp, value);
+  }
+
+  /**
    * Tiling and offset of main textures.
    */
   get tilingOffset(): Vector4 {
@@ -167,5 +183,6 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
 
     shaderData.setFloat(PBRBaseMaterial._normalTextureIntensityProp, 1);
     shaderData.setFloat(PBRBaseMaterial._occlusionTextureIntensityProp, 1);
+    shaderData.setFloat(PBRBaseMaterial._occlusionTextureCoordProp, TextureCoordinate.UV0);
   }
 }

--- a/packages/core/src/material/PBRBaseMaterial.ts
+++ b/packages/core/src/material/PBRBaseMaterial.ts
@@ -137,9 +137,9 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
 
   /**
    * Occlusion texture uv coordinate.
-   * @remark Must be UV0 or UV1.
+   * @remarks Must be UV0 or UV1.
    */
-  get occlusionTextureCoord(): number {
+  get occlusionTextureCoord(): TextureCoordinate {
     return this.shaderData.getFloat(PBRBaseMaterial._occlusionTextureCoordProp);
   }
 

--- a/packages/core/src/material/enums/TextureCoordinate.ts
+++ b/packages/core/src/material/enums/TextureCoordinate.ts
@@ -1,0 +1,13 @@
+/**
+ * Texture UV coordinate.
+ */
+export enum TextureCoordinate {
+  UV0 = 0,
+  UV1,
+  UV2,
+  UV3,
+  UV4,
+  UV5,
+  UV6,
+  UV7
+}

--- a/packages/core/src/material/index.ts
+++ b/packages/core/src/material/index.ts
@@ -1,6 +1,7 @@
 export { RenderQueueType } from "./enums/RenderQueueType";
 export { RenderFace } from "./enums/RenderFace";
 export { BlendMode } from "./enums/BlendMode";
+export { TextureCoordinate } from "./enums/TextureCoordinate";
 export { Material } from "./Material";
 export { BaseMaterial } from "./BaseMaterial";
 export { BlinnPhongMaterial } from "./BlinnPhongMaterial";

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -14,7 +14,7 @@ import { UpdateFlag } from "../UpdateFlag";
  */
 export class MeshRenderer extends Renderer implements ICustomClone {
   private static _uvMacro = Shader.getMacroByName("O3_HAS_UV");
-  private static _uv2Macro = Shader.getMacroByName("O3_HAS_UV2");
+  private static _uv1Macro = Shader.getMacroByName("O3_HAS_UV1");
   private static _normalMacro = Shader.getMacroByName("O3_HAS_NORMAL");
   private static _tangentMacro = Shader.getMacroByName("O3_HAS_TANGENT");
   private static _vertexColorMacro = Shader.getMacroByName("O3_HAS_VERTEXCOLOR");
@@ -64,7 +64,7 @@ export class MeshRenderer extends Renderer implements ICustomClone {
         const vertexElements = mesh._vertexElements;
 
         shaderData.disableMacro(MeshRenderer._uvMacro);
-        shaderData.disableMacro(MeshRenderer._uv2Macro);
+        shaderData.disableMacro(MeshRenderer._uv1Macro);
         shaderData.disableMacro(MeshRenderer._normalMacro);
         shaderData.disableMacro(MeshRenderer._tangentMacro);
         shaderData.disableMacro(MeshRenderer._vertexColorMacro);
@@ -76,7 +76,7 @@ export class MeshRenderer extends Renderer implements ICustomClone {
               shaderData.enableMacro(MeshRenderer._uvMacro);
               break;
             case "TEXCOORD_1":
-              shaderData.enableMacro(MeshRenderer._uv2Macro);
+              shaderData.enableMacro(MeshRenderer._uv1Macro);
               break;
             case "NORMAL":
               shaderData.enableMacro(MeshRenderer._normalMacro);

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -4,7 +4,6 @@ import { Camera } from "../Camera";
 import { ignoreClone } from "../clone/CloneManager";
 import { ICustomClone } from "../clone/ComponentCloner";
 import { Entity } from "../Entity";
-import { VertexElementFormat } from "../graphic/enums/VertexElementFormat";
 import { Mesh } from "../graphic/Mesh";
 import { Renderer } from "../Renderer";
 import { Shader } from "../shader/Shader";
@@ -15,6 +14,7 @@ import { UpdateFlag } from "../UpdateFlag";
  */
 export class MeshRenderer extends Renderer implements ICustomClone {
   private static _uvMacro = Shader.getMacroByName("O3_HAS_UV");
+  private static _uv2Macro = Shader.getMacroByName("O3_HAS_UV2");
   private static _normalMacro = Shader.getMacroByName("O3_HAS_NORMAL");
   private static _tangentMacro = Shader.getMacroByName("O3_HAS_TANGENT");
   private static _vertexColorMacro = Shader.getMacroByName("O3_HAS_VERTEXCOLOR");
@@ -64,6 +64,7 @@ export class MeshRenderer extends Renderer implements ICustomClone {
         const vertexElements = mesh._vertexElements;
 
         shaderData.disableMacro(MeshRenderer._uvMacro);
+        shaderData.disableMacro(MeshRenderer._uv2Macro);
         shaderData.disableMacro(MeshRenderer._normalMacro);
         shaderData.disableMacro(MeshRenderer._tangentMacro);
         shaderData.disableMacro(MeshRenderer._vertexColorMacro);
@@ -73,6 +74,9 @@ export class MeshRenderer extends Renderer implements ICustomClone {
           switch (semantic) {
             case "TEXCOORD_0":
               shaderData.enableMacro(MeshRenderer._uvMacro);
+              break;
+            case "TEXCOORD_1":
+              shaderData.enableMacro(MeshRenderer._uv2Macro);
               break;
             case "NORMAL":
               shaderData.enableMacro(MeshRenderer._normalMacro);

--- a/packages/core/src/shaderlib/common_vert.glsl
+++ b/packages/core/src/shaderlib/common_vert.glsl
@@ -4,6 +4,10 @@ attribute vec3 POSITION;
     attribute vec2 TEXCOORD_0;
 #endif
 
+#ifdef O3_HAS_UV2
+    attribute vec2 TEXCOORD_1;
+#endif
+
 #ifdef O3_HAS_SKIN
     attribute vec4 JOINTS_0;
     attribute vec4 WEIGHTS_0;

--- a/packages/core/src/shaderlib/common_vert.glsl
+++ b/packages/core/src/shaderlib/common_vert.glsl
@@ -4,7 +4,7 @@ attribute vec3 POSITION;
     attribute vec2 TEXCOORD_0;
 #endif
 
-#ifdef O3_HAS_UV2
+#ifdef O3_HAS_UV1
     attribute vec2 TEXCOORD_1;
 #endif
 

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -26,7 +26,16 @@ reflectedLight.indirectSpecular += radiance * envBRDFApprox(material.specularCol
 
 // Occlusion
 #ifdef HAS_OCCLUSIONMAP
-    float ambientOcclusion = (texture2D(u_occlusionSampler, v_uv).r - 1.0) * u_occlusionStrength + 1.0;
+    float ambientOcclusion = 1.0;  
+    if(u_occlusionTextureCoord == 1.0){
+         #ifdef O3_HAS_UV2
+            ambientOcclusion = (texture2D(u_occlusionSampler, v_uv2).r - 1.0) * u_occlusionStrength + 1.0;
+         #else
+            ambientOcclusion = (texture2D(u_occlusionSampler, v_uv).r - 1.0) * u_occlusionStrength + 1.0;
+         #endif
+    } else {
+        ambientOcclusion = (texture2D(u_occlusionSampler, v_uv).r - 1.0) * u_occlusionStrength + 1.0;
+    }
     reflectedLight.indirectDiffuse *= ambientOcclusion;
     #ifdef O3_USE_SPECULAR_ENV
         reflectedLight.indirectSpecular *= computeSpecularOcclusion(ambientOcclusion, material.roughness, dotNV);

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -26,21 +26,19 @@ reflectedLight.indirectSpecular += radiance * envBRDFApprox(material.specularCol
 
 // Occlusion
 #ifdef HAS_OCCLUSIONMAP
-    float ambientOcclusion = 1.0;  
+    vec2 aoUV = v_uv;
     if(u_occlusionTextureCoord == 1.0){
-         #ifdef O3_HAS_UV2
-            ambientOcclusion = (texture2D(u_occlusionSampler, v_uv2).r - 1.0) * u_occlusionStrength + 1.0;
-         #else
-            ambientOcclusion = (texture2D(u_occlusionSampler, v_uv).r - 1.0) * u_occlusionStrength + 1.0;
-         #endif
-    } else {
-        ambientOcclusion = (texture2D(u_occlusionSampler, v_uv).r - 1.0) * u_occlusionStrength + 1.0;
+        #ifdef O3_HAS_UV2
+            aoUV = v_uv2;
+        #endif
     }
+    float ambientOcclusion = (texture2D(u_occlusionSampler, aoUV).r - 1.0) * u_occlusionStrength + 1.0;
     reflectedLight.indirectDiffuse *= ambientOcclusion;
     #ifdef O3_USE_SPECULAR_ENV
         reflectedLight.indirectSpecular *= computeSpecularOcclusion(ambientOcclusion, material.roughness, dotNV);
     #endif
 #endif
+
 
 // Emissive
 vec3 emissiveRadiance = u_emissiveColor;

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -28,8 +28,8 @@ reflectedLight.indirectSpecular += radiance * envBRDFApprox(material.specularCol
 #ifdef HAS_OCCLUSIONMAP
     vec2 aoUV = v_uv;
     if(u_occlusionTextureCoord == 1.0){
-        #ifdef O3_HAS_UV2
-            aoUV = v_uv2;
+        #ifdef O3_HAS_UV1
+            aoUV = v_uv1;
         #endif
     }
     float ambientOcclusion = (texture2D(u_occlusionSampler, aoUV).r - 1.0) * u_occlusionStrength + 1.0;

--- a/packages/core/src/shaderlib/pbr/pbr_frag.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag.glsl
@@ -27,11 +27,11 @@ reflectedLight.indirectSpecular += radiance * envBRDFApprox(material.specularCol
 // Occlusion
 #ifdef HAS_OCCLUSIONMAP
     vec2 aoUV = v_uv;
-    if(u_occlusionTextureCoord == 1.0){
-        #ifdef O3_HAS_UV1
+    #ifdef O3_HAS_UV1
+        if(u_occlusionTextureCoord == 1.0){
             aoUV = v_uv1;
-        #endif
-    }
+        }
+    #endif
     float ambientOcclusion = (texture2D(u_occlusionSampler, aoUV).r - 1.0) * u_occlusionStrength + 1.0;
     reflectedLight.indirectDiffuse *= ambientOcclusion;
     #ifdef O3_USE_SPECULAR_ENV

--- a/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
+++ b/packages/core/src/shaderlib/pbr/pbr_frag_define.glsl
@@ -9,7 +9,7 @@ uniform vec3 u_emissiveColor;
 
 uniform float u_normalIntensity;
 uniform float u_occlusionStrength;
-
+uniform float u_occlusionTextureCoord;
 
 #ifdef HAS_BASECOLORMAP
     uniform sampler2D u_baseColorSampler;

--- a/packages/core/src/shaderlib/uv_share.glsl
+++ b/packages/core/src/shaderlib/uv_share.glsl
@@ -1,5 +1,5 @@
 varying vec2 v_uv;
 
-#ifdef O3_HAS_UV2
-    varying vec2 v_uv2;
+#ifdef O3_HAS_UV1
+    varying vec2 v_uv1;
 #endif

--- a/packages/core/src/shaderlib/uv_share.glsl
+++ b/packages/core/src/shaderlib/uv_share.glsl
@@ -1,1 +1,5 @@
 varying vec2 v_uv;
+
+#ifdef O3_HAS_UV2
+    varying vec2 v_uv2;
+#endif

--- a/packages/core/src/shaderlib/uv_vert.glsl
+++ b/packages/core/src/shaderlib/uv_vert.glsl
@@ -1,13 +1,13 @@
-    #ifdef O3_HAS_UV
-
+#ifdef O3_HAS_UV
     v_uv = TEXCOORD_0;
-
-    #else
-
+#else
     // may need this calculate normal
     v_uv = vec2( 0., 0. );
+#endif
 
-    #endif
+#ifdef O3_HAS_UV2
+    v_uv2 = TEXCOORD_1;
+#endif
 
 #ifdef O3_NEED_TILINGOFFSET
     v_uv = v_uv * u_tilingOffset.xy + u_tilingOffset.zw;

--- a/packages/core/src/shaderlib/uv_vert.glsl
+++ b/packages/core/src/shaderlib/uv_vert.glsl
@@ -5,8 +5,8 @@
     v_uv = vec2( 0., 0. );
 #endif
 
-#ifdef O3_HAS_UV2
-    v_uv2 = TEXCOORD_1;
+#ifdef O3_HAS_UV1
+    v_uv1 = TEXCOORD_1;
 #endif
 
 #ifdef O3_NEED_TILINGOFFSET

--- a/packages/loader/src/gltf/parser/MaterialParser.ts
+++ b/packages/loader/src/gltf/parser/MaterialParser.ts
@@ -1,4 +1,12 @@
-import { Material, PBRMaterial, PBRSpecularMaterial, RenderFace, UnlitMaterial } from "@oasis-engine/core";
+import {
+  Logger,
+  Material,
+  PBRMaterial,
+  PBRSpecularMaterial,
+  RenderFace,
+  TextureCoordinate,
+  UnlitMaterial
+} from "@oasis-engine/core";
 import { Color } from "@oasis-engine/math";
 import { GLTFResource } from "../GLTFResource";
 import { MaterialAlphaMode } from "../Schema";
@@ -98,11 +106,16 @@ export class MaterialParser extends Parser {
         }
 
         if (occlusionTexture) {
-          const { index, strength } = occlusionTexture;
+          const { index, strength, texCoord } = occlusionTexture;
           m.occlusionTexture = textures[index];
           MaterialParser._parseTextureTransform(material, occlusionTexture.extensions, context);
           if (strength !== undefined) {
             m.occlusionTextureIntensity = strength;
+          }
+          if (texCoord === TextureCoordinate.UV1) {
+            m.occlusionTextureCoord = TextureCoordinate.UV1;
+          } else if (texCoord > TextureCoordinate.UV1) {
+            Logger.warn("Occlusion texture uv coordinate must be UV0 or UV1.");
           }
         }
       }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature.
### What is the current behavior? (You can also link to an open issue here)
As #616 described, we only use `uv0` for all texture samplers,  in most 3D IDEs like blender, uv channel is configurable, and occlusionTexture ususally  use `UV1` or `UV0`, so we add `occlusionTextureCoord `.

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/17639043/157178174-a5402c0b-7c7e-4d10-a4ca-1738810d607a.png">


### What is the new behavior (if this is a feature change)?
Supported.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
### Other information:
