### PR TITLE
fix: break texcoor to avoid `_vertexSlotChanged` error

### DIFF
--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -164,15 +164,19 @@ export class MeshParser extends Parser {
         case "TEXCOORD_3":
           const texturecoords3 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
           mesh.setUVs(texturecoords3, 3);
+          break;
         case "TEXCOORD_4":
           const texturecoords4 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
           mesh.setUVs(texturecoords4, 4);
+          break;
         case "TEXCOORD_5":
           const texturecoords5 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
           mesh.setUVs(texturecoords5, 5);
+          break;
         case "TEXCOORD_6":
           const texturecoords6 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
           mesh.setUVs(texturecoords6, 6);
+          break;
         case "TEXCOORD_7":
           const texturecoords7 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
           mesh.setUVs(texturecoords7, 7);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix.
### What is the current behavior? (You can also link to an open issue here)
some gltf models have many uv chanels, case `_vertexSlotChanged` to be `false` and then load error.
### What is the new behavior (if this is a feature change)?
Fixed.
