### PR TITLE
FloatTexture version Blendshape 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "npm",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "bootstrap": {
     "hoist": true
   },

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/controls",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "scripts": {
     "b:types": "tsc",
@@ -15,6 +15,6 @@
     "types/**/*"
   ],
   "dependencies": {
-    "oasis-engine": "0.6.7"
+    "oasis-engine": "0.7.0-beta.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/core",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -14,9 +14,9 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/math": "0.6.7"
+    "@oasis-engine/math": "0.7.0-beta.0"
   },
   "devDependencies": {
-    "@oasis-engine/design": "0.6.7"
+    "@oasis-engine/design": "0.7.0-beta.0"
   }
 }

--- a/packages/core/src/2d/sprite/Sprite.ts
+++ b/packages/core/src/2d/sprite/Sprite.ts
@@ -1,8 +1,8 @@
 import { BoundingBox, MathUtil, Rect, Vector2, Vector4 } from "@oasis-engine/math";
 import { RefObject } from "../../asset/RefObject";
+import { BoolUpdateFlag } from "../../BoolUpdateFlag";
 import { Engine } from "../../Engine";
 import { Texture2D } from "../../texture/Texture2D";
-import { UpdateFlag } from "../../UpdateFlag";
 import { UpdateFlagManager } from "../../UpdateFlagManager";
 
 /**
@@ -182,7 +182,7 @@ export class Sprite extends RefObject {
    * Clone.
    * @returns Cloned sprite
    */
-   clone(): Sprite {
+  clone(): Sprite {
     const cloneSprite = new Sprite(
       this._engine,
       this._texture,
@@ -201,8 +201,8 @@ export class Sprite extends RefObject {
   /**
    * @internal
    */
-  _registerUpdateFlag(): UpdateFlag {
-    return this._updateFlagManager.register();
+  _registerUpdateFlag(): BoolUpdateFlag {
+    return this._updateFlagManager.createFlag(BoolUpdateFlag);
   }
 
   /**
@@ -363,7 +363,7 @@ export class Sprite extends RefObject {
 
   private _setDirtyFlagTrue(type: number): void {
     this._dirtyFlag |= type;
-    this._updateFlagManager.distribute();
+    this._updateFlagManager.dispatch();
   }
 
   private _setDirtyFlagFalse(type: number): void {

--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "../../BoolUpdateFlag";
 import { Camera } from "../../Camera";
 import { assignmentClone, deepClone, ignoreClone } from "../../clone/CloneManager";
 import { ICustomClone } from "../../clone/ComponentCloner";
@@ -28,13 +29,13 @@ export class SpriteMask extends Renderer implements ICustomClone {
   @deepClone
   private _positions: Vector3[] = [new Vector3(), new Vector3(), new Vector3(), new Vector3()];
   @ignoreClone
-  private _worldMatrixDirtyFlag: UpdateFlag;
+  private _worldMatrixDirtyFlag: BoolUpdateFlag;
   @ignoreClone
   private _sprite: Sprite = null;
   @assignmentClone
   private _alphaCutoff: number = 0.5;
   @ignoreClone
-  private _spriteDirty: UpdateFlag;
+  private _spriteDirty: BoolUpdateFlag;
 
   /** The mask layers the sprite mask influence to. */
   @assignmentClone

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -1,4 +1,5 @@
 import { BoundingBox, Color, Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "../../BoolUpdateFlag";
 import { Camera } from "../../Camera";
 import { assignmentClone, deepClone, ignoreClone } from "../../clone/CloneManager";
 import { ICustomClone } from "../../clone/ComponentCloner";
@@ -45,9 +46,9 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
   @ignoreClone
   private _dirtyFlag: number = 0;
   @ignoreClone
-  private _isWorldMatrixDirty: UpdateFlag;
+  private _isWorldMatrixDirty: BoolUpdateFlag;
   @ignoreClone
-  private _spriteDirty: UpdateFlag;
+  private _spriteDirty: BoolUpdateFlag;
   @assignmentClone
   private _maskInteraction: SpriteMaskInteraction = SpriteMaskInteraction.None;
   @assignmentClone

--- a/packages/core/src/2d/text/TextRenderer.ts
+++ b/packages/core/src/2d/text/TextRenderer.ts
@@ -1,6 +1,7 @@
 import { BoundingBox, Color, Vector3 } from "@oasis-engine/math";
 import { Sprite, SpriteMaskInteraction, SpriteMaskLayer, SpriteRenderer } from "..";
 import { CompareFunction, Renderer, UpdateFlag } from "../..";
+import { BoolUpdateFlag } from "../../BoolUpdateFlag";
 import { Camera } from "../../Camera";
 import { assignmentClone, deepClone, ignoreClone } from "../../clone/CloneManager";
 import { Entity } from "../../Entity";
@@ -55,7 +56,7 @@ export class TextRenderer extends Renderer {
   @ignoreClone
   private _dirtyFlag: number = DirtyFlag.Property;
   @ignoreClone
-  private _isWorldMatrixDirty: UpdateFlag;
+  private _isWorldMatrixDirty: BoolUpdateFlag;
   @assignmentClone
   private _maskInteraction: SpriteMaskInteraction = SpriteMaskInteraction.None;
   @assignmentClone

--- a/packages/core/src/BoolUpdateFlag.ts
+++ b/packages/core/src/BoolUpdateFlag.ts
@@ -11,6 +11,9 @@ export class BoolUpdateFlag extends UpdateFlag {
   /** Flag. */
   flag = true;
 
+  /**
+   * @inheritdoc
+   */
   dispatch(): void {
     this.flag = true;
   }

--- a/packages/core/src/BoolUpdateFlag.ts
+++ b/packages/core/src/BoolUpdateFlag.ts
@@ -1,0 +1,28 @@
+import { removeFromArray } from "./base/Util";
+import { UpdateFlag } from "./UpdateFlag";
+import { UpdateFlagManager } from "./UpdateFlagManager";
+
+/**
+ * Used to update tags.
+ */
+export class BoolUpdateFlag extends UpdateFlag {
+  /** @internal */
+  _flagManagers: UpdateFlagManager[] = [];
+
+  /** Flag. */
+  flag = true;
+
+  dispatch(): void {
+    this.flag = true;
+  }
+
+  /**
+   * Clear.
+   */
+  destroy(): void {
+    for (let i = 0, n = this._flagManagers.length; i < n; i++) {
+      removeFromArray(this._flagManagers[i]._updateFlags, this);
+    }
+    this._flagManagers.length = 0;
+  }
+}

--- a/packages/core/src/BoolUpdateFlag.ts
+++ b/packages/core/src/BoolUpdateFlag.ts
@@ -1,4 +1,3 @@
-import { removeFromArray } from "./base/Util";
 import { UpdateFlag } from "./UpdateFlag";
 import { UpdateFlagManager } from "./UpdateFlagManager";
 
@@ -14,15 +13,5 @@ export class BoolUpdateFlag extends UpdateFlag {
 
   dispatch(): void {
     this.flag = true;
-  }
-
-  /**
-   * Destroy.
-   */
-  destroy(): void {
-    for (let i = 0, n = this._flagManagers.length; i < n; i++) {
-      removeFromArray(this._flagManagers[i]._updateFlags, this);
-    }
-    this._flagManagers.length = 0;
   }
 }

--- a/packages/core/src/BoolUpdateFlag.ts
+++ b/packages/core/src/BoolUpdateFlag.ts
@@ -1,5 +1,4 @@
 import { UpdateFlag } from "./UpdateFlag";
-import { UpdateFlagManager } from "./UpdateFlagManager";
 
 /**
  * Used to update tags.

--- a/packages/core/src/BoolUpdateFlag.ts
+++ b/packages/core/src/BoolUpdateFlag.ts
@@ -5,9 +5,6 @@ import { UpdateFlagManager } from "./UpdateFlagManager";
  * Used to update tags.
  */
 export class BoolUpdateFlag extends UpdateFlag {
-  /** @internal */
-  _flagManagers: UpdateFlagManager[] = [];
-
   /** Flag. */
   flag = true;
 

--- a/packages/core/src/BoolUpdateFlag.ts
+++ b/packages/core/src/BoolUpdateFlag.ts
@@ -17,7 +17,7 @@ export class BoolUpdateFlag extends UpdateFlag {
   }
 
   /**
-   * Clear.
+   * Destroy.
    */
   destroy(): void {
     for (let i = 0, n = this._flagManagers.length; i < n; i++) {

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -1,5 +1,6 @@
 import { BoundingFrustum, MathUtil, Matrix, Quaternion, Ray, Vector2, Vector3, Vector4 } from "@oasis-engine/math";
 import { Logger } from "./base";
+import { BoolUpdateFlag } from "./BoolUpdateFlag";
 import { deepClone, ignoreClone } from "./clone/CloneManager";
 import { Component } from "./Component";
 import { dependencies } from "./ComponentsDependencies";
@@ -124,13 +125,13 @@ export class Camera extends Component {
   private _renderTarget: RenderTarget = null;
 
   @ignoreClone
-  private _frustumViewChangeFlag: UpdateFlag;
+  private _frustumViewChangeFlag: BoolUpdateFlag;
   @ignoreClone
   private _transform: Transform;
   @ignoreClone
-  private _isViewMatrixDirty: UpdateFlag;
+  private _isViewMatrixDirty: BoolUpdateFlag;
   @ignoreClone
-  private _isInvViewProjDirty: UpdateFlag;
+  private _isInvViewProjDirty: BoolUpdateFlag;
   @deepClone
   private _projectionMatrix: Matrix = new Matrix();
   @deepClone

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -32,7 +32,7 @@ import { ShaderMacroCollection } from "./shader/ShaderMacroCollection";
 import { ShaderPool } from "./shader/ShaderPool";
 import { ShaderProgramPool } from "./shader/ShaderProgramPool";
 import { RenderState } from "./shader/state/RenderState";
-import { Texture2D, TextureCube, TextureCubeFace, TextureFormat } from "./texture";
+import { Texture2D, Texture2DArray, TextureCube, TextureCubeFace, TextureFormat } from "./texture";
 
 /** TODO: delete */
 const engineFeatureManager = new FeatureManager<EngineFeature>();
@@ -63,6 +63,8 @@ export class Engine extends EventDispatcher {
   _whiteTexture2D: Texture2D;
   /* @internal */
   _whiteTextureCube: TextureCube;
+  /* @internal */
+  _whiteTexture2DArray: Texture2DArray;
   /* @internal */
   _backgroundTextureMaterial: Material;
   /* @internal */
@@ -213,6 +215,13 @@ export class Engine extends EventDispatcher {
 
     this._whiteTexture2D = whiteTexture2D;
     this._whiteTextureCube = whiteTextureCube;
+
+    if (hardwareRenderer.isWebGL2) {
+      const whiteTexture2DArray = new Texture2DArray(this, 1, 1, 1, TextureFormat.R8G8B8A8, false);
+      whiteTexture2DArray.setPixelBuffer(0, whitePixel);
+      whiteTexture2DArray.isGCIgnored = true;
+      this._whiteTexture2DArray = whiteTexture2DArray;
+    }
 
     this._backgroundTextureMaterial = new Material(this, Shader.find("background-texture"));
     this._backgroundTextureMaterial.isGCIgnored = true;

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -1,5 +1,6 @@
 import { Matrix } from "@oasis-engine/math";
 import { EngineObject } from "./base";
+import { BoolUpdateFlag } from "./BoolUpdateFlag";
 import { ComponentCloner } from "./clone/ComponentCloner";
 import { Component } from "./Component";
 import { ComponentsDependencies } from "./ComponentsDependencies";
@@ -484,7 +485,7 @@ export class Entity extends EngineObject {
 
   //--------------------------------------------------------------deprecated----------------------------------------------------------------
   private _invModelMatrix: Matrix = new Matrix();
-  private _inverseWorldMatFlag: UpdateFlag;
+  private _inverseWorldMatFlag: BoolUpdateFlag;
 
   /**
    * @deprecated

--- a/packages/core/src/ListenerUpdateFlag.ts
+++ b/packages/core/src/ListenerUpdateFlag.ts
@@ -17,7 +17,7 @@ export class ListenerUpdateFlag extends UpdateFlag {
   }
 
   /**
-   * Clear.
+   * Destroy.
    */
   destroy(): void {
     for (let i = 0, n = this._flagManagers.length; i < n; i++) {

--- a/packages/core/src/ListenerUpdateFlag.ts
+++ b/packages/core/src/ListenerUpdateFlag.ts
@@ -1,0 +1,28 @@
+import { removeFromArray } from "./base/Util";
+import { UpdateFlag } from "./UpdateFlag";
+import { UpdateFlagManager } from "./UpdateFlagManager";
+
+/**
+ * Used to update tags.
+ */
+export class ListenerUpdateFlag extends UpdateFlag {
+  /** @internal */
+  _flagManagers: UpdateFlagManager[] = [];
+
+  /** Listener. */
+  listener: Function;
+
+  dispatch(param?: Object): void {
+    this.listener && this.listener(param);
+  }
+
+  /**
+   * Clear.
+   */
+  destroy(): void {
+    for (let i = 0, n = this._flagManagers.length; i < n; i++) {
+      removeFromArray(this._flagManagers[i]._updateFlags, this);
+    }
+    this._flagManagers.length = 0;
+  }
+}

--- a/packages/core/src/ListenerUpdateFlag.ts
+++ b/packages/core/src/ListenerUpdateFlag.ts
@@ -5,9 +5,6 @@ import { UpdateFlagManager } from "./UpdateFlagManager";
  * Used to update tags.
  */
 export class ListenerUpdateFlag extends UpdateFlag {
-  /** @internal */
-  _flagManagers: UpdateFlagManager[] = [];
-
   /** Listener. */
   listener: Function;
 

--- a/packages/core/src/ListenerUpdateFlag.ts
+++ b/packages/core/src/ListenerUpdateFlag.ts
@@ -1,5 +1,4 @@
 import { UpdateFlag } from "./UpdateFlag";
-import { UpdateFlagManager } from "./UpdateFlagManager";
 
 /**
  * Used to update tags.

--- a/packages/core/src/ListenerUpdateFlag.ts
+++ b/packages/core/src/ListenerUpdateFlag.ts
@@ -11,6 +11,9 @@ export class ListenerUpdateFlag extends UpdateFlag {
   /** Listener. */
   listener: Function;
 
+  /**
+   * @inheritdoc
+   */
   dispatch(param?: Object): void {
     this.listener && this.listener(param);
   }

--- a/packages/core/src/ListenerUpdateFlag.ts
+++ b/packages/core/src/ListenerUpdateFlag.ts
@@ -1,4 +1,3 @@
-import { removeFromArray } from "./base/Util";
 import { UpdateFlag } from "./UpdateFlag";
 import { UpdateFlagManager } from "./UpdateFlagManager";
 
@@ -14,15 +13,5 @@ export class ListenerUpdateFlag extends UpdateFlag {
 
   dispatch(param?: Object): void {
     this.listener && this.listener(param);
-  }
-
-  /**
-   * Destroy.
-   */
-  destroy(): void {
-    for (let i = 0, n = this._flagManagers.length; i < n; i++) {
-      removeFromArray(this._flagManagers[i]._updateFlags, this);
-    }
-    this._flagManagers.length = 0;
   }
 }

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -1,4 +1,5 @@
 import { BoundingBox, Matrix, Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "./BoolUpdateFlag";
 import { Camera } from "./Camera";
 import { deepClone, ignoreClone, shallowClone } from "./clone/CloneManager";
 import { Component } from "./Component";
@@ -52,7 +53,7 @@ export abstract class Renderer extends Component {
   protected _materials: Material[] = [];
 
   @ignoreClone
-  private _transformChangeFlag: UpdateFlag;
+  private _transformChangeFlag: BoolUpdateFlag;
   @deepClone
   private _bounds: BoundingBox = new BoundingBox(new Vector3(), new Vector3());
   @ignoreClone

--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -1,4 +1,5 @@
 import { MathUtil, Matrix, Matrix3x3, Quaternion, Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "./BoolUpdateFlag";
 import { deepClone, ignoreClone } from "./clone/CloneManager";
 import { Component } from "./Component";
 import { Entity } from "./Entity";
@@ -539,8 +540,8 @@ export class Transform extends Component {
    * Register world transform change flag.
    * @returns Change flag
    */
-  registerWorldChangeFlag(): UpdateFlag {
-    return this._updateFlagManager.register();
+  registerWorldChangeFlag(): BoolUpdateFlag {
+    return this._updateFlagManager.createFlag(BoolUpdateFlag);
   }
 
   /**
@@ -706,7 +707,7 @@ export class Transform extends Component {
 
   private _worldAssociatedChange(type: number): void {
     this._dirtyFlag |= type;
-    this._updateFlagManager.distribute();
+    this._updateFlagManager.dispatch();
   }
 
   private _rotateByQuat(rotateQuat: Quaternion, relativeToLocal: boolean) {

--- a/packages/core/src/UpdateFlag.ts
+++ b/packages/core/src/UpdateFlag.ts
@@ -1,22 +1,34 @@
 import { removeFromArray } from "./base/Util";
+import { UpdateFlagManager } from "./UpdateFlagManager";
 
 /**
  * Used to update tags.
  */
-export class UpdateFlag {
-  /** Flag. */
-  flag = true;
+export abstract class UpdateFlag {
+  /** @internal */
+  _flagManagers: UpdateFlagManager[] = [];
 
-  constructor(private _flags: UpdateFlag[] = []) {
-    this._flags.push(this);
+  abstract dispatch(param?: Object): void;
+
+  /**
+   * Clear.
+   */
+  clearFromManagers(): void {
+    const flagManagers = this._flagManagers;
+    for (let i = 0, n = flagManagers.length; i < n; i++) {
+      removeFromArray(flagManagers[i]._updateFlags, this);
+    }
+    flagManagers.length = 0;
   }
 
   /**
    * Destroy.
    */
   destroy(): void {
-    const flags = this._flags;
-    removeFromArray(flags, this);
-    this._flags = null;
+    const flagManagers = this._flagManagers;
+    for (let i = 0, n = flagManagers.length; i < n; i++) {
+      removeFromArray(flagManagers[i]._updateFlags, this);
+    }
+    this._flagManagers = null;
   }
 }

--- a/packages/core/src/UpdateFlag.ts
+++ b/packages/core/src/UpdateFlag.ts
@@ -8,6 +8,10 @@ export abstract class UpdateFlag {
   /** @internal */
   _flagManagers: UpdateFlagManager[] = [];
 
+  /**
+   * Dispatch.
+   * @param param - Parameter
+   */
   abstract dispatch(param?: Object): void;
 
   /**

--- a/packages/core/src/UpdateFlag.ts
+++ b/packages/core/src/UpdateFlag.ts
@@ -18,21 +18,22 @@ export abstract class UpdateFlag {
    * Clear.
    */
   clearFromManagers(): void {
-    const flagManagers = this._flagManagers;
-    for (let i = 0, n = flagManagers.length; i < n; i++) {
-      removeFromArray(flagManagers[i]._updateFlags, this);
-    }
-    flagManagers.length = 0;
+    this._removeFromManagers();
+    this._flagManagers.length = 0;
   }
 
   /**
    * Destroy.
    */
   destroy(): void {
+    this._removeFromManagers();
+    this._flagManagers = null;
+  }
+
+  private _removeFromManagers(): void {
     const flagManagers = this._flagManagers;
     for (let i = 0, n = flagManagers.length; i < n; i++) {
       removeFromArray(flagManagers[i]._updateFlags, this);
     }
-    this._flagManagers = null;
   }
 }

--- a/packages/core/src/UpdateFlagManager.ts
+++ b/packages/core/src/UpdateFlagManager.ts
@@ -4,16 +4,35 @@ import { UpdateFlag } from "./UpdateFlag";
  * @internal
  */
 export class UpdateFlagManager {
-  private _updateFlags: UpdateFlag[] = [];
+  /** @internal */
+  _updateFlags: UpdateFlag[] = [];
 
-  register(): UpdateFlag {
-    return new UpdateFlag(this._updateFlags);
+  /**
+   * Create a UpdateFlag.
+   * @returns - The UpdateFlag.
+   */
+  createFlag<T extends UpdateFlag>(type: new () => T): T {
+    const flag = new type();
+    this.addFlag(flag);
+    return flag;
   }
 
-  distribute(): void {
+  /**
+   * Add a UpdateFlag.
+   * @param flag - The UpdateFlag.
+   */
+  addFlag(flag: UpdateFlag): void {
+    this._updateFlags.push(flag);
+    flag._flagManagers.push(this);
+  }
+
+  /**
+   * Dispatch.
+   */
+  dispatch(param?: Object): void {
     const updateFlags = this._updateFlags;
     for (let i = updateFlags.length - 1; i >= 0; i--) {
-      updateFlags[i].flag = true;
+      updateFlags[i].dispatch(param);
     }
   }
 }

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -1,4 +1,5 @@
 import { Quaternion, Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { assignmentClone, ignoreClone } from "../clone/CloneManager";
 import { Component } from "../Component";
 import { Entity } from "../Entity";
@@ -36,7 +37,7 @@ export class Animator extends Component {
   @assignmentClone
   protected _speed: number = 1.0;
   @ignoreClone
-  protected _controllerUpdateFlag: UpdateFlag;
+  protected _controllerUpdateFlag: BoolUpdateFlag;
 
   @ignoreClone
   private _animatorLayersData: AnimatorLayerData[] = [];

--- a/packages/core/src/animation/AnimatorController.ts
+++ b/packages/core/src/animation/AnimatorController.ts
@@ -1,4 +1,4 @@
-import { UpdateFlag } from "../UpdateFlag";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { UpdateFlagManager } from "../UpdateFlagManager";
 import { AnimatorControllerLayer } from "./AnimatorControllerLayer";
 
@@ -60,11 +60,11 @@ export class AnimatorController {
   /**
    * @internal
    */
-  _registerChangeFlag(): UpdateFlag {
-    return this._updateFlagManager.register();
+  _registerChangeFlag(): BoolUpdateFlag {
+    return this._updateFlagManager.createFlag(BoolUpdateFlag);
   }
 
   private _distributeUpdateFlag(): void {
-    this._updateFlagManager.distribute();
+    this._updateFlagManager.dispatch();
   }
 }

--- a/packages/core/src/graphic/Mesh.ts
+++ b/packages/core/src/graphic/Mesh.ts
@@ -1,6 +1,7 @@
 import { IPlatformPrimitive } from "@oasis-engine/design/types/renderingHardwareInterface/IPlatformPrimitive";
 import { BoundingBox } from "@oasis-engine/math";
 import { RefObject } from "../asset/RefObject";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { Engine } from "../Engine";
 import { BufferUtil } from "../graphic/BufferUtil";
 import { MeshTopology } from "../graphic/enums/MeshTopology";
@@ -114,8 +115,8 @@ export abstract class Mesh extends RefObject {
    * Register update flag, update flag will be true if the vertex element changes.
    * @returns Update flag
    */
-  registerUpdateFlag(): UpdateFlag {
-    return this._updateFlagManager.register();
+  registerUpdateFlag(): BoolUpdateFlag {
+    return this._updateFlagManager.createFlag(BoolUpdateFlag);
   }
 
   /**
@@ -187,6 +188,6 @@ export abstract class Mesh extends RefObject {
     const { semantic } = element;
     this._vertexElementMap[semantic] = element;
     this._vertexElements.push(element);
-    this._updateFlagManager.distribute();
+    this._updateFlagManager.dispatch();
   }
 }

--- a/packages/core/src/mesh/BlendShape.ts
+++ b/packages/core/src/mesh/BlendShape.ts
@@ -1,7 +1,7 @@
-import { BlendShapeFrame } from "./BlendShapeFrame";
 import { Vector3 } from "@oasis-engine/math";
 import { UpdateFlag } from "../UpdateFlag";
 import { UpdateFlagManager } from "../UpdateFlagManager";
+import { BlendShapeFrame } from "./BlendShapeFrame";
 
 /**
  * BlendShape.
@@ -11,9 +11,9 @@ export class BlendShape {
   name: string;
 
   /** @internal */
-  _useBlendShapeNormal: boolean = false;
+  _useBlendShapeNormal: boolean = true;
   /** @internal */
-  _useBlendShapeTangent: boolean = false;
+  _useBlendShapeTangent: boolean = true;
 
   private _frames: BlendShapeFrame[] = [];
   private _updateFlagManager: UpdateFlagManager = new UpdateFlagManager();
@@ -66,7 +66,6 @@ export class BlendShape {
     } else {
       this._addFrame(frameOrWeight);
     }
-    this._updateFlagManager.distribute();
   }
 
   /**
@@ -75,8 +74,8 @@ export class BlendShape {
   clearFrames(): void {
     this._frames.length = 0;
     this._updateFlagManager.distribute();
-    this._useBlendShapeNormal = false;
-    this._useBlendShapeTangent = false;
+    this._useBlendShapeNormal = true;
+    this._useBlendShapeTangent = true;
   }
 
   /**
@@ -92,9 +91,14 @@ export class BlendShape {
     if (frameCount > 0 && frame.deltaPositions.length !== frames[frameCount - 1].deltaPositions.length) {
       throw "Frame's deltaPositions length must same with before frame deltaPositions length.";
     }
-
-    this._useBlendShapeNormal = this._useBlendShapeNormal || frame.deltaNormals !== null;
-    this._useBlendShapeTangent = this._useBlendShapeTangent || frame.deltaTangents !== null;
     this._frames.push(frame);
+
+    const hasNormals = !!frame.deltaNormals;
+    const hasTangents = !!frame.deltaTangents;
+    if (this._useBlendShapeNormal !== hasNormals || this._useBlendShapeTangent !== hasTangents) {
+      this._useBlendShapeNormal = hasNormals;
+      this._useBlendShapeTangent = hasTangents;
+    }
+    this._updateFlagManager.distribute();
   }
 }

--- a/packages/core/src/mesh/BlendShape.ts
+++ b/packages/core/src/mesh/BlendShape.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { UpdateFlag } from "../UpdateFlag";
 import { UpdateFlagManager } from "../UpdateFlagManager";
 import { BlendShapeFrame } from "./BlendShapeFrame";
@@ -15,8 +16,9 @@ export class BlendShape {
   /** @internal */
   _useBlendShapeTangent: boolean = true;
 
+  private _layoutChangeManager: UpdateFlagManager = new UpdateFlagManager();
+  private _dataChangeManager: UpdateFlagManager = new UpdateFlagManager();
   private _frames: BlendShapeFrame[] = [];
-  private _updateFlagManager: UpdateFlagManager = new UpdateFlagManager();
 
   /**
    * Frames of BlendShape.
@@ -73,16 +75,29 @@ export class BlendShape {
    */
   clearFrames(): void {
     this._frames.length = 0;
-    this._updateFlagManager.distribute();
-    this._useBlendShapeNormal = true;
-    this._useBlendShapeTangent = true;
+    this._updateUseNormalAndTangent(true, true);
+    this._dataChangeManager.dispatch();
   }
 
   /**
    * @internal
    */
-  _registerChangeFlag(): UpdateFlag {
-    return this._updateFlagManager.register();
+  _addLayoutChangeFlag(flag: UpdateFlag): void {
+    this._layoutChangeManager.addFlag(flag);
+  }
+
+  /**
+   * @internal
+   */
+  _addDataDirtyFlag(flag: UpdateFlag): void {
+    this._dataChangeManager.addFlag(flag);
+  }
+
+  /**
+   * @internal
+   */
+  _createSubDataDirtyFlag(): BoolUpdateFlag {
+    return this._dataChangeManager.createFlag(BoolUpdateFlag);
   }
 
   private _addFrame(frame: BlendShapeFrame): void {
@@ -93,12 +108,17 @@ export class BlendShape {
     }
     this._frames.push(frame);
 
-    const hasNormals = !!frame.deltaNormals;
-    const hasTangents = !!frame.deltaTangents;
-    if (this._useBlendShapeNormal !== hasNormals || this._useBlendShapeTangent !== hasTangents) {
-      this._useBlendShapeNormal = hasNormals;
-      this._useBlendShapeTangent = hasTangents;
+    this._updateUseNormalAndTangent(!!frame.deltaNormals, !!frame.deltaTangents);
+    this._dataChangeManager.dispatch();
+  }
+
+  private _updateUseNormalAndTangent(useNormal: boolean, useTangent: boolean): void {
+    const useBlendShapeNormal = this._useBlendShapeNormal && useNormal;
+    const useBlendShapeTangent = this._useBlendShapeTangent && useTangent;
+    if (this._useBlendShapeNormal !== useBlendShapeNormal || this._useBlendShapeTangent !== useBlendShapeTangent) {
+      this._useBlendShapeNormal = useBlendShapeNormal;
+      this._useBlendShapeTangent = useBlendShapeTangent;
+      this._layoutChangeManager.dispatch(this);
     }
-    this._updateFlagManager.distribute();
   }
 }

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -17,6 +17,8 @@ export class BlendShapeManager {
   /** @internal */
   _blendShapes: BlendShape[] = [];
   /** @internal */
+  _blendShapeNamesMap: Record<string, number>;
+  /** @internal */
   _blendShapeCount: number = 0;
   /** @internal */
   _layoutDirtyFlag: ListenerUpdateFlag = new ListenerUpdateFlag();
@@ -312,6 +314,13 @@ export class BlendShapeManager {
    * @internal
    */
   _releaseMemoryCache(): void {
+    const blendShapeNamesMap: Record<string, number> = {};
+    const { _blendShapes: blendShapes } = this;
+    for (let i = 0, n = blendShapes.length; i < n; i++) {
+      blendShapeNamesMap[blendShapes[i].name] = i;
+    }
+    this._blendShapeNamesMap = blendShapeNamesMap;
+
     this._layoutDirtyFlag.destroy();
     const dataChangedFlags = this._subDataDirtyFlags;
     for (let i = 0, n = dataChangedFlags.length; i < n; i++) {

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -30,11 +30,11 @@ export class BlendShapeManager {
   /** @internal */
   _dataTexture: Texture2DArray;
   /** @internal */
-  _dataTextureInfo: Vector3 = new Vector3();
+  readonly _dataTextureInfo: Vector3 = new Vector3();
 
-  private _engine: Engine;
-  private _lastUpdateLayoutAndCountInfo: Vector3 = new Vector3(0, 0, 0);
-  private _canUseTextureStoreData: boolean = true;
+  private readonly _engine: Engine;
+  private readonly _lastUpdateLayoutAndCountInfo: Vector3 = new Vector3(0, 0, 0);
+  private readonly _canUseTextureStoreData: boolean = true;
 
   constructor(engine: Engine) {
     this._engine = engine;

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -34,6 +34,7 @@ export class BlendShapeManager {
 
   constructor(engine: Engine) {
     this._engine = engine;
+    // CM: try use attribute first
     this._usingTextureStoreData = this._engine._hardwareRenderer.capability.canUseFloatTextureBlendShape;
   }
 

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -1,0 +1,138 @@
+import { Engine } from "../Engine";
+import { Texture2DArray, TextureFilterMode, TextureFormat } from "../texture";
+import { UpdateFlag } from "../UpdateFlag";
+import { BlendShape } from "./BlendShape";
+
+/**
+ * @internal
+ */
+export class BlendShapeManager {
+  /** @internal */
+  _hasBlendShape: boolean = false;
+  /** @internal */
+  _useBlendShapeNormal: boolean = false;
+  /** @internal */
+  _useBlendShapeTangent: boolean = false;
+  /** @internal */
+  _blendShapes: BlendShape[] = [];
+  /** @internal */
+  _blendShapeUpdateFlags: UpdateFlag[] = [];
+  /** @internal */
+  _blendShapeDataTexture: Texture2DArray;
+
+  private _engine: Engine;
+
+  constructor(engine: Engine) {
+    this._engine = engine;
+  }
+
+  /**
+   * @internal
+   */
+  _addBlendShape(blendShape: BlendShape): void {
+    this._useBlendShapeNormal = this._useBlendShapeNormal || blendShape._useBlendShapeNormal;
+    this._useBlendShapeTangent = this._useBlendShapeTangent || blendShape._useBlendShapeTangent;
+    this._blendShapes.push(blendShape);
+    this._blendShapeUpdateFlags.push(blendShape._registerChangeFlag());
+    this._hasBlendShape = true;
+  }
+
+  /**
+   * @internal
+   */
+  _clearBlendShapes(): void {
+    this._useBlendShapeNormal = false;
+    this._useBlendShapeTangent = false;
+    this._blendShapes.length = 0;
+    const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
+    for (let i = 0, n = blendShapeUpdateFlags.length; i < n; i++) {
+      blendShapeUpdateFlags[i].destroy();
+    }
+    blendShapeUpdateFlags.length = 0;
+    this._hasBlendShape = false;
+  }
+
+  /**
+   * @internal
+   */
+  _updateBlendShapeDataTexture(): void {
+    const vertexCount = 0;
+    const maxTextureSize = 0;
+
+    let pixelStride = 1;
+    this._useBlendShapeNormal && pixelStride++;
+    this._useBlendShapeTangent && pixelStride++;
+
+    let textureWidth = pixelStride * vertexCount;
+    let textureHeight = 1;
+    if (textureWidth > maxTextureSize) {
+      textureWidth = maxTextureSize;
+      textureHeight = Math.ceil(textureWidth / maxTextureSize);
+    }
+
+    let blendShapeDataTexture = this._blendShapeDataTexture;
+    if (
+      !blendShapeDataTexture ||
+      blendShapeDataTexture.width !== textureWidth ||
+      blendShapeDataTexture.height !== textureHeight ||
+      blendShapeDataTexture.length !== this._blendShapes.length
+    ) {
+      blendShapeDataTexture && blendShapeDataTexture.destroy();
+
+      const blendShapes = this._blendShapes;
+      let shapeCount = blendShapes.length;
+      let bufferData = new Float32Array(shapeCount * textureWidth * textureHeight * 4);
+
+      let offset = 0;
+      for (let i = 0; i < shapeCount; i++) {
+        const blendShapeFrame = blendShapes[i].frames[0];
+
+        const positions = blendShapeFrame.deltaPositions;
+        const normals = blendShapeFrame.deltaNormals;
+        const tangents = blendShapeFrame.deltaTangents;
+
+        offset = i * textureWidth * textureHeight * 4;
+        for (let j = 0; j < vertexCount; j++) {
+          const position = positions[j];
+          bufferData[offset] = position.x;
+          bufferData[offset + 1] = position.y;
+          bufferData[offset + 2] = position.z;
+          offset += 4;
+
+          if (normals) {
+            const normal = normals[j];
+            bufferData[offset] = normal.x;
+            bufferData[offset + 1] = normal.y;
+            bufferData[offset + 2] = normal.z;
+            offset += 4;
+          }
+
+          if (tangents) {
+            const tangent = tangents[j];
+            bufferData[offset] = tangent.x;
+            bufferData[offset + 1] = tangent.y;
+            bufferData[offset + 2] = tangent.z;
+            offset += 4;
+          }
+        }
+      }
+
+      blendShapeDataTexture = new Texture2DArray(this._engine, textureWidth, textureHeight, TextureFormat.R32G32B32A32);
+      blendShapeDataTexture.filterMode = TextureFilterMode.Point;
+      blendShapeDataTexture.setPixelBuffer(0, bufferData);
+      this._blendShapeDataTexture = blendShapeDataTexture;
+    }
+
+    const blendShapes = this._blendShapes;
+    for (let i = 0, n = blendShapes.length; i < n; i++) {}
+  }
+
+  _releaseCache(): void {
+    const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
+    for (let i = 0, n = blendShapeUpdateFlags.length; i < n; i++) {
+      blendShapeUpdateFlags[i].destroy();
+    }
+    this._blendShapes = null;
+    this._blendShapeUpdateFlags = null;
+  }
+}

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -1,4 +1,5 @@
 import { Engine } from "../Engine";
+import { VertexElement, VertexElementFormat } from "../graphic";
 import { Texture2DArray, TextureFilterMode, TextureFormat } from "../texture";
 import { UpdateFlag } from "../UpdateFlag";
 import { BlendShape } from "./BlendShape";
@@ -17,6 +18,9 @@ export class BlendShapeManager {
   _blendShapes: BlendShape[] = [];
   /** @internal */
   _blendShapeUpdateFlags: UpdateFlag[] = [];
+
+  /** @internal */
+  _usingTextureStoreData: boolean = false;
   /** @internal */
   _blendShapeDataTexture: Texture2DArray;
 
@@ -55,7 +59,98 @@ export class BlendShapeManager {
   /**
    * @internal
    */
-  _updateBlendShapeDataTexture(): void {
+  _supplementalVertexElement(vertexElements: VertexElement[], offset: number): number {
+    let supplementalElementCount = 0;
+    for (let i = 0, n = this._blendShapes.length; i < n; i++) {
+      vertexElements.push(new VertexElement(`POSITION_BS${i}`, offset, VertexElementFormat.Vector3, 0));
+      offset += 12;
+      supplementalElementCount += 3;
+      if (this._useBlendShapeNormal) {
+        vertexElements.push(new VertexElement(`NORMAL_BS${i}`, offset, VertexElementFormat.Vector3, 0));
+        offset += 12;
+        supplementalElementCount += 3;
+      }
+      if (this._useBlendShapeTangent) {
+        vertexElements.push(new VertexElement(`TANGENT_BS${i}`, offset, VertexElementFormat.Vector3, 0));
+        supplementalElementCount += 3;
+      }
+    }
+    return supplementalElementCount;
+  }
+
+  /**
+   * @internal
+   */
+  _updateDataToVertices(vertices: Float32Array, offset: number, vertexCount: number, elementCount: number): void {
+    const blendShapes = this._blendShapes;
+    const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
+    const blendShapeCount = Math.min(blendShapes.length, 4);
+
+    if (!this._usingTextureStoreData) {
+      for (let i = 0; i < blendShapeCount; i++) {
+        const blendShapeUpdateFlag = blendShapeUpdateFlags[i];
+        if (blendShapeUpdateFlag.flag) {
+          const blendShape = blendShapes[i];
+          const { frames } = blendShape;
+          const frameCount = frames.length;
+          const endFrame = frames[frameCount - 1];
+          if (frameCount > 0 && endFrame.deltaPositions.length !== vertexCount) {
+            throw "BlendShape frame deltaPositions length must same with mesh vertexCount.";
+          }
+
+          const { deltaPositions } = endFrame;
+          for (let j = 0; j < vertexCount; j++) {
+            const start = elementCount * j + offset;
+            const deltaPosition = deltaPositions[j];
+            if (deltaPosition) {
+              vertices[start] = deltaPosition.x;
+              vertices[start + 1] = deltaPosition.y;
+              vertices[start + 2] = deltaPosition.z;
+            }
+          }
+          offset += 3;
+
+          if (this._useBlendShapeNormal) {
+            const { deltaNormals } = endFrame;
+            if (deltaNormals) {
+              for (let j = 0; j < vertexCount; j++) {
+                const start = elementCount * j + offset;
+                const deltaNormal = deltaNormals[j];
+                if (deltaNormal) {
+                  vertices[start] = deltaNormal.x;
+                  vertices[start + 1] = deltaNormal.y;
+                  vertices[start + 2] = deltaNormal.z;
+                }
+              }
+            }
+            offset += 3;
+          }
+
+          if (this._useBlendShapeTangent) {
+            const { deltaTangents } = endFrame;
+            if (deltaTangents) {
+              for (let j = 0; j < vertexCount; j++) {
+                const start = elementCount * j + offset;
+                const deltaTangent = deltaTangents[j];
+                if (deltaTangent) {
+                  vertices[start] = deltaTangent.x;
+                  vertices[start + 1] = deltaTangent.y;
+                  vertices[start + 2] = deltaTangent.z;
+                }
+              }
+            }
+            offset += 3;
+          }
+          blendShapeUpdateFlag.flag = false;
+        }
+      }
+    }
+  }
+
+  /**
+   * @internal
+   */
+  _updateDataToTexture(): void {
     const vertexCount = 0;
     const maxTextureSize = 0;
 
@@ -127,6 +222,9 @@ export class BlendShapeManager {
     for (let i = 0, n = blendShapes.length; i < n; i++) {}
   }
 
+  /**
+   * @internal
+   */
   _releaseCache(): void {
     const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
     for (let i = 0, n = blendShapeUpdateFlags.length; i < n; i++) {

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -18,6 +18,8 @@ export class BlendShapeManager {
   /** @internal */
   _blendShapes: BlendShape[] = [];
   /** @internal */
+  _blendShapeCount: number = 0;
+  /** @internal */
   _blendShapeUpdateFlags: UpdateFlag[] = [];
 
   /** @internal */
@@ -43,6 +45,7 @@ export class BlendShapeManager {
     this._blendShapes.push(blendShape);
     this._blendShapeUpdateFlags.push(blendShape._registerChangeFlag());
     this._hasBlendShape = true;
+    this._blendShapeCount++;
   }
 
   /**
@@ -58,6 +61,7 @@ export class BlendShapeManager {
     }
     blendShapeUpdateFlags.length = 0;
     this._hasBlendShape = false;
+    this._blendShapeCount = 0;
   }
 
   /**
@@ -250,7 +254,7 @@ export class BlendShapeManager {
   /**
    * @internal
    */
-  _releaseCache(): void {
+  _releaseMemoryCache(): void {
     const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
     for (let i = 0, n = blendShapeUpdateFlags.length; i < n; i++) {
       blendShapeUpdateFlags[i].destroy();

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -74,7 +74,15 @@ export class BlendShapeManager {
    * @internal
    */
   _useTextureStore(): boolean {
-    return this._blendShapeCount > 4 && this._canUseTextureStoreData;
+    if (!this._canUseTextureStoreData) {
+      return false;
+    }
+
+    if (this._useBlendNormal || this._useBlendTangent) {
+      return this._blendShapeCount > 4;
+    } else {
+      return this._blendShapeCount > 8;
+    }
   }
 
   /**

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -105,11 +105,13 @@ export class BlendShapeManager {
    * @internal
    */
   _needUpdateData(): boolean {
-    for (let i = 0, n = this._subDataDirtyFlags.length; i < n; i++) {
-      if (this._subDataDirtyFlags[i].flag) {
+    const subDataDirtyFlags = this._subDataDirtyFlags;
+    for (let i = 0, n = subDataDirtyFlags.length; i < n; i++) {
+      if (subDataDirtyFlags[i].flag) {
         return true;
       }
     }
+    return false;
   }
 
   /**
@@ -239,7 +241,6 @@ export class BlendShapeManager {
       textureWidth = maxTextureSize;
     }
 
-    const shapeCount = this._blendShapes.length;
     let blendShapeDataTexture = this._dataTexture;
     const blendShapeCount = this._blendShapes.length;
 
@@ -255,7 +256,7 @@ export class BlendShapeManager {
     );
     blendShapeDataTexture.filterMode = TextureFilterMode.Point;
 
-    this._dataTextureBuffer = new Float32Array(shapeCount * textureWidth * textureHeight * 4);
+    this._dataTextureBuffer = new Float32Array(blendShapeCount * textureWidth * textureHeight * 4);
     this._dataTexture = blendShapeDataTexture;
     this._dataTextureInfo.setValue(vertexPixelStride, textureWidth, textureHeight);
   }

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -34,6 +34,7 @@ export class BlendShapeManager {
 
   constructor(engine: Engine) {
     this._engine = engine;
+    this._usingTextureStoreData = this._engine._hardwareRenderer.capability.canUseFloatTextureBlendShape;
   }
 
   /**
@@ -174,7 +175,7 @@ export class BlendShapeManager {
    * @internal
    */
   _updateDataToTexture(): void {
-    const maxTextureSize = 2048; // CM: todo
+    const maxTextureSize = this._engine._hardwareRenderer.capability.maxTextureSize;
     const { _vertexCount: vertexCount } = this;
 
     let vertexPixelStride = 1;

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -1,8 +1,9 @@
 import { Vector3 } from "@oasis-engine/math";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { Engine } from "../Engine";
 import { VertexElement, VertexElementFormat } from "../graphic";
+import { ListenerUpdateFlag } from "../ListenerUpdateFlag";
 import { Texture2DArray, TextureFilterMode, TextureFormat } from "../texture";
-import { UpdateFlag } from "../UpdateFlag";
 import { BlendShape } from "./BlendShape";
 
 /**
@@ -10,178 +11,226 @@ import { BlendShape } from "./BlendShape";
  */
 export class BlendShapeManager {
   /** @internal */
-  _hasBlendShape: boolean = false;
+  _useBlendNormal: boolean = false;
   /** @internal */
-  _useBlendShapeNormal: boolean = false;
-  /** @internal */
-  _useBlendShapeTangent: boolean = false;
+  _useBlendTangent: boolean = false;
   /** @internal */
   _blendShapes: BlendShape[] = [];
   /** @internal */
   _blendShapeCount: number = 0;
   /** @internal */
-  _blendShapeUpdateFlags: UpdateFlag[] = [];
+  _layoutDirtyFlag: ListenerUpdateFlag = new ListenerUpdateFlag();
+  /** @internal */
+  _updateAllDataToVertices: boolean = false;
+  /** @internal */
+  _subDataDirtyFlags: BoolUpdateFlag[] = [];
 
   /** @internal */
-  _usingTextureStoreData: boolean = true;
+  _dataTextureBuffer: Float32Array;
   /** @internal */
-  _blendShapeDataTexture: Texture2DArray;
+  _dataTexture: Texture2DArray;
   /** @internal */
-  _blendShapeDataTextureInfo: Vector3 = new Vector3();
+  _dataTextureInfo: Vector3 = new Vector3();
 
   private _engine: Engine;
-  private _vertexCount: number = 0;
+  /* x:vertexElementCount, y:useNormal, z:useTangent */
+  private _lastUpdateVertexElementInfo: Vector3 = new Vector3(0, 0, 0);
+  private _canUseTextureStoreData: boolean = true;
 
   constructor(engine: Engine) {
     this._engine = engine;
-    // CM: try use attribute first
-    this._usingTextureStoreData = this._engine._hardwareRenderer.capability.canUseFloatTextureBlendShape;
+    this._canUseTextureStoreData = this._engine._hardwareRenderer.capability.canUseFloatTextureBlendShape;
+    this._layoutDirtyFlag.listener = this._updateUsePropertyFlag.bind(this);
   }
 
   /**
    * @internal
    */
   _addBlendShape(blendShape: BlendShape): void {
-    this._useBlendShapeNormal = this._useBlendShapeNormal || blendShape._useBlendShapeNormal;
-    this._useBlendShapeTangent = this._useBlendShapeTangent || blendShape._useBlendShapeTangent;
     this._blendShapes.push(blendShape);
-    this._blendShapeUpdateFlags.push(blendShape._registerChangeFlag());
-    this._hasBlendShape = true;
     this._blendShapeCount++;
+
+    blendShape._addLayoutChangeFlag(this._layoutDirtyFlag);
+    this._updateUsePropertyFlag(blendShape);
+
+    this._subDataDirtyFlags.push(blendShape._createSubDataDirtyFlag());
   }
 
   /**
    * @internal
    */
   _clearBlendShapes(): void {
-    this._useBlendShapeNormal = false;
-    this._useBlendShapeTangent = false;
+    this._useBlendNormal = true;
+    this._useBlendTangent = true;
     this._blendShapes.length = 0;
-    const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
-    for (let i = 0, n = blendShapeUpdateFlags.length; i < n; i++) {
-      blendShapeUpdateFlags[i].destroy();
-    }
-    blendShapeUpdateFlags.length = 0;
-    this._hasBlendShape = false;
     this._blendShapeCount = 0;
+
+    this._layoutDirtyFlag.clearFromManagers();
+    const subDataDirtyFlags = this._subDataDirtyFlags;
+    for (let i = 0, n = subDataDirtyFlags.length; i < n; i++) {
+      subDataDirtyFlags[i].destroy();
+    }
+    subDataDirtyFlags.length = 0;
   }
 
   /**
    * @internal
    */
-  _update(): void {
-    this._vertexCount = 0;
-    for (let i = 0, n = this._blendShapes.length; i < n; i++) {
-      const blendShape = this._blendShapes[i];
-      if (i === 0) {
-        this._vertexCount = blendShape.frames[0].deltaPositions.length;
-      } else if (this._vertexCount !== blendShape.frames[0].deltaPositions.length) {
-        throw "Each BlendShape must all have the same vertices count.";
-      }
+  _getUseTextureStore(): boolean {
+    return this._blendShapeCount > 4 && this._canUseTextureStoreData;
+  }
+
+  /**
+   * @internal
+   */
+  _layoutOrCountChange(): boolean {
+    if (this._dataTexture) {
+      return false;
+    }
+
+    const lastInfo = this._lastUpdateVertexElementInfo;
+    if (
+      lastInfo.x !== this._blendShapeCount ||
+      !!lastInfo.y !== this._useBlendNormal ||
+      !!lastInfo.z !== this._useBlendTangent
+    ) {
+      return true;
     }
   }
 
   /**
    * @internal
    */
-  _supplementalVertexElement(vertexElements: VertexElement[], offset: number): number {
-    let supplementalElementCount = 0;
-    for (let i = 0, n = this._blendShapes.length; i < n; i++) {
+  _updateVertexElements(vertexElements: VertexElement[], offset: number): number {
+    let elementCount = 0;
+    for (let i = 0, n = this._blendShapeCount; i < n; i++) {
       vertexElements.push(new VertexElement(`POSITION_BS${i}`, offset, VertexElementFormat.Vector3, 0));
       offset += 12;
-      supplementalElementCount += 3;
-      if (this._useBlendShapeNormal) {
+      elementCount += 3;
+      if (this._useBlendNormal) {
         vertexElements.push(new VertexElement(`NORMAL_BS${i}`, offset, VertexElementFormat.Vector3, 0));
         offset += 12;
-        supplementalElementCount += 3;
+        elementCount += 3;
       }
-      if (this._useBlendShapeTangent) {
+      if (this._useBlendTangent) {
         vertexElements.push(new VertexElement(`TANGENT_BS${i}`, offset, VertexElementFormat.Vector3, 0));
-        supplementalElementCount += 3;
+        elementCount += 3;
       }
     }
-    return supplementalElementCount;
+
+    this._lastUpdateVertexElementInfo.setValue(this._blendShapeCount, +this._useBlendNormal, +this._useBlendTangent);
+    return elementCount;
+  }
+
+  /**
+   * @internal
+   */
+  _needUpdateData(): boolean {
+    for (let i = 0, n = this._subDataDirtyFlags.length; i < n; i++) {
+      if (this._subDataDirtyFlags[i].flag) {
+        return true;
+      }
+    }
   }
 
   /**
    * @internal
    */
   _updateDataToVertices(vertices: Float32Array, offset: number, vertexCount: number, elementCount: number): void {
+    if (this._canUseTextureStoreData) {
+      return;
+    }
     const blendShapes = this._blendShapes;
-    const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
-    const blendShapeCount = Math.min(blendShapes.length, 4);
+    const subDataDirtyFlags = this._subDataDirtyFlags;
+    const updateAllDataToVertices = this._updateAllDataToVertices;
+    for (let i = 0, n = blendShapes.length; i < n; i++) {
+      const dataChangedFlag = subDataDirtyFlags[i];
+      if (updateAllDataToVertices || dataChangedFlag.flag) {
+        const { frames } = blendShapes[i];
+        const frameCount = frames.length;
+        const endFrame = frames[frameCount - 1];
+        if (frameCount > 0 && endFrame.deltaPositions.length !== vertexCount) {
+          throw "BlendShape frame deltaPositions length must same with mesh vertexCount.";
+        }
 
-    if (!this._usingTextureStoreData) {
-      for (let i = 0; i < blendShapeCount; i++) {
-        const blendShapeUpdateFlag = blendShapeUpdateFlags[i];
-        if (blendShapeUpdateFlag.flag) {
-          const blendShape = blendShapes[i];
-          const { frames } = blendShape;
-          const frameCount = frames.length;
-          const endFrame = frames[frameCount - 1];
-          if (frameCount > 0 && endFrame.deltaPositions.length !== vertexCount) {
-            throw "BlendShape frame deltaPositions length must same with mesh vertexCount.";
+        const { deltaPositions } = endFrame;
+        for (let j = 0; j < vertexCount; j++) {
+          const start = elementCount * j + offset;
+          const deltaPosition = deltaPositions[j];
+          if (deltaPosition) {
+            vertices[start] = deltaPosition.x;
+            vertices[start + 1] = deltaPosition.y;
+            vertices[start + 2] = deltaPosition.z;
           }
+        }
+        offset += 3;
 
-          const { deltaPositions } = endFrame;
-          for (let j = 0; j < vertexCount; j++) {
-            const start = elementCount * j + offset;
-            const deltaPosition = deltaPositions[j];
-            if (deltaPosition) {
-              vertices[start] = deltaPosition.x;
-              vertices[start + 1] = deltaPosition.y;
-              vertices[start + 2] = deltaPosition.z;
+        if (this._useBlendNormal) {
+          const { deltaNormals } = endFrame;
+          if (deltaNormals) {
+            for (let j = 0; j < vertexCount; j++) {
+              const start = elementCount * j + offset;
+              const deltaNormal = deltaNormals[j];
+              if (deltaNormal) {
+                vertices[start] = deltaNormal.x;
+                vertices[start + 1] = deltaNormal.y;
+                vertices[start + 2] = deltaNormal.z;
+              }
             }
           }
           offset += 3;
-
-          if (this._useBlendShapeNormal) {
-            const { deltaNormals } = endFrame;
-            if (deltaNormals) {
-              for (let j = 0; j < vertexCount; j++) {
-                const start = elementCount * j + offset;
-                const deltaNormal = deltaNormals[j];
-                if (deltaNormal) {
-                  vertices[start] = deltaNormal.x;
-                  vertices[start + 1] = deltaNormal.y;
-                  vertices[start + 2] = deltaNormal.z;
-                }
-              }
-            }
-            offset += 3;
-          }
-
-          if (this._useBlendShapeTangent) {
-            const { deltaTangents } = endFrame;
-            if (deltaTangents) {
-              for (let j = 0; j < vertexCount; j++) {
-                const start = elementCount * j + offset;
-                const deltaTangent = deltaTangents[j];
-                if (deltaTangent) {
-                  vertices[start] = deltaTangent.x;
-                  vertices[start + 1] = deltaTangent.y;
-                  vertices[start + 2] = deltaTangent.z;
-                }
-              }
-            }
-            offset += 3;
-          }
-          blendShapeUpdateFlag.flag = false;
         }
+
+        if (this._useBlendTangent) {
+          const { deltaTangents } = endFrame;
+          if (deltaTangents) {
+            for (let j = 0; j < vertexCount; j++) {
+              const start = elementCount * j + offset;
+              const deltaTangent = deltaTangents[j];
+              if (deltaTangent) {
+                vertices[start] = deltaTangent.x;
+                vertices[start + 1] = deltaTangent.y;
+                vertices[start + 2] = deltaTangent.z;
+              }
+            }
+          }
+          offset += 3;
+        }
+        dataChangedFlag.flag = false;
       }
+    }
+    this._updateAllDataToVertices = false;
+  }
+
+  _needCreateDataTexture(): boolean {
+    if (!this._dataTexture) {
+      return false;
     }
   }
 
   /**
    * @internal
    */
-  _updateDataToTexture(): void {
+  _updateTexture(
+    layoutOrCountChange: boolean,
+    vertexCountChange: boolean,
+    needUpdateBlendShape: boolean,
+    vertexCount: number
+  ): void {
+    if (!this._dataTexture || layoutOrCountChange || vertexCountChange) {
+      this._createDataTexture(vertexCount);
+    }
+    if (needUpdateBlendShape) {
+      this._updateDataToTexture(vertexCount);
+    }
+  }
+
+  private _createDataTexture(vertexCount: number): void {
     const maxTextureSize = this._engine._hardwareRenderer.capability.maxTextureSize;
-    const { _vertexCount: vertexCount } = this;
 
     let vertexPixelStride = 1;
-    this._useBlendShapeNormal && vertexPixelStride++;
-    this._useBlendShapeTangent && vertexPixelStride++;
+    this._useBlendNormal && vertexPixelStride++;
+    this._useBlendTangent && vertexPixelStride++;
 
     let textureWidth = vertexPixelStride * vertexCount;
     let textureHeight = 1;
@@ -190,78 +239,95 @@ export class BlendShapeManager {
       textureWidth = maxTextureSize;
     }
 
-    const blendShapes = this._blendShapes;
-    let shapeCount = blendShapes.length;
-    let blendShapeDataTexture = this._blendShapeDataTexture;
+    const shapeCount = this._blendShapes.length;
+    let blendShapeDataTexture = this._dataTexture;
     const blendShapeCount = this._blendShapes.length;
-    if (
-      !blendShapeDataTexture ||
-      blendShapeDataTexture.width !== textureWidth ||
-      blendShapeDataTexture.height !== textureHeight ||
-      blendShapeDataTexture.length !== shapeCount
-    ) {
-      blendShapeDataTexture && blendShapeDataTexture.destroy();
 
-      let bufferData = new Float32Array(shapeCount * textureWidth * textureHeight * 4);
+    blendShapeDataTexture && blendShapeDataTexture.destroy();
 
-      let offset = 0;
-      for (let i = 0; i < shapeCount; i++) {
-        const blendShapeFrame = blendShapes[i].frames[0];
+    blendShapeDataTexture = new Texture2DArray(
+      this._engine,
+      textureWidth,
+      textureHeight,
+      blendShapeCount,
+      TextureFormat.R32G32B32A32,
+      false
+    );
+    blendShapeDataTexture.filterMode = TextureFilterMode.Point;
 
-        const positions = blendShapeFrame.deltaPositions;
-        const normals = blendShapeFrame.deltaNormals;
-        const tangents = blendShapeFrame.deltaTangents;
+    this._dataTextureBuffer = new Float32Array(shapeCount * textureWidth * textureHeight * 4);
+    this._dataTexture = blendShapeDataTexture;
+    this._dataTextureInfo.setValue(vertexPixelStride, textureWidth, textureHeight);
+  }
 
-        offset = i * textureWidth * textureHeight * 4;
+  private _updateDataToTexture(vertexCount: number): void {
+    const {
+      _blendShapes: blendShapes,
+      _dataTexture: dataTexture,
+      _dataTextureBuffer: buffer,
+      _subDataDirtyFlags: subDataDirtyFlags
+    } = this;
+
+    const updateAllDataToVertices = this._updateAllDataToVertices;
+    let offset = 0;
+    for (let i = 0, n = blendShapes.length; i < n; i++) {
+      const subDirtyFlag = subDataDirtyFlags[i];
+      if (updateAllDataToVertices || subDirtyFlag.flag) {
+        const { frames } = blendShapes[i];
+        const frameCount = frames.length;
+        const endFrame = frames[frameCount - 1];
+        if (frameCount > 0 && endFrame.deltaPositions.length !== vertexCount) {
+          throw "BlendShape frame deltaPositions length must same with mesh vertexCount.";
+        }
+        const { deltaPositions, deltaNormals, deltaTangents } = endFrame;
+        offset = i * dataTexture.width * dataTexture.height * 4;
         for (let j = 0; j < vertexCount; j++) {
-          const position = positions[j];
-          bufferData[offset] = position.x;
-          bufferData[offset + 1] = position.y;
-          bufferData[offset + 2] = position.z;
+          const position = deltaPositions[j];
+          buffer[offset] = position.x;
+          buffer[offset + 1] = position.y;
+          buffer[offset + 2] = position.z;
           offset += 4;
 
-          if (normals) {
-            const normal = normals[j];
-            bufferData[offset] = normal.x;
-            bufferData[offset + 1] = normal.y;
-            bufferData[offset + 2] = normal.z;
+          if (deltaNormals) {
+            const normal = deltaNormals[j];
+            buffer[offset] = normal.x;
+            buffer[offset + 1] = normal.y;
+            buffer[offset + 2] = normal.z;
             offset += 4;
           }
 
-          if (tangents) {
-            const tangent = tangents[j];
-            bufferData[offset] = tangent.x;
-            bufferData[offset + 1] = tangent.y;
-            bufferData[offset + 2] = tangent.z;
+          if (deltaTangents) {
+            const tangent = deltaTangents[j];
+            buffer[offset] = tangent.x;
+            buffer[offset + 1] = tangent.y;
+            buffer[offset + 2] = tangent.z;
             offset += 4;
           }
         }
+        subDirtyFlag.flag = false;
       }
-
-      blendShapeDataTexture = new Texture2DArray(
-        this._engine,
-        textureWidth,
-        textureHeight,
-        blendShapeCount,
-        TextureFormat.R32G32B32A32,
-        false
-      );
-      blendShapeDataTexture.filterMode = TextureFilterMode.Point;
-      blendShapeDataTexture.setPixelBuffer(0, bufferData);
-      this._blendShapeDataTexture = blendShapeDataTexture;
-      this._blendShapeDataTextureInfo.setValue(vertexPixelStride, textureWidth, textureHeight);
     }
+    dataTexture.setPixelBuffer(0, buffer);
+    this._updateAllDataToVertices = false;
   }
 
   /**
    * @internal
    */
   _releaseMemoryCache(): void {
-    const blendShapeUpdateFlags = this._blendShapeUpdateFlags;
-    for (let i = 0, n = blendShapeUpdateFlags.length; i < n; i++) {
-      blendShapeUpdateFlags[i].destroy();
+    this._layoutDirtyFlag.destroy();
+    const dataChangedFlags = this._subDataDirtyFlags;
+    for (let i = 0, n = dataChangedFlags.length; i < n; i++) {
+      dataChangedFlags[i].destroy();
     }
+
+    this._layoutDirtyFlag = null;
+    this._subDataDirtyFlags = null;
     this._blendShapes = null;
-    this._blendShapeUpdateFlags = null;
+  }
+
+  private _updateUsePropertyFlag(blendShape: BlendShape): void {
+    this._useBlendNormal &&= blendShape._useBlendShapeNormal;
+    this._useBlendTangent &&= blendShape._useBlendShapeTangent;
   }
 }

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -82,10 +82,6 @@ export class BlendShapeManager {
    * @internal
    */
   _layoutOrCountChange(): boolean {
-    if (this._dataTexture) {
-      return false;
-    }
-
     const lastInfo = this._lastUpdateVertexElementInfo;
     if (
       lastInfo.x !== this._blendShapeCount ||
@@ -141,9 +137,6 @@ export class BlendShapeManager {
     elementCount: number,
     force: boolean
   ): void {
-    if (this._canUseTextureStoreData) {
-      return;
-    }
     const blendShapes = this._blendShapes;
     const subDataDirtyFlags = this._subDataDirtyFlags;
     for (let i = 0, n = blendShapes.length; i < n; i++) {

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -173,15 +173,15 @@ export class BlendShapeManager {
     const maxTextureSize = 2048; // CM: todo
     const { _vertexCount: vertexCount } = this;
 
-    let pixelStride = 1;
-    this._useBlendShapeNormal && pixelStride++;
-    this._useBlendShapeTangent && pixelStride++;
+    let vertexPixelStride = 1;
+    this._useBlendShapeNormal && vertexPixelStride++;
+    this._useBlendShapeTangent && vertexPixelStride++;
 
-    let textureWidth = pixelStride * vertexCount;
+    let textureWidth = vertexPixelStride * vertexCount;
     let textureHeight = 1;
     if (textureWidth > maxTextureSize) {
-      textureWidth = maxTextureSize;
       textureHeight = Math.ceil(textureWidth / maxTextureSize);
+      textureWidth = maxTextureSize;
     }
 
     const blendShapes = this._blendShapes;
@@ -243,7 +243,7 @@ export class BlendShapeManager {
       blendShapeDataTexture.filterMode = TextureFilterMode.Point;
       blendShapeDataTexture.setPixelBuffer(0, bufferData);
       this._blendShapeDataTexture = blendShapeDataTexture;
-      this._blendShapeDataTextureInfo.setValue(pixelStride, textureWidth, textureHeight);
+      this._blendShapeDataTextureInfo.setValue(vertexPixelStride, textureWidth, textureHeight);
     }
   }
 

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -1,3 +1,4 @@
+import { Vector3 } from "@oasis-engine/math";
 import { Engine } from "../Engine";
 import { VertexElement, VertexElementFormat } from "../graphic";
 import { Texture2DArray, TextureFilterMode, TextureFormat } from "../texture";
@@ -23,6 +24,8 @@ export class BlendShapeManager {
   _usingTextureStoreData: boolean = false;
   /** @internal */
   _blendShapeDataTexture: Texture2DArray;
+  /** @internal */
+  _blendShapeDataTextureInfo: Vector3 = new Vector3();
 
   private _engine: Engine;
 
@@ -216,6 +219,7 @@ export class BlendShapeManager {
       blendShapeDataTexture.filterMode = TextureFilterMode.Point;
       blendShapeDataTexture.setPixelBuffer(0, bufferData);
       this._blendShapeDataTexture = blendShapeDataTexture;
+      this._blendShapeDataTextureInfo.setValue(pixelStride, textureWidth, textureHeight);
     }
 
     const blendShapes = this._blendShapes;

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -17,7 +17,7 @@ export class BlendShapeManager {
   /** @internal */
   _blendShapes: BlendShape[] = [];
   /** @internal */
-  _blendShapeNamesMap: Record<string, number>;
+  _blendShapeNames: string[];
   /** @internal */
   _blendShapeCount: number = 0;
   /** @internal */
@@ -314,12 +314,12 @@ export class BlendShapeManager {
    * @internal
    */
   _releaseMemoryCache(): void {
-    const blendShapeNamesMap: Record<string, number> = {};
     const { _blendShapes: blendShapes } = this;
+    const blendShapeNamesMap = new Array<string>(blendShapes.length);
     for (let i = 0, n = blendShapes.length; i < n; i++) {
-      blendShapeNamesMap[blendShapes[i].name] = i;
+      blendShapeNamesMap[i] = blendShapes[i].name;
     }
-    this._blendShapeNamesMap = blendShapeNamesMap;
+    this._blendShapeNames = blendShapeNamesMap;
 
     this._layoutDirtyFlag.destroy();
     const dataChangedFlags = this._subDataDirtyFlags;

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -1,5 +1,6 @@
 import { BoundingBox } from "@oasis-engine/math";
 import { Logger } from "../base/Logger";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 import { Camera } from "../Camera";
 import { ignoreClone } from "../clone/CloneManager";
 import { ICustomClone } from "../clone/ComponentCloner";
@@ -22,7 +23,7 @@ export class MeshRenderer extends Renderer implements ICustomClone {
   @ignoreClone
   private _mesh: Mesh;
   @ignoreClone
-  private _meshUpdateFlag: UpdateFlag;
+  private _meshUpdateFlag: BoolUpdateFlag;
 
   /**
    * @internal

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -435,7 +435,8 @@ export class ModelMesh extends Mesh {
     const blendShapeManager = this._blendShapeManager;
     const blendShapeLayoutOrCountChange = blendShapeManager._layoutOrCountChange();
     const blendShapeDataUpdate = blendShapeManager._needUpdateData();
-    const vertexElementUpdate = this._vertexSlotChanged || blendShapeLayoutOrCountChange;
+    const vertexElementUpdate =
+      this._vertexSlotChanged || (!blendShapeManager._getUseTextureStore() && blendShapeLayoutOrCountChange);
 
     // Vertex element change
     if (vertexElementUpdate) {
@@ -802,7 +803,9 @@ export class ModelMesh extends Mesh {
     }
     this._vertexChangeFlag = 0;
 
-    this._blendShapeManager._updateDataToVertices(vertices, offset, _vertexCount, _elementCount, force);
+    if (!this._blendShapeManager._getUseTextureStore()) {
+      this._blendShapeManager._updateDataToVertices(vertices, offset, _vertexCount, _elementCount, force);
+    }
   }
 
   private _releaseCache(): void {

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -433,7 +433,7 @@ export class ModelMesh extends Mesh {
     }
 
     const blendShapeManager = this._blendShapeManager;
-    const blendShapeTextureStore = blendShapeManager._getUseTextureStore();
+    const blendShapeTextureStore = blendShapeManager._useTextureStore();
     const blendShapeLayoutOrCountChange = blendShapeManager._layoutOrCountChange();
     const blendShapeDataUpdate = blendShapeManager._needUpdateData();
     const vertexElementUpdate = this._vertexSlotChanged || (!blendShapeTextureStore && blendShapeLayoutOrCountChange);
@@ -592,7 +592,7 @@ export class ModelMesh extends Mesh {
     this._vertexSlotChanged = false;
 
     const blendShapeManager = this._blendShapeManager;
-    if (!blendShapeManager._getUseTextureStore()) {
+    if (!blendShapeManager._useTextureStore()) {
       elementCount += blendShapeManager._updateVertexElements(vertexElements, offset);
     }
 
@@ -801,7 +801,7 @@ export class ModelMesh extends Mesh {
     }
     this._vertexChangeFlag = 0;
 
-    if (!this._blendShapeManager._getUseTextureStore()) {
+    if (!this._blendShapeManager._useTextureStore()) {
       this._blendShapeManager._updateDataToVertices(vertices, offset, _vertexCount, _elementCount, force);
     }
   }

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -435,14 +435,14 @@ export class ModelMesh extends Mesh {
     const blendShapeManager = this._blendShapeManager;
     const blendShapeLayoutOrCountChange = blendShapeManager._layoutOrCountChange();
     const blendShapeDataUpdate = blendShapeManager._needUpdateData();
+    const vertexElementUpdate = this._vertexSlotChanged || blendShapeLayoutOrCountChange;
 
     // Vertex element change
-    if (this._vertexSlotChanged || blendShapeLayoutOrCountChange) {
+    if (vertexElementUpdate) {
       const vertexElements = this._vertexElementsCache;
       this._updateVertexElements(vertexElements);
       this._setVertexElements(vertexElements);
       this._vertexChangeFlag = ValueChanged.All;
-      blendShapeManager._updateAllDataToVertices = true;
     }
 
     const { _vertexCount: vertexCount } = this;
@@ -459,8 +459,7 @@ export class ModelMesh extends Mesh {
       this._verticesUint8 = new Uint8Array(vertices.buffer);
 
       this._vertexChangeFlag = ValueChanged.All;
-      blendShapeManager._updateAllDataToVertices = true;
-      this._updateVertices(vertices);
+      this._updateVertices(vertices, true);
 
       const newVertexBuffer = new Buffer(
         this._engine,
@@ -473,7 +472,7 @@ export class ModelMesh extends Mesh {
       this._lastUploadVertexCount = vertexCount;
     } else if (this._vertexChangeFlag & ValueChanged.All || blendShapeDataUpdate) {
       const vertices = this._verticesFloat32;
-      this._updateVertices(vertices);
+      this._updateVertices(vertices, vertexElementUpdate);
       vertexBuffer.setData(vertices);
     }
 
@@ -602,7 +601,7 @@ export class ModelMesh extends Mesh {
     this._elementCount = elementCount;
   }
 
-  private _updateVertices(vertices: Float32Array): void {
+  private _updateVertices(vertices: Float32Array, force: boolean): void {
     // prettier-ignore
     const { _elementCount,_vertexCount, _positions, _normals, _colors, _vertexChangeFlag, _boneWeights, _boneIndices, _tangents, _uv, _uv1, _uv2, _uv3, _uv4, _uv5, _uv6, _uv7 } = this;
 
@@ -803,7 +802,7 @@ export class ModelMesh extends Mesh {
     }
     this._vertexChangeFlag = 0;
 
-    this._blendShapeManager._updateDataToVertices(vertices, offset, _vertexCount, _elementCount);
+    this._blendShapeManager._updateDataToVertices(vertices, offset, _vertexCount, _elementCount, force);
   }
 
   private _releaseCache(): void {

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -429,11 +429,15 @@ export class ModelMesh extends Mesh {
    * @returns The index of BlendShape
    */
   getBlendShapeIndex(name: string): number {
-    const blendShapes = this._blendShapeManager._blendShapes;
-    for (let i = 0, n = blendShapes.length; i < n; i++) {
-      if (blendShapes[i].name === name) {
-        return i;
+    if (this._accessible) {
+      const blendShapes = this._blendShapeManager._blendShapes;
+      for (let i = 0, n = blendShapes.length; i < n; i++) {
+        if (blendShapes[i].name === name) {
+          return i;
+        }
       }
+    } else {
+      return this._blendShapeManager._blendShapeNamesMap[name];
     }
   }
 

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -432,16 +432,16 @@ export class ModelMesh extends Mesh {
       throw "Not allowed to access data while accessible is false.";
     }
 
-    const blendShapeManager = this._blendShapeManager;
-    const blendShapeTextureStore = blendShapeManager._useTextureStore();
-    const blendShapeLayoutOrCountChange = blendShapeManager._layoutOrCountChange();
-    const blendShapeDataUpdate = blendShapeManager._needUpdateData();
-    const vertexElementUpdate = this._vertexSlotChanged || (!blendShapeTextureStore && blendShapeLayoutOrCountChange);
+    const blendManager = this._blendShapeManager;
+    const blendTextureStore = blendManager._useTextureStore();
+    const blendLayoutOrCountChange = blendManager._layoutOrCountChange();
+    const blendDataUpdate = blendManager._needUpdateData();
+    const vertexElementUpdate = this._vertexSlotChanged || (!blendTextureStore && blendLayoutOrCountChange);
 
     // Vertex element change
     if (vertexElementUpdate) {
       const vertexElements = this._vertexElementsCache;
-      this._updateVertexElements(vertexElements, blendShapeTextureStore);
+      this._updateVertexElements(vertexElements, blendTextureStore);
       this._setVertexElements(vertexElements);
     }
 
@@ -457,7 +457,7 @@ export class ModelMesh extends Mesh {
       const vertices = new Float32Array(vertexFloatCount);
       this._verticesFloat32 = vertices;
       this._verticesUint8 = new Uint8Array(vertices.buffer);
-      this._updateVertices(vertices, blendShapeTextureStore, true);
+      this._updateVertices(vertices, blendTextureStore, true);
 
       const newVertexBuffer = new Buffer(
         this._engine,
@@ -471,10 +471,10 @@ export class ModelMesh extends Mesh {
     } else if (
       vertexElementUpdate ||
       this._vertexChangeFlag & ValueChanged.All ||
-      (!blendShapeTextureStore && blendShapeDataUpdate)
+      (!blendTextureStore && blendDataUpdate)
     ) {
       const vertices = this._verticesFloat32;
-      this._updateVertices(vertices, blendShapeTextureStore, vertexElementUpdate);
+      this._updateVertices(vertices, blendTextureStore, vertexElementUpdate);
       vertexBuffer.setData(vertices);
     }
 
@@ -498,13 +498,8 @@ export class ModelMesh extends Mesh {
       this._setIndexBufferBinding(null);
     }
 
-    if (blendShapeTextureStore) {
-      blendShapeManager._updateTexture(
-        blendShapeLayoutOrCountChange,
-        vertexCountChange,
-        blendShapeDataUpdate,
-        vertexCount
-      );
+    if (blendTextureStore) {
+      blendManager._updateTexture(blendLayoutOrCountChange, vertexCountChange, blendDataUpdate, vertexCount);
     }
 
     if (noLongerAccessible) {

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -483,8 +483,13 @@ export class ModelMesh extends Mesh {
       this._setIndexBufferBinding(null);
     }
 
-    if (this._blendShapeManager._usingTextureStoreData) {
-      this._blendShapeManager._updateDataToTexture();
+    if (this._blendShapeManager._blendShapes.length > 0) {
+      //CM: need optimize
+      this._blendShapeManager._update();
+
+      if (this._blendShapeManager._usingTextureStoreData) {
+        this._blendShapeManager._updateDataToTexture();
+      }
     }
 
     if (noLongerAccessible) {

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -424,6 +424,20 @@ export class ModelMesh extends Mesh {
   }
 
   /**
+   * Get index of BlendShape by given name.
+   * @param name - The name of BlendShape
+   * @returns The index of BlendShape
+   */
+  getBlendShapeIndex(name: string): number {
+    const blendShapes = this._blendShapeManager._blendShapes;
+    for (let i = 0, n = blendShapes.length; i < n; i++) {
+      if (blendShapes[i].name === name) {
+        return i;
+      }
+    }
+  }
+
+  /**
    * Upload Mesh Data to the graphics API.
    * @param noLongerAccessible - Whether to access data later. If true, you'll never access data anymore (free memory cache)
    */
@@ -602,7 +616,7 @@ export class ModelMesh extends Mesh {
     const { _elementCount,_vertexCount, _positions, _normals, _colors, _vertexChangeFlag, _boneWeights, _boneIndices, _tangents, _uv, _uv1, _uv2, _uv3, _uv4, _uv5, _uv6, _uv7 } = this;
 
     force && (this._vertexChangeFlag = ValueChanged.All);
-    
+
     if (_vertexChangeFlag & ValueChanged.Position) {
       for (let i = 0; i < _vertexCount; i++) {
         const start = _elementCount * i;

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -433,17 +433,16 @@ export class ModelMesh extends Mesh {
     }
 
     const blendShapeManager = this._blendShapeManager;
+    const blendShapeTextureStore = blendShapeManager._getUseTextureStore();
     const blendShapeLayoutOrCountChange = blendShapeManager._layoutOrCountChange();
     const blendShapeDataUpdate = blendShapeManager._needUpdateData();
-    const vertexElementUpdate =
-      this._vertexSlotChanged || (!blendShapeManager._getUseTextureStore() && blendShapeLayoutOrCountChange);
+    const vertexElementUpdate = this._vertexSlotChanged || (!blendShapeTextureStore && blendShapeLayoutOrCountChange);
 
     // Vertex element change
     if (vertexElementUpdate) {
       const vertexElements = this._vertexElementsCache;
       this._updateVertexElements(vertexElements);
       this._setVertexElements(vertexElements);
-      this._vertexChangeFlag = ValueChanged.All;
     }
 
     const { _vertexCount: vertexCount } = this;
@@ -458,8 +457,6 @@ export class ModelMesh extends Mesh {
       const vertices = new Float32Array(vertexFloatCount);
       this._verticesFloat32 = vertices;
       this._verticesUint8 = new Uint8Array(vertices.buffer);
-
-      this._vertexChangeFlag = ValueChanged.All;
       this._updateVertices(vertices, true);
 
       const newVertexBuffer = new Buffer(
@@ -497,7 +494,7 @@ export class ModelMesh extends Mesh {
       this._setIndexBufferBinding(null);
     }
 
-    if (blendShapeManager._getUseTextureStore()) {
+    if (blendShapeTextureStore) {
       blendShapeManager._updateTexture(
         blendShapeLayoutOrCountChange,
         vertexCountChange,
@@ -606,6 +603,7 @@ export class ModelMesh extends Mesh {
     // prettier-ignore
     const { _elementCount,_vertexCount, _positions, _normals, _colors, _vertexChangeFlag, _boneWeights, _boneIndices, _tangents, _uv, _uv1, _uv2, _uv3, _uv4, _uv5, _uv6, _uv7 } = this;
 
+    force && (this._vertexChangeFlag = ValueChanged.All);
     if (_vertexChangeFlag & ValueChanged.Position) {
       for (let i = 0; i < _vertexCount; i++) {
         const start = _elementCount * i;

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -61,13 +61,20 @@ export class ModelMesh extends Mesh {
   }
 
   /**
-   * BlendShape count of this ModelMesh.
+   * BlendShapes of this ModelMesh.
    */
   get blendShapes(): Readonly<BlendShape[]> {
     if (!this._accessible) {
       throw "Not allowed to access data while accessible is false.";
     }
     return this._blendShapeManager._blendShapes;
+  }
+
+  /**
+   * BlendShape count of this ModelMesh.
+   */
+  get blendShapeCount(): number {
+    return this._blendShapeManager._blendShapeCount;
   }
 
   /**
@@ -812,7 +819,7 @@ export class ModelMesh extends Mesh {
     this._uv5 = null;
     this._uv6 = null;
     this._uv7 = null;
-    this._blendShapeManager._releaseCache();
+    this._blendShapeManager._releaseMemoryCache();
   }
 }
 

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -602,6 +602,7 @@ export class ModelMesh extends Mesh {
     const { _elementCount,_vertexCount, _positions, _normals, _colors, _vertexChangeFlag, _boneWeights, _boneIndices, _tangents, _uv, _uv1, _uv2, _uv3, _uv4, _uv5, _uv6, _uv7 } = this;
 
     force && (this._vertexChangeFlag = ValueChanged.All);
+    
     if (_vertexChangeFlag & ValueChanged.Position) {
       for (let i = 0; i < _vertexCount; i++) {
         const start = _elementCount * i;

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -468,7 +468,7 @@ export class ModelMesh extends Mesh {
 
       this._setVertexBufferBinding(0, new VertexBufferBinding(newVertexBuffer, elementCount * 4));
       this._lastUploadVertexCount = vertexCount;
-    } else if (this._vertexChangeFlag & ValueChanged.All || blendShapeDataUpdate) {
+    } else if (this._vertexChangeFlag & ValueChanged.All || (!blendShapeTextureStore && blendShapeDataUpdate)) {
       const vertices = this._verticesFloat32;
       this._updateVertices(vertices, vertexElementUpdate);
       vertexBuffer.setData(vertices);

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -424,20 +424,16 @@ export class ModelMesh extends Mesh {
   }
 
   /**
-   * Get index of BlendShape by given name.
-   * @param name - The name of BlendShape
-   * @returns The index of BlendShape
+   * Get name of BlendShape by given index.
+   * @param index - The index of BlendShape
+   * @returns The name of BlendShape
    */
-  getBlendShapeIndex(name: string): number {
+  getBlendShapeName(index: number): string {
     if (this._accessible) {
       const blendShapes = this._blendShapeManager._blendShapes;
-      for (let i = 0, n = blendShapes.length; i < n; i++) {
-        if (blendShapes[i].name === name) {
-          return i;
-        }
-      }
+      return blendShapes[index].name;
     } else {
-      return this._blendShapeManager._blendShapeNamesMap[name];
+      return this._blendShapeManager._blendShapeNames[index];
     }
   }
 

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -16,6 +16,7 @@ import { Skin } from "./Skin";
  */
 export class SkinnedMeshRenderer extends MeshRenderer {
   private static _blendShapeMacro = Shader.getMacroByName("OASIS_BLENDSHAPE");
+  private static _blendShapeTextureMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_TEXTURE");
   private static _blendShapeNormalMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_NORMAL");
   private static _blendShapeTangentMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_TANGENT");
 
@@ -81,6 +82,12 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     const blendShapeManager = (<ModelMesh>this.mesh)._blendShapeManager;
     if (blendShapeManager._hasBlendShape) {
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
+      if (blendShapeManager._usingTextureStoreData) {
+        shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
+      } else {
+        shaderData.disableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
+      }
+
       shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
       if (blendShapeManager._usingTextureStoreData) {
         shaderData.setTexture(SkinnedMeshRenderer._blendShapeTextureProperty, blendShapeManager._blendShapeDataTexture);

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -76,17 +76,17 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       shaderData.setFloatArray(SkinnedMeshRenderer._jointMatrixProperty, this.matrixPalette);
     }
 
-    const mesh = <ModelMesh>this.mesh;
-    if (mesh._hasBlendShape) {
+    const blendShapeManager = (<ModelMesh>this.mesh)._blendShapeManager;
+    if (blendShapeManager._hasBlendShape) {
       shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
 
-      if (mesh._useBlendShapeNormal) {
+      if (blendShapeManager._useBlendShapeNormal) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeNormalMacro);
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeNormalMacro);
       }
-      if (mesh._useBlendShapeTangent) {
+      if (blendShapeManager._useBlendShapeTangent) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTangentMacro);
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeTangentMacro);

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -23,6 +23,8 @@ export class SkinnedMeshRenderer extends MeshRenderer {
   private static _jointSamplerProperty = Shader.getPropertyByName("u_jointSampler");
   private static _jointMatrixProperty = Shader.getPropertyByName("u_jointMatrix");
   private static _blendShapeWeightsProperty = Shader.getPropertyByName("u_blendShapeWeights");
+  private static _blendShapeTextureProperty = Shader.getPropertyByName("u_blendShapeTexture");
+  private static _blendShapeTextureInfoProperty = Shader.getPropertyByName("u_blendShapeTextureInfo");
 
   private static _maxJoints: number = 0;
 
@@ -78,8 +80,8 @@ export class SkinnedMeshRenderer extends MeshRenderer {
 
     const blendShapeManager = (<ModelMesh>this.mesh)._blendShapeManager;
     if (blendShapeManager._hasBlendShape) {
-      shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
+      shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
 
       if (blendShapeManager._useBlendShapeNormal) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeNormalMacro);

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -82,6 +82,13 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     if (blendShapeManager._hasBlendShape) {
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
       shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
+      if (blendShapeManager._usingTextureStoreData) {
+        shaderData.setTexture(SkinnedMeshRenderer._blendShapeTextureProperty, blendShapeManager._blendShapeDataTexture);
+        shaderData.setVector3(
+          SkinnedMeshRenderer._blendShapeTextureInfoProperty,
+          blendShapeManager._blendShapeDataTextureInfo
+        );
+      }
 
       if (blendShapeManager._useBlendShapeNormal) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeNormalMacro);

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -82,15 +82,13 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     const blendShapeManager = (<ModelMesh>this.mesh)._blendShapeManager;
     if (blendShapeManager._blendShapeCount > 0) {
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
+      shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeManager._blendShapeCount.toString());
       if (blendShapeManager._useTextureStore()) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
-        shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeManager._blendShapeCount.toString());
-
         shaderData.setTexture(SkinnedMeshRenderer._blendShapeTextureProperty, blendShapeManager._dataTexture);
         shaderData.setVector3(SkinnedMeshRenderer._blendShapeTextureInfoProperty, blendShapeManager._dataTextureInfo);
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
-        shaderData.disableMacro("OASIS_BLENDSHAPE_COUNT");
       }
 
       shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
@@ -107,6 +105,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       }
     } else {
       shaderData.disableMacro(SkinnedMeshRenderer._blendShapeMacro);
+      shaderData.disableMacro("OASIS_BLENDSHAPE_COUNT");
     }
   }
 

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -80,31 +80,27 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     }
 
     const blendShapeManager = (<ModelMesh>this.mesh)._blendShapeManager;
-    if (blendShapeManager._hasBlendShape) {
+    if (blendShapeManager._blendShapeCount > 0) {
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
-      if (blendShapeManager._usingTextureStoreData) {
+      if (blendShapeManager._getUseTextureStore()) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
         shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeManager._blendShapeCount.toString());
+
+        shaderData.setTexture(SkinnedMeshRenderer._blendShapeTextureProperty, blendShapeManager._dataTexture);
+        shaderData.setVector3(SkinnedMeshRenderer._blendShapeTextureInfoProperty, blendShapeManager._dataTextureInfo);
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
         shaderData.disableMacro("OASIS_BLENDSHAPE_COUNT");
       }
 
       shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);
-      if (blendShapeManager._usingTextureStoreData) {
-        shaderData.setTexture(SkinnedMeshRenderer._blendShapeTextureProperty, blendShapeManager._blendShapeDataTexture);
-        shaderData.setVector3(
-          SkinnedMeshRenderer._blendShapeTextureInfoProperty,
-          blendShapeManager._blendShapeDataTextureInfo
-        );
-      }
 
-      if (blendShapeManager._useBlendShapeNormal) {
+      if (blendShapeManager._useBlendNormal) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeNormalMacro);
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeNormalMacro);
       }
-      if (blendShapeManager._useBlendShapeTangent) {
+      if (blendShapeManager._useBlendTangent) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTangentMacro);
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeTangentMacro);

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -19,7 +19,6 @@ export class SkinnedMeshRenderer extends MeshRenderer {
   private static _blendShapeTextureMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_TEXTURE");
   private static _blendShapeNormalMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_NORMAL");
   private static _blendShapeTangentMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_TANGENT");
-  private static _blendShapeCountMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_COUNT");
 
   private static _jointCountProperty = Shader.getPropertyByName("u_jointCount");
   private static _jointSamplerProperty = Shader.getPropertyByName("u_jointSampler");

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -82,7 +82,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
     const blendShapeManager = (<ModelMesh>this.mesh)._blendShapeManager;
     if (blendShapeManager._blendShapeCount > 0) {
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
-      if (blendShapeManager._getUseTextureStore()) {
+      if (blendShapeManager._useTextureStore()) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
         shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeManager._blendShapeCount.toString());
 

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -19,6 +19,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
   private static _blendShapeTextureMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_TEXTURE");
   private static _blendShapeNormalMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_NORMAL");
   private static _blendShapeTangentMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_TANGENT");
+  private static _blendShapeCountMacro = Shader.getMacroByName("OASIS_BLENDSHAPE_COUNT");
 
   private static _jointCountProperty = Shader.getPropertyByName("u_jointCount");
   private static _jointSamplerProperty = Shader.getPropertyByName("u_jointSampler");
@@ -84,8 +85,10 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       shaderData.enableMacro(SkinnedMeshRenderer._blendShapeMacro);
       if (blendShapeManager._usingTextureStoreData) {
         shaderData.enableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
+        shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeManager._blendShapeCount.toString());
       } else {
         shaderData.disableMacro(SkinnedMeshRenderer._blendShapeTextureMacro);
+        shaderData.disableMacro("OASIS_BLENDSHAPE_COUNT");
       }
 
       shaderData.setFloatArray(SkinnedMeshRenderer._blendShapeWeightsProperty, this._blendShapeWeights);

--- a/packages/core/src/physics/Collider.ts
+++ b/packages/core/src/physics/Collider.ts
@@ -4,6 +4,7 @@ import { ICollider } from "@oasis-engine/design";
 import { ColliderShape } from "./shape/ColliderShape";
 import { UpdateFlag } from "../UpdateFlag";
 import { Entity } from "../Entity";
+import { BoolUpdateFlag } from "../BoolUpdateFlag";
 
 /**
  * Abstract class for collider shapes.
@@ -15,7 +16,7 @@ export abstract class Collider extends Component {
   /** @internal */
   _nativeCollider: ICollider;
 
-  protected _updateFlag: UpdateFlag;
+  protected _updateFlag: BoolUpdateFlag;
 
   private _shapes: ColliderShape[] = [];
 

--- a/packages/core/src/renderingHardwareInterface/IPlatformTexture2D.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTexture2D.ts
@@ -16,9 +16,9 @@ export interface IPlatformTexture2D extends IPlatformTexture {
    */
   setPixelBuffer(
     colorBuffer: ArrayBufferView,
-    mipLevel?: number,
-    x?: number,
-    y?: number,
+    mipLevel: number,
+    x: number,
+    y: number,
     width?: number,
     height?: number
   ): void;
@@ -34,11 +34,11 @@ export interface IPlatformTexture2D extends IPlatformTexture {
    */
   setImageSource(
     imageSource: TexImageSource | OffscreenCanvas,
-    mipLevel?: number,
-    flipY?: boolean,
-    premultiplyAlpha?: boolean,
-    x?: number,
-    y?: number
+    mipLevel: number,
+    flipY: boolean,
+    premultiplyAlpha: boolean,
+    x: number,
+    y: number
   ): void;
 
   /**

--- a/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
@@ -18,9 +18,9 @@ export interface IPlatformTexture2DArray extends IPlatformTexture {
   setPixelBuffer(
     elementIndex: number,
     colorBuffer: ArrayBufferView,
-    mipLevel?: number,
-    x?: number,
-    y?: number,
+    mipLevel: number,
+    x: number,
+    y: number,
     width?: number,
     height?: number
   ): void;
@@ -38,11 +38,11 @@ export interface IPlatformTexture2DArray extends IPlatformTexture {
   setImageSource(
     elementIndex: number,
     imageSource: TexImageSource | OffscreenCanvas,
-    mipLevel?: number,
-    flipY?: boolean,
-    premultiplyAlpha?: boolean,
-    x?: number,
-    y?: number
+    mipLevel: number,
+    flipY: boolean,
+    premultiplyAlpha: boolean,
+    x: number,
+    y: number
   ): void;
 
   /**

--- a/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
@@ -1,0 +1,67 @@
+import { IPlatformTexture } from "./IPlatformTexture";
+
+/**
+ * 2D texture array interface specification.
+ */
+export interface IPlatformTexture2DArray extends IPlatformTexture {
+  /**
+   * Setting pixels data through color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
+   * @remarks If it is the WebGL1.0 platform and the texture format is compressed, the first upload must be filled with textures.
+   * @param elementIndex - The texture array element index
+   * @param colorBuffer - Color buffer data
+   * @param mipLevel - Texture mipmapping level
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   * @param width - Data width. if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
+   * @param height - Data height. if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   */
+  setPixelBuffer(
+    elementIndex: number,
+    colorBuffer: ArrayBufferView,
+    mipLevel?: number,
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+  ): void;
+
+  /**
+   * Setting pixels data through TexImageSource, designated area and texture mipmapping level.
+   * @param elementIndex - The texture array element index
+   * @param imageSource - The source of texture
+   * @param mipLevel - Texture mipmapping level
+   * @param flipY - Whether to flip the Y axis
+   * @param premultiplyAlpha - Whether to premultiply the transparent channel
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   */
+  setImageSource(
+    elementIndex: number,
+    imageSource: TexImageSource | OffscreenCanvas,
+    mipLevel?: number,
+    flipY?: boolean,
+    premultiplyAlpha?: boolean,
+    x?: number,
+    y?: number
+  ): void;
+
+  /**
+   * Get the pixel color buffer according to the specified area.
+   * @param elementIndex - The texture array element index
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   * @param width - Area width
+   * @param height - Area height
+   * @param mipLevel - Set mip level the data want to get from
+   * @param out - Color buffer
+   */
+  getPixelBuffer(
+    elementIndex: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    mipLevel: number,
+    out: ArrayBufferView
+  ): void;
+}

--- a/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
@@ -6,7 +6,6 @@ import { IPlatformTexture } from "./IPlatformTexture";
 export interface IPlatformTexture2DArray extends IPlatformTexture {
   /**
    * Setting pixels data through color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
-   * @remarks If it is the WebGL1.0 platform and the texture format is compressed, the first upload must be filled with textures.
    * @param offsetIndex - The texture array element offset index
    * @param colorBuffer - Color buffer data
    * @param mipLevel - Texture mipmapping level

--- a/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTexture2DArray.ts
@@ -7,27 +7,29 @@ export interface IPlatformTexture2DArray extends IPlatformTexture {
   /**
    * Setting pixels data through color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
    * @remarks If it is the WebGL1.0 platform and the texture format is compressed, the first upload must be filled with textures.
-   * @param elementIndex - The texture array element index
+   * @param offsetIndex - The texture array element offset index
    * @param colorBuffer - Color buffer data
    * @param mipLevel - Texture mipmapping level
    * @param x - X coordinate of area start
    * @param y - Y coordinate of area start
    * @param width - Data width. if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
    * @param height - Data height. if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   * @param length - Data length.
    */
   setPixelBuffer(
-    elementIndex: number,
+    offsetIndex: number,
     colorBuffer: ArrayBufferView,
     mipLevel: number,
     x: number,
     y: number,
     width?: number,
-    height?: number
+    height?: number,
+    length?: number
   ): void;
 
   /**
    * Setting pixels data through TexImageSource, designated area and texture mipmapping level.
-   * @param elementIndex - The texture array element index
+   * @param index - The texture array element index
    * @param imageSource - The source of texture
    * @param mipLevel - Texture mipmapping level
    * @param flipY - Whether to flip the Y axis
@@ -36,7 +38,7 @@ export interface IPlatformTexture2DArray extends IPlatformTexture {
    * @param y - Y coordinate of area start
    */
   setImageSource(
-    elementIndex: number,
+    index: number,
     imageSource: TexImageSource | OffscreenCanvas,
     mipLevel: number,
     flipY: boolean,

--- a/packages/core/src/renderingHardwareInterface/IPlatformTextureCube.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTextureCube.ts
@@ -19,9 +19,9 @@ export interface IPlatformTextureCube extends IPlatformTexture {
   setPixelBuffer(
     face: TextureCubeFace,
     colorBuffer: ArrayBufferView,
-    mipLevel?: number,
-    x?: number,
-    y?: number,
+    mipLevel: number,
+    x: number,
+    y: number,
     width?: number,
     height?: number
   ): void;
@@ -39,11 +39,11 @@ export interface IPlatformTextureCube extends IPlatformTexture {
   setImageSource(
     face: TextureCubeFace,
     imageSource: TexImageSource,
-    mipLevel?: number,
-    flipY?: boolean,
-    premultiplyAlpha?: boolean,
-    x?: number,
-    y?: number
+    mipLevel: number,
+    flipY: boolean,
+    premultiplyAlpha: boolean,
+    x: number,
+    y: number
   ): void;
 
   /**

--- a/packages/core/src/renderingHardwareInterface/IPlatformTextureCube.ts
+++ b/packages/core/src/renderingHardwareInterface/IPlatformTextureCube.ts
@@ -38,7 +38,7 @@ export interface IPlatformTextureCube extends IPlatformTexture {
    */
   setImageSource(
     face: TextureCubeFace,
-    imageSource: TexImageSource,
+    imageSource: TexImageSource | OffscreenCanvas,
     mipLevel: number,
     flipY: boolean,
     premultiplyAlpha: boolean,

--- a/packages/core/src/renderingHardwareInterface/index.ts
+++ b/packages/core/src/renderingHardwareInterface/index.ts
@@ -2,4 +2,6 @@ export type { IHardwareRenderer } from "./IHardwareRenderer";
 export type { IPlatformRenderTarget } from "./IPlatformRenderTarget";
 export type { IPlatformTexture } from "./IPlatformTexture";
 export type { IPlatformTexture2D } from "./IPlatformTexture2D";
+export type { IPlatformTexture2DArray } from "./IPlatformTexture2DArray";
 export type { IPlatformTextureCube } from "./IPlatformTextureCube";
+

--- a/packages/core/src/renderingHardwareInterface/index.ts
+++ b/packages/core/src/renderingHardwareInterface/index.ts
@@ -4,4 +4,3 @@ export type { IPlatformTexture } from "./IPlatformTexture";
 export type { IPlatformTexture2D } from "./IPlatformTexture2D";
 export type { IPlatformTexture2DArray } from "./IPlatformTexture2DArray";
 export type { IPlatformTextureCube } from "./IPlatformTextureCube";
-

--- a/packages/core/src/shader/ShaderProgram.ts
+++ b/packages/core/src/shader/ShaderProgram.ts
@@ -402,8 +402,20 @@ export class ShaderProgram {
         case gl.SAMPLER_2D:
         case gl.SAMPLER_CUBE:
         case (<WebGL2RenderingContext>gl).SAMPLER_2D_ARRAY:
-          const defaultTexture = type === gl.SAMPLER_2D ? this._engine._whiteTexture2D : this._engine._whiteTextureCube;
-          //CM: SAMPLER_2D_ARRAY defaultTexture
+          let defaultTexture: Texture;
+          switch (type) {
+            case gl.SAMPLER_2D:
+              defaultTexture = this._engine._whiteTexture2D;
+              break;
+            case gl.SAMPLER_CUBE:
+              defaultTexture = this._engine._whiteTextureCube;
+              break;
+            case (<WebGL2RenderingContext>gl).SAMPLER_2D_ARRAY:
+              defaultTexture = this._engine._whiteTexture2DArray;
+              break;
+            default:
+              throw new Error("Unsupported texture type.");
+          }
 
           isTexture = true;
           if (isArray) {
@@ -445,7 +457,7 @@ export class ShaderProgram {
   private _getUniformInfos(): WebGLActiveInfo[] {
     const gl = this._gl;
     const program = this._glProgram;
-    const uniformInfos: WebGLActiveInfo[] = [];
+    const uniformInfos = new Array<WebGLActiveInfo>();
 
     const uniformCount = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
     for (let i = 0; i < uniformCount; ++i) {
@@ -459,7 +471,7 @@ export class ShaderProgram {
   private _getAttributeInfos(): WebGLActiveInfo[] {
     const gl = this._gl;
     const program = this._glProgram;
-    const attributeInfos: WebGLActiveInfo[] = [];
+    const attributeInfos = new Array<WebGLActiveInfo>();
 
     const attributeCount = gl.getProgramParameter(program, gl.ACTIVE_ATTRIBUTES);
     for (let i = 0; i < attributeCount; ++i) {

--- a/packages/core/src/shader/ShaderProgram.ts
+++ b/packages/core/src/shader/ShaderProgram.ts
@@ -401,7 +401,9 @@ export class ShaderProgram {
           break;
         case gl.SAMPLER_2D:
         case gl.SAMPLER_CUBE:
+        case (<WebGL2RenderingContext>gl).SAMPLER_2D_ARRAY:
           const defaultTexture = type === gl.SAMPLER_2D ? this._engine._whiteTexture2D : this._engine._whiteTextureCube;
+          //CM: SAMPLER_2D_ARRAY defaultTexture
 
           isTexture = true;
           if (isArray) {

--- a/packages/core/src/shaderlib/ShaderFactory.ts
+++ b/packages/core/src/shaderlib/ShaderFactory.ts
@@ -3,9 +3,7 @@ import { Logger } from "../base/Logger";
 
 class ShaderFactory {
   static parseCustomMacros(macros: string[]) {
-    return (
-      macros.map((m) => `#define ${m}\n`).join("")
-    );
+    return macros.map((m) => `#define ${m}\n`).join("");
   }
 
   static parseIncludes(src: string) {
@@ -27,12 +25,10 @@ class ShaderFactory {
 
   /**
    * GLSL extension.
-   * @param {string[]} extensions - such as ["GL_EXT_shader_texture_lod"]
+   * @param extensions - such as ["GL_EXT_shader_texture_lod"]
    * */
-  static parseExtension(extensions: string[]) {
-    return (
-      extensions.map((e) => `#extension ${e} : enable\n`).join("")
-    );
+  static parseExtension(extensions: string[]): string {
+    return extensions.map((e) => `#extension ${e} : enable\n`).join("");
   }
 
   /**

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -1,7 +1,7 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
 		uniform mediump sampler2DArray u_blendShapeTexture;
-		uniform vec3 u_blendShapeTextureInfo;
+		uniform ivec3 u_blendShapeTextureInfo;
 	#else
 		attribute vec3 POSITION_BS0;
 		attribute vec3 POSITION_BS1;
@@ -33,12 +33,12 @@
 	uniform float u_blendShapeWeights[OASIS_BLENDSHAPE_COUNT];
 
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
-		vec3 getBlendShapeVertexElement(int blendShapeIndex, float vertexElementIndex)
+		vec3 getBlendShapeVertexElement(int blendShapeIndex, int vertexElementIndex)
 		{			
-			float y = floor(vertexElementIndex / u_blendShapeTextureInfo.y);
-			float x = vertexElementIndex - y * u_blendShapeTextureInfo.y;
-			vec3 textureUV = vec3((x + 0.5) / u_blendShapeTextureInfo.y, (y + 0.5) / u_blendShapeTextureInfo.z, blendShapeIndex);
-			return texture(u_blendShapeTexture, textureUV).xyz;
+			int y = vertexElementIndex / u_blendShapeTextureInfo.y;
+			int x = vertexElementIndex - y * u_blendShapeTextureInfo.y;
+			ivec3 uv = ivec3(x, y , blendShapeIndex);
+			return texelFetch(u_blendShapeTexture, uv, 0).xyz;
 		}
 	#endif
 #endif

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -22,7 +22,7 @@
 			attribute vec3 TANGENT_BS3;
 		#endif
 	#endif
-	uniform float u_blendShapeWeights[4];
+	uniform float u_blendShapeWeights[8];
 
 
 	#ifdef OASIS_BLENDSHAPE_TEXTURE

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -26,10 +26,10 @@
 
 
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
-		vec3 getBlendShapeVertexElement(int blendShapeIndex, float vertexIndex)
+		vec3 getBlendShapeVertexElement(int blendShapeIndex, float vertexElementIndex)
 		{			
-			float y = floor(vertexIndex / u_blendShapeTextureInfo.y);
-			float x = vertexIndex - y * u_blendShapeTextureInfo.y;
+			float y = floor(vertexElementIndex / u_blendShapeTextureInfo.y);
+			float x = vertexElementIndex - y * u_blendShapeTextureInfo.y;
 			vec3 textureUV = vec3((x + 0.5) / u_blendShapeTextureInfo.y, (y + 0.5) / u_blendShapeTextureInfo.z, blendShapeIndex);
 			return texture(u_blendShapeTexture, textureUV).xyz;
 		}

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -26,7 +26,7 @@
 
 
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
-		vec3 readFromBlendShapeTexture(int blendShapeIndex, float vertexIndex)
+		vec3 getBlendShapeVertexElement(int blendShapeIndex, float vertexIndex)
 		{			
 			float y = floor(vertexIndex / u_blendShapeTextureInfo.y);
 			float x = vertexIndex - y * u_blendShapeTextureInfo.y;

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -1,6 +1,6 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
-		uniform sampler2DArray u_blendShapeTexture;
+		uniform mediump sampler2DArray u_blendShapeTexture;
 		uniform vec3 u_blendShapeTextureInfo;
 	#else
 		attribute vec3 POSITION_BS0;

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -8,22 +8,29 @@
 		attribute vec3 POSITION_BS2;
 		attribute vec3 POSITION_BS3;
 
-		#ifdef OASIS_BLENDSHAPE_NORMAL
-		    attribute vec3 NORMAL_BS0;
-			attribute vec3 NORMAL_BS1;
-			attribute vec3 NORMAL_BS2;
-			attribute vec3 NORMAL_BS3;
-		#endif
+		#if defined( OASIS_BLENDSHAPE_NORMAL ) || defined( OASIS_BLENDSHAPE_TANGENT )
+			#ifdef OASIS_BLENDSHAPE_NORMAL
+				attribute vec3 NORMAL_BS0;
+				attribute vec3 NORMAL_BS1;
+				attribute vec3 NORMAL_BS2;
+				attribute vec3 NORMAL_BS3;
+			#endif
 
-		#ifdef OASIS_BLENDSHAPE_TANGENT
-		    attribute vec3 TANGENT_BS0;
-			attribute vec3 TANGENT_BS1;
-			attribute vec3 TANGENT_BS2;
-			attribute vec3 TANGENT_BS3;
+			#ifdef OASIS_BLENDSHAPE_TANGENT
+				attribute vec3 TANGENT_BS0;
+				attribute vec3 TANGENT_BS1;
+				attribute vec3 TANGENT_BS2;
+				attribute vec3 TANGENT_BS3;
+			#endif
+		#else
+			attribute vec3 POSITION_BS4;
+			attribute vec3 POSITION_BS5;
+			attribute vec3 POSITION_BS6;
+			attribute vec3 POSITION_BS7;
 		#endif
 	#endif
-	uniform float u_blendShapeWeights[8];
 
+	uniform float u_blendShapeWeights[OASIS_BLENDSHAPE_COUNT];
 
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
 		vec3 getBlendShapeVertexElement(int blendShapeIndex, float vertexElementIndex)

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -1,5 +1,8 @@
 #ifdef OASIS_BLENDSHAPE
-	#ifndef OASIS_BLENDSHAPE_TEXTURE
+	#ifdef OASIS_BLENDSHAPE_TEXTURE
+		uniform sampler2DArray u_blendShapeTexture;
+		uniform vec3 u_blendShapeTextureInfo;
+	#else
 		attribute vec3 POSITION_BS0;
 		attribute vec3 POSITION_BS1;
 		attribute vec3 POSITION_BS2;
@@ -20,4 +23,15 @@
 		#endif
 	#endif
 	uniform float u_blendShapeWeights[4];
+
+
+	#ifdef OASIS_BLENDSHAPE_TEXTURE
+		vec3 readFromBlendShapeTexture(int blendShapeIndex, float vertexIndex)
+		{			
+			float y = floor(vertexIndex / u_blendShapeTextureInfo.y);
+			float x = vertexIndex - y * u_blendShapeTextureInfo.y;
+			vec3 textureUV = vec3((x + 0.5) / u_blendShapeTextureInfo.y, (y + 0.5) / u_blendShapeTextureInfo.z, blendShapeIndex);
+			return texture(u_blendShapeTexture, textureUV).xyz;
+		}
+	#endif
 #endif

--- a/packages/core/src/shaderlib/blendShape_input.glsl
+++ b/packages/core/src/shaderlib/blendShape_input.glsl
@@ -2,6 +2,7 @@
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
 		uniform mediump sampler2DArray u_blendShapeTexture;
 		uniform ivec3 u_blendShapeTextureInfo;
+		uniform float u_blendShapeWeights[OASIS_BLENDSHAPE_COUNT];
 	#else
 		attribute vec3 POSITION_BS0;
 		attribute vec3 POSITION_BS1;
@@ -22,15 +23,17 @@
 				attribute vec3 TANGENT_BS2;
 				attribute vec3 TANGENT_BS3;
 			#endif
+			uniform float u_blendShapeWeights[4];
 		#else
 			attribute vec3 POSITION_BS4;
 			attribute vec3 POSITION_BS5;
 			attribute vec3 POSITION_BS6;
 			attribute vec3 POSITION_BS7;
+			uniform float u_blendShapeWeights[8];
 		#endif
 	#endif
 
-	uniform float u_blendShapeWeights[OASIS_BLENDSHAPE_COUNT];
+	
 
 	#ifdef OASIS_BLENDSHAPE_TEXTURE
 		vec3 getBlendShapeVertexElement(int blendShapeIndex, int vertexElementIndex)

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -5,21 +5,6 @@
 			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 		}
 		
-		#ifndef OMIT_NORMAL
-			#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
-			    vertexElementOffset += 1.0;
-				for(int i = 0; i < OASIS_BLENDSHAPE_COUNT; i++){
-					normal.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
-				}
-			#endif
-
-			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
-			    vertexElementOffset += 1.0;
-				for(int i = 0; i< OASIS_BLENDSHAPE_COUNT; i++){
-					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
-				}
-			#endif
-		#endif
 	#else
 		position.xyz += POSITION_BS0 * u_blendShapeWeights[0];
 		position.xyz += POSITION_BS1 * u_blendShapeWeights[1];

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,19 +1,20 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE	
-		float vertexOffset = float(gl_VertexID) * u_blendShapeTextureInfo.x;
+		int vertexOffset = gl_VertexID * u_blendShapeTextureInfo.x;
 		for(int i = 0; i < OASIS_BLENDSHAPE_COUNT; i++){
-			float vertexElementOffset = vertexOffset;
-			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
+			int vertexElementOffset = vertexOffset;
+			float weight = u_blendShapeWeights[i];
+			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 			
 			#ifndef OMIT_NORMAL
 				#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
-					vertexElementOffset += 1.0;
-					normal.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
+					vertexElementOffset += 1;
+					normal += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 
 				#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
-					vertexElementOffset += 1.0;
-					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
+					vertexElementOffset += 1;
+					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * weight;
 				#endif
 			#endif
 		}
@@ -26,10 +27,10 @@
 		#if defined( OASIS_BLENDSHAPE_NORMAL ) || defined( OASIS_BLENDSHAPE_TANGENT )
 			#ifndef OMIT_NORMAL
 				#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
-					normal.xyz += NORMAL_BS0 * u_blendShapeWeights[0];
-					normal.xyz += NORMAL_BS1 * u_blendShapeWeights[1];
-					normal.xyz += NORMAL_BS2 * u_blendShapeWeights[2];
-					normal.xyz += NORMAL_BS3 * u_blendShapeWeights[3];
+					normal += NORMAL_BS0 * u_blendShapeWeights[0];
+					normal += NORMAL_BS1 * u_blendShapeWeights[1];
+					normal += NORMAL_BS2 * u_blendShapeWeights[2];
+					normal += NORMAL_BS3 * u_blendShapeWeights[3];
 				#endif
 
 				#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -10,21 +10,28 @@
 		position.xyz += POSITION_BS1 * u_blendShapeWeights[1];
 		position.xyz += POSITION_BS2 * u_blendShapeWeights[2];
 		position.xyz += POSITION_BS3 * u_blendShapeWeights[3];
-		
-		#ifndef OMIT_NORMAL
-			#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
-				normal.xyz += NORMAL_BS0 * u_blendShapeWeights[0];
-				normal.xyz += NORMAL_BS1 * u_blendShapeWeights[1];
-				normal.xyz += NORMAL_BS2 * u_blendShapeWeights[2];
-				normal.xyz += NORMAL_BS3 * u_blendShapeWeights[3];
-			#endif
 
-			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
-				tangent.xyz += TANGENT_BS0 * u_blendShapeWeights[0];
-				tangent.xyz += TANGENT_BS1 * u_blendShapeWeights[1];
-				tangent.xyz += TANGENT_BS2 * u_blendShapeWeights[2];
-				tangent.xyz += TANGENT_BS3 * u_blendShapeWeights[3];
+		#if defined( OASIS_BLENDSHAPE_NORMAL ) || defined( OASIS_BLENDSHAPE_TANGENT )
+			#ifndef OMIT_NORMAL
+				#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
+					normal.xyz += NORMAL_BS0 * u_blendShapeWeights[0];
+					normal.xyz += NORMAL_BS1 * u_blendShapeWeights[1];
+					normal.xyz += NORMAL_BS2 * u_blendShapeWeights[2];
+					normal.xyz += NORMAL_BS3 * u_blendShapeWeights[3];
+				#endif
+
+				#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
+					tangent.xyz += TANGENT_BS0 * u_blendShapeWeights[0];
+					tangent.xyz += TANGENT_BS1 * u_blendShapeWeights[1];
+					tangent.xyz += TANGENT_BS2 * u_blendShapeWeights[2];
+					tangent.xyz += TANGENT_BS3 * u_blendShapeWeights[3];
+				#endif
 			#endif
+		#else
+			position.xyz += POSITION_BS4 * u_blendShapeWeights[4];
+			position.xyz += POSITION_BS5 * u_blendShapeWeights[5];
+			position.xyz += POSITION_BS6 * u_blendShapeWeights[6];
+			position.xyz += POSITION_BS7 * u_blendShapeWeights[7];
 		#endif
 	#endif
 #endif

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,6 +1,29 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE	
+		float vertexID = float(gl_VertexID) * u_blendShapeTextureInfo.x;
+		position.xyz += readFromBlendShapeTexture(0, vertexID) * u_blendShapeWeights[0];
+		position.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
+		position.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
+		position.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
+		
 
+		#ifndef OMIT_NORMAL
+			#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
+			    vertexID += 1.0;
+				normal.xyz += readFromBlendShapeTexture(0, vertexID) * u_blendShapeWeights[0];
+				normal.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
+				normal.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
+				normal.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
+			#endif
+
+			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
+			    vertexID += 1.0;
+				tangent.xyz += readFromBlendShapeTexture(0, vertexID) * u_blendShapeWeights[0];
+				tangent.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
+				tangent.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
+				tangent.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
+			#endif
+		#endif
 	#else
 		position.xyz += POSITION_BS0 * u_blendShapeWeights[0];
 		position.xyz += POSITION_BS1 * u_blendShapeWeights[1];
@@ -15,7 +38,7 @@
 				normal.xyz += NORMAL_BS3 * u_blendShapeWeights[3];
 			#endif
 
-			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined(OASIS_BLENDSHAPE_TANGENT)
+			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
 				tangent.xyz += TANGENT_BS0 * u_blendShapeWeights[0];
 				tangent.xyz += TANGENT_BS1 * u_blendShapeWeights[1];
 				tangent.xyz += TANGENT_BS2 * u_blendShapeWeights[2];

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,39 +1,23 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE	
-		float vertexID = float(gl_VertexID) * u_blendShapeTextureInfo.x;
-		position.xyz += readFromBlendShapeTexture(0, vertexID) * u_blendShapeWeights[0];
-		position.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
-		position.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
-		position.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
-		position.xyz += readFromBlendShapeTexture(4, vertexID) * u_blendShapeWeights[4];
-		position.xyz += readFromBlendShapeTexture(5, vertexID) * u_blendShapeWeights[5];
-		position.xyz += readFromBlendShapeTexture(6, vertexID) * u_blendShapeWeights[6];
-		position.xyz += readFromBlendShapeTexture(7, vertexID) * u_blendShapeWeights[7];
+		float vertexElementOffset = float(gl_VertexID) * u_blendShapeTextureInfo.x;
+		for(int i=0; i<8; i++){
+			position.xyz += readFromBlendShapeTexture(i, vertexElementOffset) * u_blendShapeWeights[i];
+		}
 		
-
 		#ifndef OMIT_NORMAL
 			#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
-			    vertexID += 1.0;
-				normal.xyz += readFromBlendShapeTexture(0, vertexID) * u_blendShapeWeights[0];
-				normal.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
-				normal.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
-				normal.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
-				normal.xyz += readFromBlendShapeTexture(4, vertexID) * u_blendShapeWeights[4];
-				normal.xyz += readFromBlendShapeTexture(5, vertexID) * u_blendShapeWeights[5];
-				normal.xyz += readFromBlendShapeTexture(6, vertexID) * u_blendShapeWeights[6];
-				normal.xyz += readFromBlendShapeTexture(7, vertexID) * u_blendShapeWeights[7];
+			    vertexElementOffset += 1.0;
+				for(int i=0; i<8; i++){
+					normal.xyz += readFromBlendShapeTexture(i, vertexElementOffset) * u_blendShapeWeights[i];
+				}
 			#endif
 
 			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
-			    vertexID += 1.0;
-				tangent.xyz += readFromBlendShapeTexture(0, vertexID) * u_blendShapeWeights[0];
-				tangent.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
-				tangent.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
-				tangent.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
-				tangent.xyz += readFromBlendShapeTexture(4, vertexID) * u_blendShapeWeights[4];
-				tangent.xyz += readFromBlendShapeTexture(5, vertexID) * u_blendShapeWeights[5];
-				tangent.xyz += readFromBlendShapeTexture(6, vertexID) * u_blendShapeWeights[6];
-				tangent.xyz += readFromBlendShapeTexture(7, vertexID) * u_blendShapeWeights[7];
+			    vertexElementOffset += 1.0;
+				for(int i=0; i<8; i++){
+					tangent.xyz += readFromBlendShapeTexture(i, vertexElementOffset) * u_blendShapeWeights[i];
+				}
 			#endif
 		#endif
 	#else

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,22 +1,22 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE	
 		float vertexElementOffset = float(gl_VertexID) * u_blendShapeTextureInfo.x;
-		for(int i=0; i<8; i++){
-			position.xyz += readFromBlendShapeTexture(i, vertexElementOffset) * u_blendShapeWeights[i];
+		for(int i = 0; i < 8; i++){
+			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 		}
 		
 		#ifndef OMIT_NORMAL
 			#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
 			    vertexElementOffset += 1.0;
-				for(int i=0; i<8; i++){
-					normal.xyz += readFromBlendShapeTexture(i, vertexElementOffset) * u_blendShapeWeights[i];
+				for(int i = 0; i < 8; i++){
+					normal.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 				}
 			#endif
 
 			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
 			    vertexElementOffset += 1.0;
-				for(int i=0; i<8; i++){
-					tangent.xyz += readFromBlendShapeTexture(i, vertexElementOffset) * u_blendShapeWeights[i];
+				for(int i = 0; i< 8; i++){
+					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 				}
 			#endif
 		#endif
@@ -43,3 +43,5 @@
 		#endif
 	#endif
 #endif
+
+

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -5,6 +5,10 @@
 		position.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
 		position.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
 		position.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
+		position.xyz += readFromBlendShapeTexture(4, vertexID) * u_blendShapeWeights[4];
+		position.xyz += readFromBlendShapeTexture(5, vertexID) * u_blendShapeWeights[5];
+		position.xyz += readFromBlendShapeTexture(6, vertexID) * u_blendShapeWeights[6];
+		position.xyz += readFromBlendShapeTexture(7, vertexID) * u_blendShapeWeights[7];
 		
 
 		#ifndef OMIT_NORMAL
@@ -14,6 +18,10 @@
 				normal.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
 				normal.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
 				normal.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
+				normal.xyz += readFromBlendShapeTexture(4, vertexID) * u_blendShapeWeights[4];
+				normal.xyz += readFromBlendShapeTexture(5, vertexID) * u_blendShapeWeights[5];
+				normal.xyz += readFromBlendShapeTexture(6, vertexID) * u_blendShapeWeights[6];
+				normal.xyz += readFromBlendShapeTexture(7, vertexID) * u_blendShapeWeights[7];
 			#endif
 
 			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
@@ -22,6 +30,10 @@
 				tangent.xyz += readFromBlendShapeTexture(1, vertexID) * u_blendShapeWeights[1];
 				tangent.xyz += readFromBlendShapeTexture(2, vertexID) * u_blendShapeWeights[2];
 				tangent.xyz += readFromBlendShapeTexture(3, vertexID) * u_blendShapeWeights[3];
+				tangent.xyz += readFromBlendShapeTexture(4, vertexID) * u_blendShapeWeights[4];
+				tangent.xyz += readFromBlendShapeTexture(5, vertexID) * u_blendShapeWeights[5];
+				tangent.xyz += readFromBlendShapeTexture(6, vertexID) * u_blendShapeWeights[6];
+				tangent.xyz += readFromBlendShapeTexture(7, vertexID) * u_blendShapeWeights[7];
 			#endif
 		#endif
 	#else

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,10 +1,22 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE	
-		float vertexElementOffset = float(gl_VertexID) * u_blendShapeTextureInfo.x;
+		float vertexOffset = float(gl_VertexID) * u_blendShapeTextureInfo.x;
 		for(int i = 0; i < OASIS_BLENDSHAPE_COUNT; i++){
+			float vertexElementOffset = vertexOffset;
 			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
+			
+			#ifndef OMIT_NORMAL
+				#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
+					vertexElementOffset += 1.0;
+					normal.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
+				#endif
+
+				#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
+					vertexElementOffset += 1.0;
+					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
+				#endif
+			#endif
 		}
-		
 	#else
 		position.xyz += POSITION_BS0 * u_blendShapeWeights[0];
 		position.xyz += POSITION_BS1 * u_blendShapeWeights[1];

--- a/packages/core/src/shaderlib/blendShape_vert.glsl
+++ b/packages/core/src/shaderlib/blendShape_vert.glsl
@@ -1,21 +1,21 @@
 #ifdef OASIS_BLENDSHAPE
 	#ifdef OASIS_BLENDSHAPE_TEXTURE	
 		float vertexElementOffset = float(gl_VertexID) * u_blendShapeTextureInfo.x;
-		for(int i = 0; i < 8; i++){
+		for(int i = 0; i < OASIS_BLENDSHAPE_COUNT; i++){
 			position.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 		}
 		
 		#ifndef OMIT_NORMAL
 			#if defined( O3_HAS_NORMAL ) && defined( OASIS_BLENDSHAPE_NORMAL )
 			    vertexElementOffset += 1.0;
-				for(int i = 0; i < 8; i++){
+				for(int i = 0; i < OASIS_BLENDSHAPE_COUNT; i++){
 					normal.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 				}
 			#endif
 
 			#if defined( O3_HAS_TANGENT ) && defined( O3_NORMAL_TEXTURE ) && defined( OASIS_BLENDSHAPE_TANGENT )
 			    vertexElementOffset += 1.0;
-				for(int i = 0; i< 8; i++){
+				for(int i = 0; i< OASIS_BLENDSHAPE_COUNT; i++){
 					tangent.xyz += getBlendShapeVertexElement(i, vertexElementOffset) * u_blendShapeWeights[i];
 				}
 			#endif

--- a/packages/core/src/texture/Texture2D.ts
+++ b/packages/core/src/texture/Texture2D.ts
@@ -50,8 +50,8 @@ export class Texture2D extends Texture {
   setPixelBuffer(
     colorBuffer: ArrayBufferView,
     mipLevel: number = 0,
-    x?: number,
-    y?: number,
+    x: number = 0,
+    y: number = 0,
     width?: number,
     height?: number
   ): void {
@@ -72,8 +72,8 @@ export class Texture2D extends Texture {
     mipLevel: number = 0,
     flipY: boolean = false,
     premultiplyAlpha: boolean = false,
-    x?: number,
-    y?: number
+    x: number = 0,
+    y: number = 0
   ): void {
     (this._platformTexture as IPlatformTexture2D).setImageSource(imageSource, mipLevel, flipY, premultiplyAlpha, x, y);
   }

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -9,13 +9,13 @@ import { Texture } from "./Texture";
  * Two-dimensional texture array.
  */
 export class Texture2DArray extends Texture {
-  private _depth: number;
+  private _length: number;
 
   /**
-   * The depth of the texture.
+   * The length of the texture.
    */
-  get depth(): number {
-    return this._depth;
+  get length(): number {
+    return this._length;
   }
 
   /**
@@ -23,7 +23,7 @@ export class Texture2DArray extends Texture {
    * @param engine - Define the engine to use to render this texture
    * @param width - Texture width
    * @param height - Texture height
-   * @param depth - Texture depth
+   * @param length - Texture length
    * @param format - Texture format. default  `TextureFormat.R8G8B8A8`
    * @param mipmap - Whether to use multi-level texture
    */
@@ -31,7 +31,7 @@ export class Texture2DArray extends Texture {
     engine: Engine,
     width: number,
     height: number,
-    depth: number,
+    length: number,
     format: TextureFormat = TextureFormat.R8G8B8A8,
     mipmap: boolean = true
   ) {
@@ -39,7 +39,7 @@ export class Texture2DArray extends Texture {
     this._mipmap = mipmap;
     this._width = width;
     this._height = height;
-    this._depth = depth;
+    this._length = length;
     this._format = format;
     this._mipmapCount = this._getMipmapCount();
 

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -1,0 +1,209 @@
+import { Engine } from "../Engine";
+import { IPlatformTexture2DArray } from "../renderingHardwareInterface";
+import { TextureFilterMode } from "./enums/TextureFilterMode";
+import { TextureFormat } from "./enums/TextureFormat";
+import { TextureWrapMode } from "./enums/TextureWrapMode";
+import { Texture } from "./Texture";
+
+/**
+ * Two-dimensional texture array.
+ */
+export class Texture2DArray extends Texture {
+  private _depth: number;
+
+  /**
+   * The depth of the texture.
+   */
+  get depth(): number {
+    return this._depth;
+  }
+
+  /**
+   * Create Texture2D.
+   * @param engine - Define the engine to use to render this texture
+   * @param width - Texture width
+   * @param height - Texture height
+   * @param depth - Texture depth
+   * @param format - Texture format. default  `TextureFormat.R8G8B8A8`
+   * @param mipmap - Whether to use multi-level texture
+   */
+  constructor(
+    engine: Engine,
+    width: number,
+    height: number,
+    depth: number,
+    format: TextureFormat = TextureFormat.R8G8B8A8,
+    mipmap: boolean = true
+  ) {
+    super(engine);
+    this._mipmap = mipmap;
+    this._width = width;
+    this._height = height;
+    this._depth = depth;
+    this._format = format;
+    this._mipmapCount = this._getMipmapCount();
+
+    this._platformTexture = engine._hardwareRenderer.createPlatformTexture2D(this);
+
+    this.filterMode = TextureFilterMode.Bilinear;
+    this.wrapModeU = this.wrapModeV = TextureWrapMode.Repeat;
+  }
+
+  /**
+   * Setting pixels data through color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
+   * @remarks If it is the WebGL1.0 platform and the texture format is compressed, the first upload must be filled with textures.
+   * @param elementIndex - The texture array element index
+   * @param colorBuffer - Color buffer data
+   * @param mipLevel - Texture mipmapping level
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   * @param width - Data width. if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
+   * @param height - Data height. if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   */
+  setPixelBuffer(
+    elementIndex: number,
+    colorBuffer: ArrayBufferView,
+    mipLevel: number = 0,
+    x?: number,
+    y?: number,
+    width?: number,
+    height?: number
+  ): void {
+    (this._platformTexture as IPlatformTexture2DArray).setPixelBuffer(
+      elementIndex,
+      colorBuffer,
+      mipLevel,
+      x,
+      y,
+      width,
+      height
+    );
+  }
+
+  /**
+   * Setting pixels data through TexImageSource, designated area and texture mipmapping level.
+   * @param elementIndex - The texture array element index
+   * @param imageSource - The source of texture
+   * @param flipY - Whether to flip the Y axis
+   * @param premultiplyAlpha - Whether to premultiply the transparent channel
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   */
+  setImageSource(
+    elementIndex: number,
+    imageSource: TexImageSource | OffscreenCanvas,
+    mipLevel: number = 0,
+    flipY: boolean = false,
+    premultiplyAlpha: boolean = false,
+    x?: number,
+    y?: number
+  ): void {
+    (this._platformTexture as IPlatformTexture2DArray).setImageSource(
+      elementIndex,
+      imageSource,
+      mipLevel,
+      flipY,
+      premultiplyAlpha,
+      x,
+      y
+    );
+  }
+
+  /**
+   * Get pixel color buffer.
+   * @param out - Color buffer
+   */
+  getPixelBuffer(elementIndex: number, out: ArrayBufferView): void;
+
+  /**
+   * Get the pixel color buffer according to the specified mip level.
+   * @param elementIndex - The texture array element index
+   * @param mipLevel - Tet mip level want to get
+   * @param out - Color buffer
+   */
+  getPixelBuffer(elementIndex: number, mipLevel: number, out: ArrayBufferView): void;
+
+  /**
+   * Get the pixel color buffer according to the specified area.
+   * @param elementIndex - The texture array element index
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   * @param width - Area width
+   * @param height - Area height
+   * @param out - Color buffer
+   */
+  getPixelBuffer(elementIndex: number, x: number, y: number, width: number, height: number, out: ArrayBufferView): void;
+
+  /**
+   * Get the pixel color buffer according to the specified area and mip level.
+   * @param elementIndex - The texture array element index
+   * @param x - X coordinate of area start
+   * @param y - Y coordinate of area start
+   * @param width - Area width
+   * @param height - Area height
+   * @param mipLevel - Tet mip level want to get
+   * @param out - Color buffer
+   */
+  getPixelBuffer(
+    elementIndex: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    mipLevel: number,
+    out: ArrayBufferView
+  ): void;
+
+  getPixelBuffer(
+    elementIndex: number,
+    xOrMipLevelOrOut: number | ArrayBufferView,
+    yOrMipLevel?: number | ArrayBufferView,
+    width?: number,
+    height?: number,
+    mipLevelOrOut?: number | ArrayBufferView,
+    out?: ArrayBufferView
+  ): void {
+    const argsLength = arguments.length;
+    if (argsLength === 1) {
+      (this._platformTexture as IPlatformTexture2DArray).getPixelBuffer(
+        elementIndex,
+        0,
+        0,
+        this._width,
+        this._height,
+        0,
+        <ArrayBufferView>xOrMipLevelOrOut
+      );
+    } else if (argsLength === 2) {
+      (this._platformTexture as IPlatformTexture2DArray).getPixelBuffer(
+        elementIndex,
+        0,
+        0,
+        this._width >> (<number>xOrMipLevelOrOut),
+        this._height >> (<number>xOrMipLevelOrOut),
+        <number>xOrMipLevelOrOut,
+        <ArrayBufferView>yOrMipLevel
+      );
+    } else if (argsLength === 5) {
+      (this._platformTexture as IPlatformTexture2DArray).getPixelBuffer(
+        elementIndex,
+        <number>xOrMipLevelOrOut,
+        <number>yOrMipLevel,
+        width,
+        height,
+        0,
+        <ArrayBufferView>mipLevelOrOut
+      );
+    } else if (argsLength === 6) {
+      (this._platformTexture as IPlatformTexture2DArray).getPixelBuffer(
+        elementIndex,
+        <number>xOrMipLevelOrOut,
+        <number>yOrMipLevel,
+        width,
+        height,
+        <number>mipLevelOrOut,
+        out
+      );
+    }
+  }
+}

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -24,7 +24,7 @@ export class Texture2DArray extends Texture {
    * @param width - Texture width
    * @param height - Texture height
    * @param length - Texture length
-   * @param format - Texture format. default  `TextureFormat.R8G8B8A8`
+   * @param format - Texture format. default `TextureFormat.R8G8B8A8`
    * @param mipmap - Whether to use multi-level texture
    */
   constructor(

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -52,31 +52,34 @@ export class Texture2DArray extends Texture {
   /**
    * Setting pixels data through color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
    * @remarks If it is the WebGL1.0 platform and the texture format is compressed, the first upload must be filled with textures.
-   * @param elementIndex - The texture array element index
+   * @param offsetIndex - The texture array element offset index
    * @param colorBuffer - Color buffer data
    * @param mipLevel - Texture mipmapping level
    * @param x - X coordinate of area start
    * @param y - Y coordinate of area start
    * @param width - Data width. if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
    * @param height - Data height. if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   * @param length - Data length. if it's empty, length is the length of Texture2DArray.length
    */
   setPixelBuffer(
-    elementIndex: number,
+    offsetIndex: number,
     colorBuffer: ArrayBufferView,
     mipLevel: number = 0,
     x: number = 0,
     y: number = 0,
     width?: number,
-    height?: number
+    height?: number,
+    length?: number
   ): void {
     (this._platformTexture as IPlatformTexture2DArray).setPixelBuffer(
-      elementIndex,
+      offsetIndex,
       colorBuffer,
       mipLevel,
       x,
       y,
       width,
-      height
+      height,
+      length
     );
   }
 

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -9,7 +9,7 @@ import { Texture } from "./Texture";
  * Two-dimensional texture array.
  */
 export class Texture2DArray extends Texture {
-  private _length: number;
+  private readonly _length: number;
 
   /**
    * The length of the texture.
@@ -87,6 +87,7 @@ export class Texture2DArray extends Texture {
    * Setting pixels data through TexImageSource, designated area and texture mipmapping level.
    * @param elementIndex - The texture array element index
    * @param imageSource - The source of texture
+   * @param mipLevel - Texture mipmapping level
    * @param flipY - Whether to flip the Y axis
    * @param premultiplyAlpha - Whether to premultiply the transparent channel
    * @param x - X coordinate of area start
@@ -114,6 +115,7 @@ export class Texture2DArray extends Texture {
 
   /**
    * Get pixel color buffer.
+   * @param elementIndex - The texture array element index
    * @param out - Color buffer
    */
   getPixelBuffer(elementIndex: number, out: ArrayBufferView): void;

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -43,7 +43,7 @@ export class Texture2DArray extends Texture {
     this._format = format;
     this._mipmapCount = this._getMipmapCount();
 
-    this._platformTexture = engine._hardwareRenderer.createPlatformTexture2D(this);
+    this._platformTexture = engine._hardwareRenderer.createPlatformTexture2DArray(this);
 
     this.filterMode = TextureFilterMode.Bilinear;
     this.wrapModeU = this.wrapModeV = TextureWrapMode.Repeat;

--- a/packages/core/src/texture/Texture2DArray.ts
+++ b/packages/core/src/texture/Texture2DArray.ts
@@ -19,7 +19,7 @@ export class Texture2DArray extends Texture {
   }
 
   /**
-   * Create Texture2D.
+   * Create Texture2D Array.
    * @param engine - Define the engine to use to render this texture
    * @param width - Texture width
    * @param height - Texture height
@@ -64,8 +64,8 @@ export class Texture2DArray extends Texture {
     elementIndex: number,
     colorBuffer: ArrayBufferView,
     mipLevel: number = 0,
-    x?: number,
-    y?: number,
+    x: number = 0,
+    y: number = 0,
     width?: number,
     height?: number
   ): void {
@@ -95,8 +95,8 @@ export class Texture2DArray extends Texture {
     mipLevel: number = 0,
     flipY: boolean = false,
     premultiplyAlpha: boolean = false,
-    x?: number,
-    y?: number
+    x: number = 0,
+    y: number = 0
   ): void {
     (this._platformTexture as IPlatformTexture2DArray).setImageSource(
       elementIndex,

--- a/packages/core/src/texture/TextureCube.ts
+++ b/packages/core/src/texture/TextureCube.ts
@@ -67,7 +67,7 @@ export class TextureCube extends Texture {
    */
   setImageSource(
     face: TextureCubeFace,
-    imageSource: TexImageSource,
+    imageSource: TexImageSource | OffscreenCanvas,
     mipLevel: number = 0,
     flipY: boolean = false,
     premultiplyAlpha: boolean = false,

--- a/packages/core/src/texture/TextureCube.ts
+++ b/packages/core/src/texture/TextureCube.ts
@@ -47,8 +47,8 @@ export class TextureCube extends Texture {
     face: TextureCubeFace,
     colorBuffer: ArrayBufferView,
     mipLevel: number = 0,
-    x?: number,
-    y?: number,
+    x: number = 0,
+    y: number = 0,
     width?: number,
     height?: number
   ): void {
@@ -71,8 +71,8 @@ export class TextureCube extends Texture {
     mipLevel: number = 0,
     flipY: boolean = false,
     premultiplyAlpha: boolean = false,
-    x?: number,
-    y?: number
+    x: number = 0,
+    y: number = 0
   ): void {
     (this._platformTexture as IPlatformTextureCube).setImageSource(
       face,

--- a/packages/core/src/texture/index.ts
+++ b/packages/core/src/texture/index.ts
@@ -5,5 +5,6 @@ export { TextureWrapMode } from "./enums/TextureWrapMode";
 export { RenderTarget } from "./RenderTarget";
 export { Texture } from "./Texture";
 export { Texture2D } from "./Texture2D";
+export { Texture2DArray } from "./Texture2DArray";
 export { TextureCube } from "./TextureCube";
 

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/design",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -13,6 +13,6 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
-    "@oasis-engine/math": "0.6.7"
+    "@oasis-engine/math": "0.7.0-beta.0"
   }
 }

--- a/packages/draco/package.json
+++ b/packages/draco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/draco",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "scripts": {
     "b:types": "tsc"
@@ -13,6 +13,6 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/core": "0.6.7"
+    "@oasis-engine/core": "0.7.0-beta.0"
   }
 }

--- a/packages/framebuffer-picker/package.json
+++ b/packages/framebuffer-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/framebuffer-picker",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -14,6 +14,6 @@
     "types/**/*"
   ],
   "dependencies": {
-    "oasis-engine": "0.6.7"
+    "oasis-engine": "0.7.0-beta.0"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/loader",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "types": "types/index.d.ts",
   "scripts": {
@@ -14,9 +14,9 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/core": "0.6.7",
-    "@oasis-engine/draco": "0.6.7",
-    "@oasis-engine/math": "0.6.7",
-    "@oasis-engine/rhi-webgl": "0.6.7"
+    "@oasis-engine/core": "0.7.0-beta.0",
+    "@oasis-engine/draco": "0.7.0-beta.0",
+    "@oasis-engine/math": "0.7.0-beta.0",
+    "@oasis-engine/rhi-webgl": "0.7.0-beta.0"
   }
 }

--- a/packages/loader/src/scene-loader/GLTFModel.ts
+++ b/packages/loader/src/scene-loader/GLTFModel.ts
@@ -1,4 +1,5 @@
 import { Animator, AnimatorController, AnimatorState, Component, Entity, UpdateFlag } from "@oasis-engine/core";
+import { BoolUpdateFlag } from "@oasis-engine/core/types/BoolUpdateFlag";
 import { GLTFResource } from "../gltf/GLTFResource";
 
 /**
@@ -14,7 +15,7 @@ export class GLTFModel extends Component {
   private _glTFEntity: Entity;
   private _clipPreview: string;
   private _hasBuiltNode: boolean = false;
-  private _controllerUpdateFlag: UpdateFlag;
+  private _controllerUpdateFlag: BoolUpdateFlag;
 
   get asset() {
     return this._asset;
@@ -52,7 +53,7 @@ export class GLTFModel extends Component {
   set animatorController(animatorController: AnimatorController) {
     const { _animator: animator } = this;
     if (animatorController !== this._animatorController) {
-      this._controllerUpdateFlag && this._controllerUpdateFlag.destroy();
+      this._controllerUpdateFlag && this._controllerUpdateFlag.clearFromManagers();
       // @ts-ignore
       this._controllerUpdateFlag = animatorController && animatorController._registerChangeFlag();
       this._animatorController = animatorController;

--- a/packages/loader/src/scene-loader/GLTFModel.ts
+++ b/packages/loader/src/scene-loader/GLTFModel.ts
@@ -1,4 +1,4 @@
-import { Animator, AnimatorController, AnimatorState, Component, Entity, UpdateFlag } from "@oasis-engine/core";
+import { Animator, AnimatorController, Component, Entity } from "@oasis-engine/core";
 import { BoolUpdateFlag } from "@oasis-engine/core/types/BoolUpdateFlag";
 import { GLTFResource } from "../gltf/GLTFResource";
 
@@ -165,7 +165,7 @@ export class GLTFModel extends Component {
         this._animator.play(playStateName, 0);
       }
     } else {
-       // @ts-ignore
+      // @ts-ignore
       this._animator._reset();
     }
     if (this._controllerUpdateFlag?.flag) {
@@ -185,7 +185,7 @@ export class GLTFModel extends Component {
         if (defaultStateName) {
           animator.play(defaultStateName, i);
         } else {
-           // @ts-ignore
+          // @ts-ignore
           animator._reset();
         }
         if (this._controllerUpdateFlag?.flag) {

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -13,8 +13,5 @@
   "files": [
     "dist/**/*",
     "types/**/*"
-  ],
-  "devDependencies": {
-    "@oasis-engine/design": "0.7.0-beta.0"
-  }
+  ]
 }

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/math",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -15,6 +15,6 @@
     "types/**/*"
   ],
   "devDependencies": {
-    "@oasis-engine/design": "0.6.7"
+    "@oasis-engine/design": "0.7.0-beta.0"
   }
 }

--- a/packages/oasis-engine/package.json
+++ b/packages/oasis-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oasis-engine",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "scripts": {
     "b:types": "tsc"
@@ -14,9 +14,9 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/core": "0.6.7",
-    "@oasis-engine/loader": "0.6.7",
-    "@oasis-engine/math": "0.6.7",
-    "@oasis-engine/rhi-webgl": "0.6.7"
+    "@oasis-engine/core": "0.7.0-beta.0",
+    "@oasis-engine/loader": "0.7.0-beta.0",
+    "@oasis-engine/math": "0.7.0-beta.0",
+    "@oasis-engine/rhi-webgl": "0.7.0-beta.0"
   }
 }

--- a/packages/physics-lite/package.json
+++ b/packages/physics-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/physics-lite",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -15,8 +15,8 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/design": "0.6.7",
-    "oasis-engine": "0.6.7"
+    "@oasis-engine/design": "0.7.0-beta.0",
+    "oasis-engine": "0.7.0-beta.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/physics-physx",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -15,8 +15,8 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/design": "0.6.7",
-    "oasis-engine": "0.6.7"
+    "@oasis-engine/design": "0.7.0-beta.0",
+    "oasis-engine": "0.7.0-beta.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rhi-webgl/package.json
+++ b/packages/rhi-webgl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/rhi-webgl",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/main.js",
   "module": "dist/module.js",
@@ -14,10 +14,10 @@
     "types/**/*"
   ],
   "dependencies": {
-    "@oasis-engine/core": "0.6.7",
-    "@oasis-engine/math": "0.6.7"
+    "@oasis-engine/core": "0.7.0-beta.0",
+    "@oasis-engine/math": "0.7.0-beta.0"
   },
   "devDependencies": {
-    "@oasis-engine/design": "0.6.7"
+    "@oasis-engine/design": "0.7.0-beta.0"
   }
 }

--- a/packages/rhi-webgl/src/GLCapability.ts
+++ b/packages/rhi-webgl/src/GLCapability.ts
@@ -15,6 +15,10 @@ export class GLCapability {
   _rhi: WebGLRenderer;
   capabilityList: Map<GLCapabilityType, boolean>;
 
+  get maxTextureSize(): boolean {
+    return this.rhi.renderStates.getParameter(this.rhi.gl.MAX_TEXTURE_SIZE);
+  }
+
   get canUseFloatTextureBlendShape(): boolean {
     return (
       this.canIUse(GLCapabilityType.shaderVertexID) &&

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -16,9 +16,6 @@ import { WebGLRenderer } from "./WebGLRenderer";
  */
 export class GLTexture implements IPlatformTexture {
   /** @internal */
-  static _readFrameBuffer: WebGLFramebuffer = null;
-
-  /** @internal */
   static _isPowerOf2(v: number): boolean {
     return (v & (v - 1)) === 0;
   }
@@ -514,11 +511,7 @@ export class GLTexture implements IPlatformTexture {
     const gl = this._gl;
     const { baseFormat, dataType } = this._formatDetail;
 
-    if (!GLTexture._readFrameBuffer) {
-      GLTexture._readFrameBuffer = gl.createFramebuffer();
-    }
-
-    gl.bindFramebuffer(gl.FRAMEBUFFER, GLTexture._readFrameBuffer);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this._getReadFrameBuffer());
 
     if (mipLevel > 0 && !this._isWebGL2) {
       mipLevel = 0;
@@ -569,5 +562,13 @@ export class GLTexture implements IPlatformTexture {
         gl.texParameteri(target, pname, gl.MIRRORED_REPEAT);
         break;
     }
+  }
+
+  protected _getReadFrameBuffer(): WebGLFramebuffer {
+    let frameBuffer = this._rhi._readFrameBuffer;
+    if (!frameBuffer) {
+      this._rhi._readFrameBuffer = frameBuffer = this._gl.createFramebuffer();
+    }
+    return frameBuffer;
   }
 }

--- a/packages/rhi-webgl/src/GLTexture2D.ts
+++ b/packages/rhi-webgl/src/GLTexture2D.ts
@@ -41,8 +41,8 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
   setPixelBuffer(
     colorBuffer: ArrayBufferView,
     mipLevel: number = 0,
-    x?: number,
-    y?: number,
+    x: number,
+    y: number,
     width?: number,
     height?: number
   ): void {
@@ -52,8 +52,6 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
     const mipWidth = Math.max(1, this._texture.width >> mipLevel);
     const mipHeight = Math.max(1, this._texture.height >> mipLevel);
 
-    x = x || 0;
-    y = y || 0;
     width = width || mipWidth - x;
     height = height || mipHeight - y;
 
@@ -80,11 +78,11 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
    */
   setImageSource(
     imageSource: TexImageSource,
-    mipLevel: number = 0,
-    flipY: boolean = false,
-    premultiplyAlpha: boolean = false,
-    x?: number,
-    y?: number
+    mipLevel: number,
+    flipY: boolean,
+    premultiplyAlpha: boolean,
+    x: number,
+    y: number
   ): void {
     const gl = this._gl;
     const { baseFormat, dataType } = this._formatDetail;

--- a/packages/rhi-webgl/src/GLTexture2D.ts
+++ b/packages/rhi-webgl/src/GLTexture2D.ts
@@ -6,14 +6,9 @@ import { WebGLRenderer } from "./WebGLRenderer";
  * Texture 2d in WebGL platform.
  */
 export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
-  /**
-   * Backward compatible with WebGL1.0.
-   */
+  /** Backward compatible with WebGL1.0. */
   private _compressedMipFilled: number = 0;
 
-  /**
-   * Create texture2D in WebGL platform.
-   */
   constructor(rhi: WebGLRenderer, texture2D: Texture2D) {
     super(rhi, texture2D, rhi.gl.TEXTURE_2D);
 
@@ -41,14 +36,7 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
   }
 
   /**
-   * Setting pixels data through color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
-   * @remarks If it is the WebGL1.0 platform and the texture format is compressed, the first upload must be filled with textures.
-   * @param colorBuffer - Color buffer data
-   * @param mipLevel - Texture mipmapping level
-   * @param x - X coordinate of area start
-   * @param y - Y coordinate of area start
-   * @param width - Data width. if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
-   * @param height - Data height. if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   * {@inheritDoc IPlatformTexture2D.setPixelBuffer}
    */
   setPixelBuffer(
     colorBuffer: ArrayBufferView,
@@ -88,13 +76,7 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
   }
 
   /**
-   * Setting pixels data through TexImageSource, designated area and texture mipmapping level.
-   * @param imageSource - The source of texture
-   * @param mipLevel - Texture mipmapping level
-   * @param flipY - Whether to flip the Y axis
-   * @param premultiplyAlpha - Whether to premultiply the transparent channel
-   * @param x - X coordinate of area start
-   * @param y - Y coordinate of area start
+   * {@inheritDoc IPlatformTexture2D.setImageSource}
    */
   setImageSource(
     imageSource: TexImageSource,
@@ -114,13 +96,7 @@ export class GLTexture2D extends GLTexture implements IPlatformTexture2D {
   }
 
   /**
-   * Get the pixel color buffer according to the specified area.
-   * @param x - X coordinate of area start
-   * @param y - Y coordinate of area start
-   * @param width - Area width
-   * @param height - Area height
-   * @param mipLevel - Set mip level the data want to get from
-   * @param out - Color buffer
+   * {@inheritDoc IPlatformTexture2D.getPixelBuffer }
    */
   getPixelBuffer(x: number, y: number, width: number, height: number, mipLevel: number, out: ArrayBufferView): void {
     if (this._formatDetail.isCompressed) {

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -9,7 +9,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
   constructor(rhi: WebGLRenderer, texture2DArray: Texture2DArray) {
     super(rhi, texture2DArray, (<WebGL2RenderingContext>rhi.gl).TEXTURE_2D_ARRAY);
 
-    const { format, width, height, depth, mipmapCount } = texture2DArray;
+    const { format, width, height, length, mipmapCount } = texture2DArray;
 
     if (!this._isWebGL2) {
       throw new Error(`Texture2D Array is not supported in WebGL1.0`);
@@ -20,7 +20,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
     }
 
     this._formatDetail = GLTexture._getFormatDetail(format, this._gl, true);
-    this._gl.texStorage3D(this._target, mipmapCount, this._formatDetail.internalFormat, width, height, depth);
+    this._gl.texStorage3D(this._target, mipmapCount, this._formatDetail.internalFormat, width, height, length);
   }
 
   /**

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -19,6 +19,7 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
       throw new Error(`Texture format is not supported:${TextureFormat[format]}`);
     }
 
+    this._bind();
     this._formatDetail = GLTexture._getFormatDetail(format, this._gl, true);
     this._gl.texStorage3D(this._target, mipmapCount, this._formatDetail.internalFormat, width, height, length);
   }

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -27,28 +27,41 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
    * {@inheritDoc IPlatformTexture2DArray.setPixelBuffer}
    */
   setPixelBuffer(
-    elementIndex: number,
+    offsetIndex: number,
     colorBuffer: ArrayBufferView,
-    mipLevel: number = 0,
-    x: number = 0,
-    y: number = 0,
+    mipLevel: number,
+    x: number,
+    y: number,
     width?: number,
-    height?: number
+    height?: number,
+    length?: number
   ): void {
     const { _target: target, _gl: gl } = this;
     const { internalFormat, baseFormat, dataType, isCompressed } = this._formatDetail;
 
     width = width || Math.max(1, this._texture.width >> mipLevel) - x;
     height = height || Math.max(1, this._texture.height >> mipLevel) - y;
+    length = length || (<Texture2DArray>this._texture).length;
 
     this._bind();
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
     gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
 
     if (isCompressed) {
-      gl.compressedTexSubImage3D(target, mipLevel, x, y, elementIndex, width, height, 1, internalFormat, colorBuffer);
+      gl.compressedTexSubImage3D(
+        target,
+        mipLevel,
+        x,
+        y,
+        offsetIndex,
+        width,
+        height,
+        length,
+        internalFormat,
+        colorBuffer
+      );
     } else {
-      gl.texSubImage3D(target, mipLevel, x, y, elementIndex, width, height, 1, baseFormat, dataType, colorBuffer);
+      gl.texSubImage3D(target, mipLevel, x, y, offsetIndex, width, height, length, baseFormat, dataType, colorBuffer);
     }
   }
 

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -3,7 +3,7 @@ import { GLTexture } from "./GLTexture";
 import { WebGLRenderer } from "./WebGLRenderer";
 
 /**
- * Texture 2D in WebGL platform.
+ * Texture 2D array in WebGL platform.
  */
 export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArray {
   constructor(rhi: WebGLRenderer, texture2DArray: Texture2DArray) {
@@ -58,11 +58,11 @@ export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArr
   setImageSource(
     elementIndex: number,
     imageSource: TexImageSource,
-    mipLevel: number = 0,
-    flipY: boolean = false,
-    premultiplyAlpha: boolean = false,
-    x: number = 0,
-    y: number = 0
+    mipLevel: number,
+    flipY: boolean,
+    premultiplyAlpha: boolean,
+    x: number,
+    y: number
   ): void {
     const gl = this._gl;
     const { baseFormat, dataType } = this._formatDetail;

--- a/packages/rhi-webgl/src/GLTexture2DArray.ts
+++ b/packages/rhi-webgl/src/GLTexture2DArray.ts
@@ -1,0 +1,111 @@
+import { IPlatformTexture2DArray, Texture2DArray, TextureFormat } from "@oasis-engine/core";
+import { GLTexture } from "./GLTexture";
+import { WebGLRenderer } from "./WebGLRenderer";
+
+/**
+ * Texture 2D in WebGL platform.
+ */
+export class GLTexture2DArray extends GLTexture implements IPlatformTexture2DArray {
+  constructor(rhi: WebGLRenderer, texture2DArray: Texture2DArray) {
+    super(rhi, texture2DArray, (<WebGL2RenderingContext>rhi.gl).TEXTURE_2D_ARRAY);
+
+    const { format, width, height, depth, mipmapCount } = texture2DArray;
+
+    if (!this._isWebGL2) {
+      throw new Error(`Texture2D Array is not supported in WebGL1.0`);
+    }
+
+    if (!GLTexture._supportTextureFormat(format, rhi)) {
+      throw new Error(`Texture format is not supported:${TextureFormat[format]}`);
+    }
+
+    this._formatDetail = GLTexture._getFormatDetail(format, this._gl, true);
+    this._gl.texStorage3D(this._target, mipmapCount, this._formatDetail.internalFormat, width, height, depth);
+  }
+
+  /**
+   * {@inheritDoc IPlatformTexture2DArray.setPixelBuffer}
+   */
+  setPixelBuffer(
+    elementIndex: number,
+    colorBuffer: ArrayBufferView,
+    mipLevel: number = 0,
+    x: number = 0,
+    y: number = 0,
+    width?: number,
+    height?: number
+  ): void {
+    const { _target: target, _gl: gl } = this;
+    const { internalFormat, baseFormat, dataType, isCompressed } = this._formatDetail;
+
+    width = width || Math.max(1, this._texture.width >> mipLevel) - x;
+    height = height || Math.max(1, this._texture.height >> mipLevel) - y;
+
+    this._bind();
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
+
+    if (isCompressed) {
+      gl.compressedTexSubImage3D(target, mipLevel, x, y, elementIndex, width, height, 1, internalFormat, colorBuffer);
+    } else {
+      gl.texSubImage3D(target, mipLevel, x, y, elementIndex, width, height, 1, baseFormat, dataType, colorBuffer);
+    }
+  }
+
+  /**
+   * {@inheritDoc IPlatformTexture2DArray.setImageSource}
+   */
+  setImageSource(
+    elementIndex: number,
+    imageSource: TexImageSource,
+    mipLevel: number = 0,
+    flipY: boolean = false,
+    premultiplyAlpha: boolean = false,
+    x: number = 0,
+    y: number = 0
+  ): void {
+    const gl = this._gl;
+    const { baseFormat, dataType } = this._formatDetail;
+
+    this._bind();
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, +flipY);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, +premultiplyAlpha);
+    gl.texSubImage3D(
+      this._target,
+      mipLevel,
+      x,
+      y,
+      elementIndex,
+      imageSource.width,
+      imageSource.height,
+      1,
+      baseFormat,
+      dataType,
+      imageSource
+    );
+  }
+
+  /**
+   * {@inheritDoc IPlatformTexture2DArray.getPixelBuffer}
+   */
+  getPixelBuffer(
+    elementIndex: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    mipLevel: number,
+    out: ArrayBufferView
+  ): void {
+    const { _gl: gl, _formatDetail: formatDetail } = this;
+
+    if (formatDetail.isCompressed) {
+      throw new Error("Unable to read compressed texture");
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this._getReadFrameBuffer());
+    gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, this._glTexture, mipLevel, elementIndex);
+    gl.readPixels(x, y, width, height, formatDetail.baseFormat, formatDetail.dataType, out);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  }
+}

--- a/packages/rhi-webgl/src/GLTextureCube.ts
+++ b/packages/rhi-webgl/src/GLTextureCube.ts
@@ -41,9 +41,9 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
   setPixelBuffer(
     face: TextureCubeFace,
     colorBuffer: ArrayBufferView,
-    mipLevel: number = 0,
-    x?: number,
-    y?: number,
+    mipLevel: number,
+    x: number,
+    y: number,
     width?: number,
     height?: number
   ): void {
@@ -52,8 +52,6 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
     const { internalFormat, baseFormat, dataType, isCompressed } = this._formatDetail;
     const mipSize = Math.max(1, this._texture.width >> mipLevel);
 
-    x = x || 0;
-    y = y || 0;
     width = width || mipSize - x;
     height = height || mipSize - y;
 
@@ -108,11 +106,11 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
   setImageSource(
     face: TextureCubeFace,
     imageSource: TexImageSource,
-    mipLevel: number = 0,
-    flipY: boolean = false,
-    premultiplyAlpha: boolean = false,
-    x?: number,
-    y?: number
+    mipLevel: number,
+    flipY: boolean,
+    premultiplyAlpha: boolean,
+    x: number,
+    y: number
   ): void {
     const gl = this._gl;
     const { baseFormat, dataType } = this._formatDetail;

--- a/packages/rhi-webgl/src/GLTextureCube.ts
+++ b/packages/rhi-webgl/src/GLTextureCube.ts
@@ -1,4 +1,4 @@
-import { IPlatformTextureCube, Logger, TextureCubeFace, TextureCube, TextureFormat } from "@oasis-engine/core";
+import { IPlatformTextureCube, Logger, TextureCube, TextureCubeFace, TextureFormat } from "@oasis-engine/core";
 import { GLTexture } from "./GLTexture";
 import { WebGLRenderer } from "./WebGLRenderer";
 
@@ -6,14 +6,9 @@ import { WebGLRenderer } from "./WebGLRenderer";
  * Cube texture in WebGL platform.
  */
 export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
-  /**
-   * Backward compatible with WebGL1.0.。
-   */
+  /** Backward compatible with WebGL1.0. */
   private _compressedFaceFilled: number[] = [0, 0, 0, 0, 0, 0];
 
-  /**
-   * Create cube texture in WebGL platform.
-   */
   constructor(rhi: WebGLRenderer, textureCube: TextureCube) {
     super(rhi, textureCube, rhi.gl.TEXTURE_CUBE_MAP);
 
@@ -41,15 +36,7 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
   }
 
   /**
-   * Setting pixels data through cube face,color buffer data, designated area and texture mipmapping level,it's also applicable to compressed formats.
-   * @remarks When compressed texture is in WebGL1, the texture must be filled first before writing the sub-region
-   * @param face - Cube face
-   * @param colorBuffer - Color buffer data
-   * @param mipLevel - Texture mipmapping level
-   * @param x - X coordinate of area start
-   * @param y -  Y coordinate of area start
-   * @param width - Data width.if it's empty, width is the width corresponding to mipLevel minus x , width corresponding to mipLevel is Math.max(1, this.width >> mipLevel)
-   * @param height - Data height.if it's empty, height is the height corresponding to mipLevel minus y , height corresponding to mipLevel is Math.max(1, this.height >> mipLevel)
+   * {@inheritDoc IPlatformTextureCube.setPixelBuffer}
    */
   setPixelBuffer(
     face: TextureCubeFace,
@@ -116,14 +103,7 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
   }
 
   /**
-   * Setting pixels data through cube face, TexImageSource, designated area and texture mipmapping level.
-   * @param face - Cube face
-   * @param imageSource - The source of texture
-   * @param mipLevel - Texture mipmapping level
-   * @param flipY - Whether to flip the Y axis
-   * @param premultiplyAlpha - Whether to premultiply the transparent channel
-   * @param x - X coordinate of area start
-   * @param y - Y coordinate of area start
+   * {@inheritDoc IPlatformTextureCube.setImageSource}
    */
   setImageSource(
     face: TextureCubeFace,
@@ -153,14 +133,7 @@ export class GLTextureCube extends GLTexture implements IPlatformTextureCube {
   }
 
   /**
-   * Get the pixel color buffer according to the specified cube face and area.
-   * @param face - You can choose which cube face to read
-   * @param x - X coordinate of area start
-   * @param y - Y coordinate of area start
-   * @param width - Area width
-   * @param height - Area height
-   * @param mipLevel - Set mip level the data want to get from
-   * @param out - Color buffer
+   * {@inheritDoc IPlatformTextureCube.getPixelBuffer}
    */
   getPixelBuffer(
     face: TextureCubeFace,

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -14,6 +14,7 @@ import {
   RenderTarget,
   SubMesh,
   Texture2D,
+  Texture2DArray,
   TextureCube
 } from "@oasis-engine/core";
 import { IPlatformPrimitive } from "@oasis-engine/design";
@@ -25,6 +26,7 @@ import { GLRenderStates } from "./GLRenderStates";
 import { GLRenderTarget } from "./GLRenderTarget";
 import { GLTexture } from "./GLTexture";
 import { GLTexture2D } from "./GLTexture2D";
+import { GLTexture2DArray } from "./GLTexture2DArray";
 import { GLTextureCube } from "./GLTextureCube";
 import { WebGLExtension } from "./type";
 import { WebCanvas } from "./WebCanvas";
@@ -153,6 +155,10 @@ export class WebGLRenderer implements IHardwareRenderer {
 
   createPlatformTexture2D(texture2D: Texture2D): IPlatformTexture2D {
     return new GLTexture2D(this, texture2D);
+  }
+
+  createPlatformTexture2DArray(texture2D: Texture2DArray): GLTexture2DArray {
+    return new GLTexture2DArray(this, texture2D);
   }
 
   createPlatformTextureCube(textureCube: TextureCube): IPlatformTextureCube {

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -53,6 +53,9 @@ export interface WebGLRendererOptions extends WebGLContextAttributes {
  * WebGL renderer, including WebGL1.0 and WebGL2.0.
  */
 export class WebGLRenderer implements IHardwareRenderer {
+  /** @internal */
+  _readFrameBuffer: WebGLFramebuffer;
+
   _currentBind: any;
 
   private _options: WebGLRendererOptions;

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/stats",
-  "version": "0.6.7",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "scripts": {
     "b:types": "tsc"
@@ -14,6 +14,6 @@
     "types/**/*"
   ],
   "dependencies": {
-    "oasis-engine": "0.6.7"
+    "oasis-engine": "0.7.0-beta.0"
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

This PR mainly include:
- Use `float texture mode` when `BlendShape` count is limit by GPU attribute count
- When there are no normals and tangents, the number of `attribute mode` support is increased to 8

Else:
- Add `Texture2DArraty` 
- Unified texture name, rename `TextureCubeMap` to `TextureCube`
- Add `ListenerUpdateFlag` and rename `UpdateFlag` to `BoolUpdateFlag`