### PR TITLE
fix:  fix the order of layerState when AnimatorStatePlayState.Finished

### DIFF
--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -482,7 +482,6 @@ export class Animator extends Component {
     }
     if (playState === AnimatorStatePlayState.Finished) {
       this._callAnimatorScriptOnExit(state, layerIndex);
-      return;
     } else {
       this._callAnimatorScriptOnUpdate(state, layerIndex);
     }

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -473,11 +473,16 @@ export class Animator extends Component {
 
     eventHandlers.length && this._fireAnimationEvents(playData, eventHandlers, lastClipTime, clipTime);
 
+    if (playState === AnimatorStatePlayState.Finished) {
+      layerData.layerState = LayerState.Standby;
+    }
+
     if (lastPlayState === AnimatorStatePlayState.UnStarted) {
       this._callAnimatorScriptOnEnter(state, layerIndex);
     }
     if (playState === AnimatorStatePlayState.Finished) {
       this._callAnimatorScriptOnExit(state, layerIndex);
+      return;
     } else {
       this._callAnimatorScriptOnUpdate(state, layerIndex);
     }
@@ -492,10 +497,6 @@ export class Animator extends Component {
       }
     }
     playData.frameTime += state.speed * delta;
-
-    if (playState === AnimatorStatePlayState.Finished) {
-      layerData.layerState = LayerState.Standby;
-    }
   }
 
   private _updateCrossFade(

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -473,6 +473,18 @@ export class Animator extends Component {
 
     eventHandlers.length && this._fireAnimationEvents(playData, eventHandlers, lastClipTime, clipTime);
 
+    for (let i = curves.length - 1; i >= 0; i--) {
+      const owner = curveOwners[i];
+      const value = this._evaluateCurve(owner.property, curves[i].curve, clipTime, additive);
+      if (additive) {
+        this._applyClipValueAdditive(owner, value, weight);
+      } else {
+        this._applyClipValue(owner, value, weight);
+      }
+    }
+    playData.frameTime += state.speed * delta;
+
+
     if (playState === AnimatorStatePlayState.Finished) {
       layerData.layerState = LayerState.Standby;
     }
@@ -485,17 +497,6 @@ export class Animator extends Component {
     } else {
       this._callAnimatorScriptOnUpdate(state, layerIndex);
     }
-
-    for (let i = curves.length - 1; i >= 0; i--) {
-      const owner = curveOwners[i];
-      const value = this._evaluateCurve(owner.property, curves[i].curve, clipTime, additive);
-      if (additive) {
-        this._applyClipValueAdditive(owner, value, weight);
-      } else {
-        this._applyClipValue(owner, value, weight);
-      }
-    }
-    playData.frameTime += state.speed * delta;
   }
 
   private _updateCrossFade(

--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -484,7 +484,6 @@ export class Animator extends Component {
     }
     playData.frameTime += state.speed * delta;
 
-
     if (playState === AnimatorStatePlayState.Finished) {
       layerData.layerState = LayerState.Standby;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information: