### PR TITLE
Improve ShaderData Macro feature

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export { BackgroundMode } from "./enums/BackgroundMode";
 export { CameraClearFlags } from "./enums/CameraClearFlags";
 export { ColorSpace } from "./enums/ColorSpace";
 export { BackgroundTextureFillMode } from "./enums/BackgroundTextureFillMode";
+export { BoolUpdateFlag } from "./BoolUpdateFlag";
 export * from "./input/index";
 export * from "./lighting/index";
 export * from "./material/index";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,6 @@ export { BackgroundMode } from "./enums/BackgroundMode";
 export { CameraClearFlags } from "./enums/CameraClearFlags";
 export { ColorSpace } from "./enums/ColorSpace";
 export { BackgroundTextureFillMode } from "./enums/BackgroundTextureFillMode";
-export { BoolUpdateFlag } from "./BoolUpdateFlag";
 export * from "./input/index";
 export * from "./lighting/index";
 export * from "./material/index";

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -49,20 +49,32 @@ export class Shader {
    * @param name - Name of the shader macro
    * @returns Shader macro
    */
-  static getMacroByName(name: string): ShaderMacro {
-    let macro = Shader._macroMap[name];
+  static getMacroByName(name: string): ShaderMacro;
+
+  /**
+   * Get shader macro by name.
+   * @param name - Name of the shader macro
+   * @param value - Value of the shader macro
+   * @returns Shader macro
+   */
+  static getMacroByName(name: string, value: string): ShaderMacro;
+
+  static getMacroByName(name: string, value?: string): ShaderMacro {
+    const key = value ? name + ` ` + value : name;
+    let macro = Shader._macroMap[key];
     if (!macro) {
       const maskMap = Shader._macroMaskMap;
       const counter = Shader._macroCounter;
       const index = Math.floor(counter / 32);
       const bit = counter % 32;
-      macro = new ShaderMacro(name, index, 1 << bit);
-      Shader._macroMap[name] = macro;
+
+      macro = new ShaderMacro(name, index, 1 << bit, value);
+      Shader._macroMap[key] = macro;
       if (index == maskMap.length) {
         maskMap.length++;
         maskMap[index] = new Array<string>(32);
       }
-      maskMap[index][bit] = name;
+      maskMap[index][bit] = key;
       Shader._macroCounter++;
     }
     return macro;

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -68,7 +68,7 @@ export class Shader {
       const index = Math.floor(counter / 32);
       const bit = counter % 32;
 
-      macro = new ShaderMacro(name, index, 1 << bit, value);
+      macro = new ShaderMacro(name, value, index, 1 << bit);
       Shader._macroMap[key] = macro;
       if (index == maskMap.length) {
         maskMap.length++;

--- a/packages/core/src/shader/ShaderData.ts
+++ b/packages/core/src/shader/ShaderData.ts
@@ -498,7 +498,7 @@ export class ShaderData implements IRefObject, IClone {
     if (typeof macro === "string") {
       macro = Shader.getMacroByName(macro, value);
     }
-    const nameID = macro._nameID;
+    const nameID = macro._nameId;
     const lastMacro = this._macroMap[nameID];
     if (lastMacro !== macro) {
       const macroCollection = this._macroCollection;
@@ -523,12 +523,12 @@ export class ShaderData implements IRefObject, IClone {
   disableMacro(macro: string | ShaderMacro): void {
     let nameID: number;
     if (typeof macro === "string") {
-      nameID = ShaderMacro._macroNameIDMap[macro];
+      nameID = ShaderMacro._macroNameIdMap[macro];
       if (nameID === undefined) {
         return;
       }
     } else {
-      nameID = macro._nameID;
+      nameID = macro._nameId;
     }
 
     const currentMacro = this._macroMap[nameID];

--- a/packages/core/src/shader/ShaderData.ts
+++ b/packages/core/src/shader/ShaderData.ts
@@ -31,10 +31,16 @@ export class ShaderData implements IRefObject, IClone {
   _properties: Record<number, ShaderPropertyValueType> = Object.create(null);
   /** @internal */
   _macroCollection: ShaderMacroCollection = new ShaderMacroCollection();
-  
 
-  private _variableMacros: Record<string, string> = Object.create(null);
+  private _macroMap: Record<number, ShaderMacro> = Object.create(null);
   private _refCount: number = 0;
+
+  /**
+   * Shader macro array that are currently enabled for ShaderData.
+   */
+  get macros(): ShaderMacro[] {
+    return Object.values(this._macroMap);
+  }
 
   /**
    * @internal
@@ -476,33 +482,36 @@ export class ShaderData implements IRefObject, IClone {
   }
 
   /**
-   * Enable macro.
+   * Enable macro with name.
    * @param macroName - Macro name
    */
   enableMacro(macroName: string): void;
 
   /**
-   * Enable macro.
-   * @param macro - Shader macro
-   */
-  enableMacro(macro: ShaderMacro): void;
-
-  /**
-   * Enable macro.
-   * @remarks Name and value will combine one macro, it's equal the macro of "name value".
+   * Enable macro with name and value.
+   * @remarks Name and value will combine, it's equal the macro of "name value".
    * @param name - Macro name
    * @param value - Macro value
    */
   enableMacro(name: string, value: string): void;
 
-  enableMacro(macro: string | ShaderMacro, value: string = null): void {
-    if (value) {
-      this._enableVariableMacro(<string>macro, value);
-    } else {
-      if (typeof macro === "string") {
-        macro = Shader.getMacroByName(macro);
-      }
-      this._macroCollection.enable(macro);
+  /**
+   * Enable macro with shaderMacro.
+   * @param macro - Shader macro
+   */
+  enableMacro(macro: ShaderMacro): void;
+
+  enableMacro(macro: string | ShaderMacro, value?: string): void {
+    if (typeof macro === "string") {
+      macro = Shader.getMacroByName(macro, value);
+    }
+    const nameID = macro._nameID;
+    const lastMacro = this._macroMap[nameID];
+    if (lastMacro !== macro) {
+      const macroCollection = this._macroCollection;
+      lastMacro && macroCollection.disable(lastMacro);
+      macroCollection.enable(macro);
+      this._macroMap[nameID] = macro;
     }
   }
 
@@ -519,17 +528,20 @@ export class ShaderData implements IRefObject, IClone {
   disableMacro(macro: ShaderMacro): void;
 
   disableMacro(macro: string | ShaderMacro): void {
+    let nameID: number;
     if (typeof macro === "string") {
-      // @todo: should optimization variable macros disable performance
-      const variableValue = this._variableMacros[macro];
-      if (variableValue) {
-        this._disableVariableMacro(macro, variableValue);
-      } else {
-        macro = Shader.getMacroByName(macro);
-        this._macroCollection.disable(macro);
+      nameID = ShaderMacro._macroNameIDMap[macro];
+      if (nameID === undefined) {
+        return;
       }
     } else {
-      this._macroCollection.disable(macro);
+      nameID = macro._nameID;
+    }
+
+    const currentMacro = this._macroMap[nameID];
+    if (currentMacro) {
+      this._macroCollection.disable(currentMacro);
+      delete this._macroMap[nameID];
     }
   }
 
@@ -541,7 +553,7 @@ export class ShaderData implements IRefObject, IClone {
 
   cloneTo(target: ShaderData): void {
     CloneManager.deepCloneObject(this._macroCollection, target._macroCollection);
-    Object.assign(target._variableMacros, this._variableMacros);
+    Object.assign(target._macroMap, this._macroMap);
 
     const properties = this._properties;
     const targetProperties = target._properties;
@@ -619,23 +631,5 @@ export class ShaderData implements IRefObject, IClone {
         property._addRefCount(value);
       }
     }
-  }
-
-  private _enableVariableMacro(name: string, value: string): void {
-    const variableMacro = this._variableMacros;
-    const variableValue = variableMacro[name];
-    if (variableValue !== value) {
-      variableValue && this._disableVariableMacro(name, variableValue);
-
-      const macro = Shader.getMacroByName(`${name} ${value}`);
-      this._macroCollection.enable(macro);
-      variableMacro[name] = value;
-    }
-  }
-
-  private _disableVariableMacro(name: string, value: string): void {
-    const oldMacro = Shader.getMacroByName(`${name} ${value}`);
-    this._macroCollection.disable(oldMacro);
-    delete this._variableMacros[name];
   }
 }

--- a/packages/core/src/shader/ShaderData.ts
+++ b/packages/core/src/shader/ShaderData.ts
@@ -36,13 +36,6 @@ export class ShaderData implements IRefObject, IClone {
   private _refCount: number = 0;
 
   /**
-   * Shader macro array that are currently enabled for ShaderData.
-   */
-  get macros(): ShaderMacro[] {
-    return Object.values(this._macroMap);
-  }
-
-  /**
    * @internal
    */
   constructor(group: ShaderDataGroup) {
@@ -516,13 +509,13 @@ export class ShaderData implements IRefObject, IClone {
   }
 
   /**
-   * Disable macro
+   * Disable macro.
    * @param macroName - Macro name
    */
   disableMacro(macroName: string): void;
 
   /**
-   * Disable macro
+   * Disable macro.
    * @param macro - Shader macro
    */
   disableMacro(macro: ShaderMacro): void;
@@ -542,6 +535,28 @@ export class ShaderData implements IRefObject, IClone {
     if (currentMacro) {
       this._macroCollection.disable(currentMacro);
       delete this._macroMap[nameID];
+    }
+  }
+
+  /**
+   * Get shader macro array that are currently enabled for ShaderData.
+   */
+  getMacros(): ShaderMacro[];
+  /**
+   * Get shader macro array that are currently enabled for ShaderData.
+   * @param out - Shader macro array
+   */
+  getMacros(out: ShaderMacro[]): void;
+
+  getMacros(out?: ShaderMacro[]): ShaderMacro[] | void {
+    if (out) {
+      const macroMap = this._macroMap;
+      out.length = 0;
+      for (var key in macroMap) {
+        out.push(macroMap[key]);
+      }
+    } else {
+      return Object.values(this._macroMap);
     }
   }
 

--- a/packages/core/src/shader/ShaderMacro.ts
+++ b/packages/core/src/shader/ShaderMacro.ts
@@ -2,20 +2,37 @@
  * Shader macro。
  */
 export class ShaderMacro {
-  /** name */
-  readonly name: string;
+  /** @internal */
+  static _macroNameIDMap: Record<string, number> = Object.create(null);
 
+  private static _macroNameCounter: number = 0;
+
+  /** Name. */
+  readonly name: string;
+  /** Value. */
+  readonly value: string;
+
+  /** @internal */
+  _nameID: number;
   /** @internal */
   _index: number;
   /** @internal */
-  _value: number;
+  _maskValue: number;
 
   /**
    * @internal
    */
-  constructor(name: string, index: number, value: number) {
+  constructor(name: string, index: number, maskValue: number, value?: string) {
     this.name = name;
     this._index = index;
-    this._value = value;
+    this._maskValue = maskValue;
+    this.value = value;
+
+    const macroNameIDMap = ShaderMacro._macroNameIDMap;
+    let nameID = macroNameIDMap[name];
+    if (macroNameIDMap[name] === undefined) {
+      macroNameIDMap[name] = nameID = ShaderMacro._macroNameCounter++;
+    }
+    this._nameID = nameID;
   }
 }

--- a/packages/core/src/shader/ShaderMacro.ts
+++ b/packages/core/src/shader/ShaderMacro.ts
@@ -3,7 +3,7 @@
  */
 export class ShaderMacro {
   /** @internal */
-  static _macroNameIDMap: Record<string, number> = Object.create(null);
+  static _macroNameIdMap: Record<string, number> = Object.create(null);
 
   private static _macroNameCounter: number = 0;
 
@@ -13,7 +13,7 @@ export class ShaderMacro {
   readonly value: string;
 
   /** @internal */
-  _nameID: number;
+  _nameId: number;
   /** @internal */
   _maskIndex: number;
   /** @internal */
@@ -28,11 +28,11 @@ export class ShaderMacro {
     this._maskValue = maskValue;
     this.value = value;
 
-    const macroNameIDMap = ShaderMacro._macroNameIDMap;
+    const macroNameIDMap = ShaderMacro._macroNameIdMap;
     let nameID = macroNameIDMap[name];
     if (macroNameIDMap[name] === undefined) {
       macroNameIDMap[name] = nameID = ShaderMacro._macroNameCounter++;
     }
-    this._nameID = nameID;
+    this._nameId = nameID;
   }
 }

--- a/packages/core/src/shader/ShaderMacro.ts
+++ b/packages/core/src/shader/ShaderMacro.ts
@@ -15,7 +15,7 @@ export class ShaderMacro {
   /** @internal */
   _nameID: number;
   /** @internal */
-  _index: number;
+  _maskIndex: number;
   /** @internal */
   _maskValue: number;
 
@@ -24,7 +24,7 @@ export class ShaderMacro {
    */
   constructor(name: string, index: number, maskValue: number, value?: string) {
     this.name = name;
-    this._index = index;
+    this._maskIndex = index;
     this._maskValue = maskValue;
     this.value = value;
 

--- a/packages/core/src/shader/ShaderMacro.ts
+++ b/packages/core/src/shader/ShaderMacro.ts
@@ -22,9 +22,9 @@ export class ShaderMacro {
   /**
    * @internal
    */
-  constructor(name: string, value: string, index: number, maskValue: number) {
+  constructor(name: string, value: string, maskIndex: number, maskValue: number) {
     this.name = name;
-    this._maskIndex = index;
+    this._maskIndex = maskIndex;
     this._maskValue = maskValue;
     this.value = value;
 

--- a/packages/core/src/shader/ShaderMacro.ts
+++ b/packages/core/src/shader/ShaderMacro.ts
@@ -22,7 +22,7 @@ export class ShaderMacro {
   /**
    * @internal
    */
-  constructor(name: string, index: number, maskValue: number, value?: string) {
+  constructor(name: string, value: string, index: number, maskValue: number) {
     this.name = name;
     this._maskIndex = index;
     this._maskValue = maskValue;

--- a/packages/core/src/shader/ShaderMacroCollection.ts
+++ b/packages/core/src/shader/ShaderMacroCollection.ts
@@ -57,10 +57,10 @@ export class ShaderMacroCollection {
       for (; maskStart < index; maskStart++) {
         mask[maskStart] = 0;
       }
-      mask[index] = macro._value;
+      mask[index] = macro._maskValue;
       this._length = size;
     } else {
-      mask[index] |= macro._value;
+      mask[index] |= macro._maskValue;
     }
   }
 
@@ -75,7 +75,7 @@ export class ShaderMacroCollection {
     if (index > endIndex) {
       return;
     }
-    const newValue = mask[index] & ~macro._value;
+    const newValue = mask[index] & ~macro._maskValue;
     if (index == endIndex && newValue === 0) {
       this._length--;
     } else {
@@ -155,7 +155,7 @@ export class ShaderMacroCollection {
     if (index >= this._length) {
       return false;
     }
-    return (this._mask[index] & macro._value) !== 0;
+    return (this._mask[index] & macro._maskValue) !== 0;
   }
 
   /**

--- a/packages/core/src/shader/ShaderMacroCollection.ts
+++ b/packages/core/src/shader/ShaderMacroCollection.ts
@@ -48,7 +48,7 @@ export class ShaderMacroCollection {
    * @param macro - ShaderMacro
    */
   enable(macro: ShaderMacro): void {
-    const index = macro._index;
+    const index = macro._maskIndex;
     const size = index + 1;
     const mask = this._mask;
     let maskStart = this._length; // must from this._length because this._length maybe less than mask.length and have dirty data should clear.
@@ -69,7 +69,7 @@ export class ShaderMacroCollection {
    * @param macro - ShaderMacro
    */
   disable(macro: ShaderMacro): void {
-    const index = macro._index;
+    const index = macro._maskIndex;
     const mask = this._mask;
     const endIndex = this._length - 1;
     if (index > endIndex) {
@@ -151,7 +151,7 @@ export class ShaderMacroCollection {
    * @param macro - ShaderMacro
    */
   isEnable(macro: ShaderMacro): boolean {
-    const index = macro._index;
+    const index = macro._maskIndex;
     if (index >= this._length) {
       return false;
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

- Add instance method `getMacros()` method for ShaderData, developer can get current enabled macros list
- Add static method `getMacroByName(name: string, value: string)` for `Shader`,devleoper can cache `ShaderMacro` for    name + value macro
- Fix Bug when `enableMacro(name)`, then call `enableMacro(name,value)`