### PR TITLE
Fix `InputManager.isKeyHeldDown` bug

### DIFF
--- a/packages/core/src/input/InputManager.ts
+++ b/packages/core/src/input/InputManager.ts
@@ -40,7 +40,7 @@ export class InputManager {
     if (key === undefined) {
       return this._keyboardManager._curFrameHeldDownList.length > 0;
     } else {
-      return !!this._keyboardManager._curHeldDownKeyToIndexMap[key];
+      return this._keyboardManager._curHeldDownKeyToIndexMap[key] != null;
     }
   }
 


### PR DESCRIPTION
Because `!!0 = false`, the isKeyHeldDown interface returns an error.