### PR TITLE
Refactor `cloneTo` to `copyFrom` for math library and rename `setValue` to `set`

### DIFF
--- a/packages/core/src/2d/dynamic-atlas/DynamicTextAtlas.ts
+++ b/packages/core/src/2d/dynamic-atlas/DynamicTextAtlas.ts
@@ -65,7 +65,7 @@ export class DynamicTextAtlas {
 
     const { _width, _height } = this;
     const region = DynamicTextAtlas._region;
-    region.setValue(this._curX / _width, this._curY / _height, width / _width, height / _height);
+    region.set(this._curX / _width, this._curY / _height, width / _width, height / _height);
 
     // destroy origin texture.
     sprite.texture && sprite.texture.destroy();

--- a/packages/core/src/2d/sprite/Sprite.ts
+++ b/packages/core/src/2d/sprite/Sprite.ts
@@ -85,7 +85,7 @@ export class Sprite extends RefObject {
   set atlasRegion(value: Rect) {
     const x = MathUtil.clamp(value.x, 0, 1);
     const y = MathUtil.clamp(value.y, 0, 1);
-    this._atlasRegion.setValue(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
+    this._atlasRegion.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
     this._setDirtyFlagTrue(DirtyFlag.positions | DirtyFlag.uv);
   }
 
@@ -99,7 +99,7 @@ export class Sprite extends RefObject {
   set atlasRegionOffset(value: Vector4) {
     const x = MathUtil.clamp(value.x, 0, 1);
     const y = MathUtil.clamp(value.y, 0, 1);
-    this._atlasRegionOffset.setValue(x, y, MathUtil.clamp(value.z, 0, 1 - x), MathUtil.clamp(value.w, 0, 1 - y));
+    this._atlasRegionOffset.set(x, y, MathUtil.clamp(value.z, 0, 1 - x), MathUtil.clamp(value.w, 0, 1 - y));
     this._setDirtyFlagTrue(DirtyFlag.positions | DirtyFlag.uv);
   }
 
@@ -114,7 +114,7 @@ export class Sprite extends RefObject {
     const pivot = this._pivot;
     const { x, y } = value;
     if (pivot === value || pivot.x !== x || pivot.y !== y) {
-      pivot.setValue(x, y);
+      pivot.set(x, y);
       this._setDirtyFlagTrue(DirtyFlag.positions);
     }
   }
@@ -130,7 +130,7 @@ export class Sprite extends RefObject {
     const region = this._region;
     const x = MathUtil.clamp(value.x, 0, 1);
     const y = MathUtil.clamp(value.y, 0, 1);
-    region.setValue(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
+    region.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
     this._setDirtyFlagTrue(DirtyFlag.positions | DirtyFlag.uv);
   }
 
@@ -171,8 +171,8 @@ export class Sprite extends RefObject {
     this._texture = texture;
     this._pixelsPerUnit = pixelsPerUnit;
 
-    region && region.cloneTo(this._region);
-    pivot && pivot.cloneTo(this._pivot);
+    region && this._region.copyFrom(region);
+    pivot && this._pivot.copyFrom(pivot);
 
     this._triangles = Sprite._rectangleTriangles;
   }
@@ -192,8 +192,8 @@ export class Sprite extends RefObject {
     );
     cloneSprite._assetID = this._assetID;
     cloneSprite._atlasRotated = this._atlasRotated;
-    this._atlasRegion.cloneTo(cloneSprite._atlasRegion);
-    this._atlasRegionOffset.cloneTo(cloneSprite._atlasRegionOffset);
+    cloneSprite._atlasRegion.copyFrom(this._atlasRegion);
+    cloneSprite._atlasRegionOffset.copyFrom(this._atlasRegionOffset);
     return cloneSprite;
   }
 
@@ -237,21 +237,21 @@ export class Sprite extends RefObject {
       // Assign values ​​to _positions
       const positions = this._positions;
       // Top-left.
-      positions[0].setValue(left, top);
+      positions[0].set(left, top);
       // Top-right.
-      positions[1].setValue(right, top);
+      positions[1].set(right, top);
       // Bottom-right.
-      positions[2].setValue(right, bottom);
+      positions[2].set(right, bottom);
       // Bottom-left.
-      positions[3].setValue(left, bottom);
+      positions[3].set(left, bottom);
 
       // Update bounds.
-      bounds.min.setValue(left, bottom, 0);
-      bounds.max.setValue(right, top, 0);
+      bounds.min.set(left, bottom, 0);
+      bounds.max.set(right, top, 0);
     } else {
       // Update bounds.
-      bounds.min.setValue(0, 0, 0);
-      bounds.max.setValue(0, 0, 0);
+      bounds.min.set(0, 0, 0);
+      bounds.max.set(0, 0, 0);
     }
   }
 
@@ -278,13 +278,13 @@ export class Sprite extends RefObject {
       const right = atlasRegionW + atlasRegionX - Math.max(regionRight - offsetRight, 0) * realWidth;
       const bottom = atlasRegionH + atlasRegionY - Math.max(regionY - offsetBottom, 0) * realHeight;
       // Top-left.
-      uv[0].setValue(left, top);
+      uv[0].set(left, top);
       // Top-right.
-      uv[1].setValue(right, top);
+      uv[1].set(right, top);
       // Bottom-right.
-      uv[2].setValue(right, bottom);
+      uv[2].set(right, bottom);
       // Bottom-left.
-      uv[3].setValue(left, bottom);
+      uv[3].set(left, bottom);
     }
     this._setDirtyFlagFalse(DirtyFlag.all);
   }

--- a/packages/core/src/2d/sprite/SpriteMask.ts
+++ b/packages/core/src/2d/sprite/SpriteMask.ts
@@ -8,7 +8,6 @@ import { Renderer } from "../../Renderer";
 import { SpriteMaskElement } from "../../RenderPipeline/SpriteMaskElement";
 import { Shader } from "../../shader/Shader";
 import { ShaderProperty } from "../../shader/ShaderProperty";
-import { UpdateFlag } from "../../UpdateFlag";
 import { SpriteMaskLayer } from "../enums/SpriteMaskLayer";
 import { Sprite } from "./Sprite";
 
@@ -119,7 +118,7 @@ export class SpriteMask extends Renderer implements ICustomClone {
 
       for (let i = 0, n = positions.length; i < n; i++) {
         const curVertexPos = localPositions[i];
-        localVertexPos.setValue(curVertexPos.x, curVertexPos.y, 0);
+        localVertexPos.set(curVertexPos.x, curVertexPos.y, 0);
         Vector3.transformToVec3(localVertexPos, worldMatrix, positions[i]);
       }
 

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -8,7 +8,6 @@ import { Renderer } from "../../Renderer";
 import { CompareFunction } from "../../shader/enums/CompareFunction";
 import { Shader } from "../../shader/Shader";
 import { ShaderProperty } from "../../shader/ShaderProperty";
-import { UpdateFlag } from "../../UpdateFlag";
 import { SpriteMaskInteraction } from "../enums/SpriteMaskInteraction";
 import { SpriteMaskLayer } from "../enums/SpriteMaskLayer";
 import { Sprite } from "./Sprite";
@@ -19,7 +18,7 @@ import { Sprite } from "./Sprite";
 export class SpriteRenderer extends Renderer implements ICustomClone {
   /** @internal */
   static _textureProperty: ShaderProperty = Shader.getPropertyByName("u_spriteTexture");
-  
+
   private static _tempVec3: Vector3 = new Vector3();
 
   /** @internal temp solution. */
@@ -80,7 +79,7 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
 
   set color(value: Color) {
     if (this._color !== value) {
-      value.cloneTo(this._color);
+      this._color.copyFrom(value);
     }
   }
 
@@ -173,7 +172,7 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
 
       for (let i = 0, n = _positions.length; i < n; i++) {
         const curVertexPos = localPositions[i];
-        localVertexPos.setValue(flipX ? -curVertexPos.x : curVertexPos.x, flipY ? -curVertexPos.y : curVertexPos.y, 0);
+        localVertexPos.set(flipX ? -curVertexPos.x : curVertexPos.x, flipY ? -curVertexPos.y : curVertexPos.y, 0);
         Vector3.transformToVec3(localVertexPos, worldMatrix, _positions[i]);
       }
 
@@ -264,8 +263,8 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
         BoundingBox.transform(localBounds, worldMatrix, worldBounds);
       }
     } else {
-      worldBounds.min.setValue(0, 0, 0);
-      worldBounds.max.setValue(0, 0, 0);
+      worldBounds.min.set(0, 0, 0);
+      worldBounds.max.set(0, 0, 0);
     }
   }
 

--- a/packages/core/src/2d/text/TextRenderer.ts
+++ b/packages/core/src/2d/text/TextRenderer.ts
@@ -75,7 +75,7 @@ export class TextRenderer extends Renderer {
 
   set color(value: Color) {
     if (this._color !== value) {
-      value.cloneTo(this._color);
+      this._color.copyFrom(value);
     }
   }
 
@@ -446,7 +446,7 @@ export class TextRenderer extends Renderer {
     const { _positions } = this;
     for (let i = 0, n = _positions.length; i < n; i++) {
       const curVertexPos = localPositions[i];
-      localVertexPos.setValue(curVertexPos.x, curVertexPos.y, 0);
+      localVertexPos.set(curVertexPos.x, curVertexPos.y, 0);
       Vector3.transformToVec3(localVertexPos, worldMatrix, _positions[i]);
     }
   }

--- a/packages/core/src/Background.ts
+++ b/packages/core/src/Background.ts
@@ -92,24 +92,24 @@ export class Background {
 
     switch (this._textureFillMode) {
       case BackgroundTextureFillMode.Fill:
-        positions[0].setValue(-1, -1, 1);
-        positions[1].setValue(1, -1, 1);
-        positions[2].setValue(-1, 1, 1);
-        positions[3].setValue(1, 1, 1);
+        positions[0].set(-1, -1, 1);
+        positions[1].set(1, -1, 1);
+        positions[2].set(-1, 1, 1);
+        positions[3].set(1, 1, 1);
         break;
       case BackgroundTextureFillMode.AspectFitWidth:
         const fitWidthScale = (this._texture.height * width) / this.texture.width / height;
-        positions[0].setValue(-1, -fitWidthScale, 1);
-        positions[1].setValue(1, -fitWidthScale, 1);
-        positions[2].setValue(-1, fitWidthScale, 1);
-        positions[3].setValue(1, fitWidthScale, 1);
+        positions[0].set(-1, -fitWidthScale, 1);
+        positions[1].set(1, -fitWidthScale, 1);
+        positions[2].set(-1, fitWidthScale, 1);
+        positions[3].set(1, fitWidthScale, 1);
         break;
       case BackgroundTextureFillMode.AspectFitHeight:
         const fitHeightScale = (this._texture.width * height) / this.texture.height / width;
-        positions[0].setValue(-fitHeightScale, -1, 1);
-        positions[1].setValue(fitHeightScale, -1, 1);
-        positions[2].setValue(-fitHeightScale, 1, 1);
-        positions[3].setValue(fitHeightScale, 1, 1);
+        positions[0].set(-fitHeightScale, -1, 1);
+        positions[1].set(fitHeightScale, -1, 1);
+        positions[2].set(-fitHeightScale, 1, 1);
+        positions[3].set(fitHeightScale, 1, 1);
         break;
     }
     _backgroundTextureMesh.setPositions(positions);

--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -1,4 +1,4 @@
-import { BoundingFrustum, MathUtil, Matrix, Quaternion, Ray, Vector2, Vector3, Vector4 } from "@oasis-engine/math";
+import { BoundingFrustum, MathUtil, Matrix, Ray, Vector2, Vector3, Vector4 } from "@oasis-engine/math";
 import { Logger } from "./base";
 import { BoolUpdateFlag } from "./BoolUpdateFlag";
 import { deepClone, ignoreClone } from "./clone/CloneManager";
@@ -159,7 +159,7 @@ export class Camera extends Component {
 
   set viewport(value: Vector4) {
     if (value !== this._viewport) {
-      value.cloneTo(this._viewport);
+      this._viewport.copyFrom(value);
     }
     this._projMatChange();
   }
@@ -313,7 +313,7 @@ export class Camera extends Component {
     Vector3.transformToVec4(cameraPoint, this.projectionMatrix, viewportPoint);
 
     const w = viewportPoint.w;
-    out.setValue((viewportPoint.x / w + 1.0) * 0.5, (1.0 - viewportPoint.y / w) * 0.5, -cameraPoint.z);
+    out.set((viewportPoint.x / w + 1.0) * 0.5, (1.0 - viewportPoint.y / w) * 0.5, -cameraPoint.z);
     return out;
   }
 
@@ -494,7 +494,7 @@ export class Camera extends Component {
     // Depth is a normalized value, 0 is nearPlane, 1 is farClipPlane.
     // Transform to clipping space matrix
     const clipPoint = MathTemp.tempVec3;
-    clipPoint.setValue(x * 2 - 1, 1 - y * 2, z * 2 - 1);
+    clipPoint.set(x * 2 - 1, 1 - y * 2, z * 2 - 1);
     Vector3.transformCoordinate(clipPoint, invViewProjMat, out);
     return out;
   }

--- a/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
+++ b/packages/core/src/RenderPipeline/BasicRenderPipeline.ts
@@ -224,7 +224,7 @@ export class BasicRenderPipeline {
       (this._lastCanvasSize.x !== canvas.width || this._lastCanvasSize.y !== canvas.height) &&
       background._textureFillMode !== BackgroundTextureFillMode.Fill
     ) {
-      this._lastCanvasSize.setValue(canvas.width, canvas.height);
+      this._lastCanvasSize.set(canvas.width, canvas.height);
       background._resizeBackgroundTexture();
     }
 
@@ -255,7 +255,7 @@ export class BasicRenderPipeline {
     ShaderMacroCollection.unionCollection(camera._globalShaderMacro, shaderData._macroCollection, compileMacros);
 
     const { viewMatrix, projectionMatrix } = camera;
-    viewMatrix.cloneTo(_matrix);
+    _matrix.copyFrom(viewMatrix);
     const e = _matrix.elements;
     e[12] = e[13] = e[14] = 0;
     Matrix.multiply(projectionMatrix, _matrix, _matrix);

--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -3,7 +3,6 @@ import { BoolUpdateFlag } from "./BoolUpdateFlag";
 import { deepClone, ignoreClone } from "./clone/CloneManager";
 import { Component } from "./Component";
 import { Entity } from "./Entity";
-import { UpdateFlag } from "./UpdateFlag";
 import { UpdateFlagManager } from "./UpdateFlagManager";
 
 /**
@@ -19,7 +18,6 @@ export class Transform extends Component {
   private static _tempMat32: Matrix3x3 = new Matrix3x3();
   private static _tempMat41: Matrix = new Matrix();
   private static _tempMat42: Matrix = new Matrix();
-  private static _tempMat43: Matrix = new Matrix();
 
   @deepClone
   private _position: Vector3 = new Vector3();
@@ -59,7 +57,7 @@ export class Transform extends Component {
 
   set position(value: Vector3) {
     if (this._position !== value) {
-      value.cloneTo(this._position);
+      this._position.copyFrom(value);
     }
   }
 
@@ -74,7 +72,7 @@ export class Transform extends Component {
       if (this._getParentTransform()) {
         this.worldMatrix.getTranslation(worldPosition);
       } else {
-        this._position.cloneTo(worldPosition);
+        worldPosition.copyFrom(this._position);
       }
       //@ts-ignore
       worldPosition._onValueChanged = this._onWorldPositionChanged;
@@ -86,7 +84,7 @@ export class Transform extends Component {
 
   set worldPosition(value: Vector3) {
     if (this._worldPosition !== value) {
-      value.cloneTo(this._worldPosition);
+      this._worldPosition.copyFrom(value);
     }
   }
 
@@ -111,7 +109,7 @@ export class Transform extends Component {
 
   set rotation(value: Vector3) {
     if (this._rotation !== value) {
-      value.cloneTo(this._rotation);
+      this._rotation.copyFrom(value);
     }
   }
 
@@ -135,7 +133,7 @@ export class Transform extends Component {
 
   set worldRotation(value: Vector3) {
     if (this._worldRotation !== value) {
-      value.cloneTo(this._worldRotation);
+      this._worldRotation.copyFrom(value);
     }
   }
 
@@ -163,7 +161,7 @@ export class Transform extends Component {
   set rotationQuaternion(value: Quaternion) {
     if (this._rotationQuaternion !== value) {
       if (value.normalized) {
-        value.cloneTo(this._rotationQuaternion);
+        this._rotationQuaternion.copyFrom(value);
       } else {
         Quaternion.normalize(value, this._rotationQuaternion);
       }
@@ -184,7 +182,7 @@ export class Transform extends Component {
       if (parent != null) {
         Quaternion.multiply(parent.worldRotationQuaternion, this.rotationQuaternion, worldRotationQuaternion);
       } else {
-        this.rotationQuaternion.cloneTo(worldRotationQuaternion);
+        worldRotationQuaternion.copyFrom(this.rotationQuaternion);
       }
       //@ts-ignore
       worldRotationQuaternion._onValueChanged = this._onWorldRotationQuaternionChanged;
@@ -196,7 +194,7 @@ export class Transform extends Component {
   set worldRotationQuaternion(value: Quaternion) {
     if (this._worldRotationQuaternion !== value) {
       if (value.normalized) {
-        value.cloneTo(this._worldRotationQuaternion);
+        this._worldRotationQuaternion.copyFrom(value);
       } else {
         Quaternion.normalize(value, this._worldRotationQuaternion);
       }
@@ -213,7 +211,7 @@ export class Transform extends Component {
 
   set scale(value: Vector3) {
     if (this._scale !== value) {
-      value.cloneTo(this._scale);
+      this._scale.copyFrom(value);
     }
   }
 
@@ -227,9 +225,9 @@ export class Transform extends Component {
       if (this._getParentTransform()) {
         const scaleMat = this._getScaleMatrix();
         const e = scaleMat.elements;
-        this._lossyWorldScale.setValue(e[0], e[4], e[8]);
+        this._lossyWorldScale.set(e[0], e[4], e[8]);
       } else {
-        this._scale.cloneTo(this._lossyWorldScale);
+        this._lossyWorldScale.copyFrom(this._scale);
       }
       this._setDirtyFlagFalse(TransformFlag.WorldScale);
     }
@@ -250,7 +248,7 @@ export class Transform extends Component {
 
   set localMatrix(value: Matrix) {
     if (this._localMatrix !== value) {
-      value.cloneTo(this._localMatrix);
+      this._localMatrix.copyFrom(value);
     }
 
     this._localMatrix.decompose(this._position, this._rotationQuaternion, this._scale);
@@ -270,7 +268,7 @@ export class Transform extends Component {
       if (parent) {
         Matrix.multiply(parent.worldMatrix, this.localMatrix, this._worldMatrix);
       } else {
-        this.localMatrix.cloneTo(this._worldMatrix);
+        this._worldMatrix.copyFrom(this.localMatrix);
       }
       this._setDirtyFlagFalse(TransformFlag.WorldMatrix);
     }
@@ -279,14 +277,14 @@ export class Transform extends Component {
 
   set worldMatrix(value: Matrix) {
     if (this._worldMatrix !== value) {
-      value.cloneTo(this._worldMatrix);
+      this._worldMatrix.copyFrom(value);
     }
     const parent = this._getParentTransform();
     if (parent) {
       Matrix.invert(parent.worldMatrix, Transform._tempMat42);
       Matrix.multiply(value, Transform._tempMat42, this._localMatrix);
     } else {
-      value.cloneTo(this._localMatrix);
+      this._localMatrix.copyFrom(value);
     }
     this.localMatrix = this._localMatrix;
     this._setDirtyFlagFalse(TransformFlag.WorldMatrix);
@@ -329,7 +327,7 @@ export class Transform extends Component {
    * @param z - Z coordinate
    */
   setPosition(x: number, y: number, z: number): void {
-    this._position.setValue(x, y, z);
+    this._position.set(x, y, z);
   }
 
   /**
@@ -340,7 +338,7 @@ export class Transform extends Component {
    * @param z - The angle of rotation around the Z axis
    */
   setRotation(x: number, y: number, z: number): void {
-    this._rotation.setValue(x, y, z);
+    this._rotation.set(x, y, z);
   }
 
   /**
@@ -351,7 +349,7 @@ export class Transform extends Component {
    * @param w - W component of quaternion
    */
   setRotationQuaternion(x: number, y: number, z: number, w: number): void {
-    this._rotationQuaternion.setValue(x, y, z, w);
+    this._rotationQuaternion.set(x, y, z, w);
   }
 
   /**
@@ -361,7 +359,7 @@ export class Transform extends Component {
    * @param z - Scaling along Z axis
    */
   setScale(x: number, y: number, z: number): void {
-    this._scale.setValue(x, y, z);
+    this._scale.set(x, y, z);
   }
 
   /**
@@ -371,7 +369,7 @@ export class Transform extends Component {
    * @param z - Z coordinate
    */
   setWorldPosition(x: number, y: number, z: number): void {
-    this._worldPosition.setValue(x, y, z);
+    this._worldPosition.set(x, y, z);
   }
 
   /**
@@ -381,7 +379,7 @@ export class Transform extends Component {
    * @param z - The angle of rotation around the Z axis
    */
   setWorldRotation(x: number, y: number, z: number): void {
-    this._worldRotation.setValue(x, y, z);
+    this._worldRotation.set(x, y, z);
   }
 
   /**
@@ -392,7 +390,7 @@ export class Transform extends Component {
    * @param w - W component of quaternion
    */
   setWorldRotationQuaternion(x: number, y: number, z: number, w: number): void {
-    this._worldRotationQuaternion.setValue(x, y, z, w);
+    this._worldRotationQuaternion.set(x, y, z, w);
   }
 
   /**
@@ -402,7 +400,7 @@ export class Transform extends Component {
    */
   getWorldForward(forward: Vector3): Vector3 {
     const e = this.worldMatrix.elements;
-    forward.setValue(-e[8], -e[9], -e[10]);
+    forward.set(-e[8], -e[9], -e[10]);
     return forward.normalize();
   }
 
@@ -413,7 +411,7 @@ export class Transform extends Component {
    */
   getWorldRight(right: Vector3): Vector3 {
     const e = this.worldMatrix.elements;
-    right.setValue(e[0], e[1], e[2]);
+    right.set(e[0], e[1], e[2]);
     return right.normalize();
   }
 
@@ -424,11 +422,11 @@ export class Transform extends Component {
    */
   getWorldUp(up: Vector3): Vector3 {
     const e = this.worldMatrix.elements;
-    up.setValue(e[4], e[5], e[6]);
+    up.set(e[4], e[5], e[6]);
     return up.normalize();
   }
 
- /**
+  /**
    * Translate in the direction and distance of the translation.
    * @param translation - Direction and distance of translation
    * @param relativeToLocal - Is relative to the local coordinate system
@@ -452,7 +450,7 @@ export class Transform extends Component {
   ): void {
     if (typeof translationOrX === "number") {
       const translate = Transform._tempVec30;
-      translate.setValue(translationOrX, <number>relativeToLocalOrY, z);
+      translate.set(translationOrX, <number>relativeToLocalOrY, z);
       this._translate(translate, relativeToLocal);
     } else {
       this._translate(translationOrX, <boolean>relativeToLocalOrY);
@@ -518,7 +516,7 @@ export class Transform extends Component {
     if (worldUp) {
       Vector3.cross(worldUp, zAxis, xAxis);
     } else {
-      xAxis.setValue(zAxis.z, 0, -zAxis.x);
+      xAxis.set(zAxis.z, 0, -zAxis.x);
     }
     axisLen = xAxis.length();
     if (axisLen <= MathUtil.zeroTolerance) {
@@ -685,7 +683,7 @@ export class Transform extends Component {
     const invRotationMat = Transform._tempMat30;
     const worldRotScaMat = Transform._tempMat31;
     const scaMat = Transform._tempMat32;
-    worldRotScaMat.setValueByMatrix(this.worldMatrix);
+    worldRotScaMat.copyFromMatrix(this.worldMatrix);
     Quaternion.invert(this.worldRotationQuaternion, invRotation);
     Matrix3x3.rotationQuaternion(invRotation, invRotationMat);
     Matrix3x3.multiply(invRotationMat, worldRotScaMat, scaMat);
@@ -750,7 +748,7 @@ export class Transform extends Component {
       Matrix.invert(parent.worldMatrix, Transform._tempMat41);
       Vector3.transformCoordinate(worldPosition, Transform._tempMat41, this._position);
     } else {
-      worldPosition.cloneTo(this._position);
+      this._position.copyFrom(worldPosition);
     }
     this._setDirtyFlagFalse(TransformFlag.WorldPosition);
   }
@@ -786,7 +784,7 @@ export class Transform extends Component {
       Quaternion.invert(parent.worldRotationQuaternion, invParentQuaternion);
       Quaternion.multiply(invParentQuaternion, worldRotationQuaternion, this._rotationQuaternion);
     } else {
-      worldRotationQuaternion.cloneTo(this._rotationQuaternion);
+      this._rotationQuaternion.copyFrom(worldRotationQuaternion);
     }
     this._setDirtyFlagFalse(TransformFlag.WorldQuat);
   }

--- a/packages/core/src/animation/AnimationCurve.ts
+++ b/packages/core/src/animation/AnimationCurve.ts
@@ -1,4 +1,3 @@
-import { IClone } from "@oasis-engine/design";
 import { Quaternion, Vector2, Vector3, Vector4 } from "@oasis-engine/math";
 import { InterpolableValueType } from "./enums/InterpolableValueType";
 import { InterpolationType } from "./enums/InterpolationType";
@@ -242,7 +241,7 @@ export class AnimationCurve {
       case InterpolableValueType.Vector3:
       case InterpolableValueType.Vector4:
       case InterpolableValueType.Quaternion:
-        (keys[frameIndex].value as IClone).cloneTo(out);
+        (<Vector4>out).copyFrom(<Vector4>keys[frameIndex].value);
         return out;
     }
   }

--- a/packages/core/src/animation/internal/AnimationCurveOwner.ts
+++ b/packages/core/src/animation/internal/AnimationCurveOwner.ts
@@ -54,13 +54,13 @@ export class AnimationCurveOwner {
   saveDefaultValue(): void {
     switch (this.property) {
       case AnimationProperty.Position:
-        this.target.transform.position.cloneTo(<Vector3>this.defaultValue);
+        (<Vector3>this.defaultValue).copyFrom(this.target.transform.position);
         break;
       case AnimationProperty.Rotation:
-        this.target.transform.rotationQuaternion.cloneTo(<Quaternion>this.defaultValue);
+        (<Quaternion>this.defaultValue).copyFrom(this.target.transform.rotationQuaternion);
         break;
       case AnimationProperty.Scale:
-        this.target.transform.scale.cloneTo(<Vector3>this.defaultValue);
+        (<Vector3>this.defaultValue).copyFrom(this.target.transform.scale);
         break;
       case AnimationProperty.BlendShapeWeights:
         const { blendShapeWeights } = <SkinnedMeshRenderer>this.component;
@@ -75,13 +75,13 @@ export class AnimationCurveOwner {
   saveFixedPoseValue(): void {
     switch (this.property) {
       case AnimationProperty.Position:
-        this.target.transform.position.cloneTo(<Vector3>this.fixedPoseValue);
+        (<Vector3>this.fixedPoseValue).copyFrom(this.target.transform.position);
         break;
       case AnimationProperty.Rotation:
-        this.target.transform.rotationQuaternion.cloneTo(<Quaternion>this.fixedPoseValue);
+        (<Quaternion>this.fixedPoseValue).copyFrom(this.target.transform.rotationQuaternion);
         break;
       case AnimationProperty.Scale:
-        this.target.transform.scale.cloneTo(<Vector3>this.fixedPoseValue);
+        (<Vector3>this.fixedPoseValue).copyFrom(this.target.transform.scale);
         break;
       case AnimationProperty.BlendShapeWeights:
         const { blendShapeWeights } = <SkinnedMeshRenderer>this.component;

--- a/packages/core/src/env-probe/CubeProbe.ts
+++ b/packages/core/src/env-probe/CubeProbe.ts
@@ -47,7 +47,7 @@ export class CubeProbe extends Probe {
    * Store original camera parameters.
    */
   private _storeCamera(camera: Camera) {
-    camera.viewMatrix.cloneTo(this.oriViewMatrix);
+    this.oriViewMatrix.copyFrom(camera.viewMatrix);
     this._oriFieldOfView = camera.fieldOfView;
   }
 
@@ -55,7 +55,7 @@ export class CubeProbe extends Probe {
    * Restore camera parameters.
    */
   private _restoreCamera(camera: Camera) {
-    this.oriViewMatrix.cloneTo(camera.viewMatrix);
+    camera.viewMatrix.copyFrom(this.oriViewMatrix);
     camera.fieldOfView = this._oriFieldOfView;
   }
 
@@ -66,33 +66,33 @@ export class CubeProbe extends Probe {
     switch (faceIndex) {
       // positive_x
       case 0:
-        cacheUp.setValue(0, -1, 0);
-        cacheDir.setValue(1, 0, 0);
+        cacheUp.set(0, -1, 0);
+        cacheDir.set(1, 0, 0);
         break;
       // negative_x
       case 1:
-        cacheUp.setValue(0, -1, 0);
-        cacheDir.setValue(-1, 0, 0);
+        cacheUp.set(0, -1, 0);
+        cacheDir.set(-1, 0, 0);
         break;
       // positive_y
       case 2:
-        cacheUp.setValue(0, 0, 1);
-        cacheDir.setValue(0, 1, 0);
+        cacheUp.set(0, 0, 1);
+        cacheDir.set(0, 1, 0);
         break;
       // negative_y
       case 3:
-        cacheUp.setValue(0, 0, -1);
-        cacheDir.setValue(0, -1, 0);
+        cacheUp.set(0, 0, -1);
+        cacheDir.set(0, -1, 0);
         break;
       // positive_z
       case 4:
-        cacheUp.setValue(0, -1, 0);
-        cacheDir.setValue(0, 0, 1);
+        cacheUp.set(0, -1, 0);
+        cacheDir.set(0, 0, 1);
         break;
       // negative_z
       case 5:
-        cacheUp.setValue(0, -1, 0);
-        cacheDir.setValue(0, 0, -1);
+        cacheUp.set(0, -1, 0);
+        cacheDir.set(0, 0, -1);
         break;
     }
 

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -142,7 +142,7 @@ export class PointerManager {
       }
       pointer._uniqueID = pointerId;
       pointer._needUpdate = true;
-      pointer.position.setValue(x, y);
+      pointer.position.set(x, y);
       pointer.phase = phase;
       pointers.splice(i, 0, pointer);
     }
@@ -154,7 +154,7 @@ export class PointerManager {
 
   private _updatePointer(pointerIndex: number, x: number, y: number, phase: PointerPhase): void {
     const updatedPointer = this._pointers[pointerIndex];
-    updatedPointer.position.setValue(x, y);
+    updatedPointer.position.set(x, y);
     updatedPointer._needUpdate = true;
     updatedPointer.phase = phase;
   }
@@ -209,14 +209,14 @@ export class PointerManager {
       if (activePointerCount === 0) {
         // Get the pointer coordinates when leaving, and use it to correctly dispatch the click event.
         const lastNativeEvent = nativeEvents[nativeEventsLen - 1];
-        currentPosition.setValue(lastNativeEvent.offsetX * pixelRatioWidth, lastNativeEvent.offsetY * pixelRatioHeight);
+        currentPosition.set(lastNativeEvent.offsetX * pixelRatioWidth, lastNativeEvent.offsetY * pixelRatioHeight);
       } else {
-        currentPosition.setValue(0, 0);
+        currentPosition.set(0, 0);
         for (let i = 0; i < pointerCount; i++) {
           const pointer = pointers[i];
           const { position } = pointer;
           if (pointer._needUpdate) {
-            position.setValue(position.x * pixelRatioWidth, position.y * pixelRatioHeight);
+            position.set(position.x * pixelRatioWidth, position.y * pixelRatioHeight);
             pointer._needUpdate = false;
           }
           currentPosition.add(position);
@@ -240,7 +240,7 @@ export class PointerManager {
         }
         const { x: vpX, y: vpY, z: vpW, w: vpH } = camera.viewport;
         if (x >= vpX && y >= vpY && x - vpX <= vpW && y - vpY <= vpH) {
-          point.setValue((x - vpX) / vpW, (y - vpY) / vpH);
+          point.set((x - vpX) / vpW, (y - vpY) / vpH);
           // TODO: Only check which colliders have listened to the input.
           if (this._engine.physicsManager.raycast(camera.viewportPointToRay(point, ray), hitResult)) {
             return hitResult.entity;

--- a/packages/core/src/lighting/AmbientLight.ts
+++ b/packages/core/src/lighting/AmbientLight.ts
@@ -79,7 +79,7 @@ export class AmbientLight {
 
   set diffuseSolidColor(value: Color) {
     if (value !== this._diffuseSolidColor) {
-      value.cloneTo(this._diffuseSolidColor);
+      this._diffuseSolidColor.copyFrom(value);
     }
   }
 

--- a/packages/core/src/material/BlinnPhongMaterial.ts
+++ b/packages/core/src/material/BlinnPhongMaterial.ts
@@ -22,7 +22,7 @@ export class BlinnPhongMaterial extends BaseMaterial {
   set baseColor(value: Color) {
     const baseColor = this.shaderData.getColor(BlinnPhongMaterial._baseColorProp);
     if (value !== baseColor) {
-      value.cloneTo(baseColor);
+      baseColor.copyFrom(value);
     }
   }
 
@@ -52,7 +52,7 @@ export class BlinnPhongMaterial extends BaseMaterial {
   set specularColor(value: Color) {
     const specularColor = this.shaderData.getColor(BlinnPhongMaterial._specularColorProp);
     if (value !== specularColor) {
-      value.cloneTo(specularColor);
+      specularColor.copyFrom(value);
     }
   }
 
@@ -82,7 +82,7 @@ export class BlinnPhongMaterial extends BaseMaterial {
   set emissiveColor(value: Color) {
     const emissiveColor = this.shaderData.getColor(BlinnPhongMaterial._emissiveColorProp);
     if (value !== emissiveColor) {
-      value.cloneTo(emissiveColor);
+      emissiveColor.copyFrom(value);
     }
   }
 
@@ -150,7 +150,7 @@ export class BlinnPhongMaterial extends BaseMaterial {
   set tilingOffset(value: Vector4) {
     const tilingOffset = this.shaderData.getVector4(BlinnPhongMaterial._tilingOffsetProp);
     if (value !== tilingOffset) {
-      value.cloneTo(tilingOffset);
+      tilingOffset.copyFrom(value);
     }
   }
 

--- a/packages/core/src/material/PBRBaseMaterial.ts
+++ b/packages/core/src/material/PBRBaseMaterial.ts
@@ -30,7 +30,7 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   set baseColor(value: Color) {
     const baseColor = this.shaderData.getColor(PBRBaseMaterial._baseColorProp);
     if (value !== baseColor) {
-      value.cloneTo(baseColor);
+      baseColor.copyFrom(value);
     }
   }
 
@@ -87,7 +87,7 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   set emissiveColor(value: Color) {
     const emissiveColor = this.shaderData.getColor(PBRBaseMaterial._emissiveColorProp);
     if (value !== emissiveColor) {
-      value.cloneTo(emissiveColor);
+      emissiveColor.copyFrom(value);
     }
   }
 
@@ -159,7 +159,7 @@ export abstract class PBRBaseMaterial extends BaseMaterial {
   set tilingOffset(value: Vector4) {
     const tilingOffset = this.shaderData.getVector4(PBRBaseMaterial._tilingOffsetProp);
     if (value !== tilingOffset) {
-      value.cloneTo(tilingOffset);
+      tilingOffset.copyFrom(value);
     }
   }
 

--- a/packages/core/src/material/PBRSpecularMaterial.ts
+++ b/packages/core/src/material/PBRSpecularMaterial.ts
@@ -24,7 +24,7 @@ export class PBRSpecularMaterial extends PBRBaseMaterial {
   set specularColor(value: Color) {
     const specularColor = this.shaderData.getColor(PBRSpecularMaterial._specularColorProp);
     if (value !== specularColor) {
-      value.cloneTo(specularColor);
+      specularColor.copyFrom(value);
     }
   }
 

--- a/packages/core/src/material/UnlitMaterial.ts
+++ b/packages/core/src/material/UnlitMaterial.ts
@@ -18,7 +18,7 @@ export class UnlitMaterial extends BaseMaterial {
   set baseColor(value: Color) {
     const baseColor = this.shaderData.getColor(UnlitMaterial._baseColorProp);
     if (value !== baseColor) {
-      value.cloneTo(baseColor);
+      baseColor.copyFrom(value);
     }
   }
 
@@ -48,7 +48,7 @@ export class UnlitMaterial extends BaseMaterial {
   set tilingOffset(value: Vector4) {
     const tilingOffset = this.shaderData.getVector4(UnlitMaterial._tilingOffsetProp);
     if (value !== tilingOffset) {
-      value.cloneTo(tilingOffset);
+      tilingOffset.copyFrom(value);
     }
   }
 

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -223,7 +223,7 @@ export class BlendShapeManager {
       } else {
         this._createVertexBuffers(vertexCount, noLongerAccessible);
       }
-      this._lastCreateHostInfo.setValue(this._blendShapeCount, +this._useBlendNormal, +this._useBlendTangent);
+      this._lastCreateHostInfo.set(this._blendShapeCount, +this._useBlendNormal, +this._useBlendTangent);
     }
     if (this._needUpdateData()) {
       if (useTexture) {
@@ -319,7 +319,7 @@ export class BlendShapeManager {
 
     this._vertices = new Float32Array(blendShapeCount * textureWidth * textureHeight * 4);
     this._vertexTexture = blendShapeDataTexture;
-    this._dataTextureInfo.setValue(vertexPixelStride, textureWidth, textureHeight);
+    this._dataTextureInfo.set(vertexPixelStride, textureWidth, textureHeight);
   }
 
   /**
@@ -353,7 +353,7 @@ export class BlendShapeManager {
 
         let storeInfo = storeInfos[i];
         storeInfo || (storeInfos[i] = storeInfo = new Vector2());
-        storeInfo.setValue(bufferIndex + 1, indexInBuffer * blendShapeByteStride); // BlendShape buffer is start from 1
+        storeInfo.set(bufferIndex + 1, indexInBuffer * blendShapeByteStride); // BlendShape buffer is start from 1
 
         const { deltaPositions } = endFrame;
         for (let j = 0; j < vertexCount; j++) {

--- a/packages/core/src/mesh/MeshRenderer.ts
+++ b/packages/core/src/mesh/MeshRenderer.ts
@@ -138,8 +138,8 @@ export class MeshRenderer extends Renderer implements ICustomClone {
       const worldMatrix = this._entity.transform.worldMatrix;
       BoundingBox.transform(localBounds, worldMatrix, worldBounds);
     } else {
-      worldBounds.min.setValue(0, 0, 0);
-      worldBounds.max.setValue(0, 0, 0);
+      worldBounds.min.set(0, 0, 0);
+      worldBounds.max.set(0, 0, 0);
     }
   }
 }

--- a/packages/core/src/mesh/PrimitiveMesh.ts
+++ b/packages/core/src/mesh/PrimitiveMesh.ts
@@ -77,8 +77,8 @@ export class PrimitiveMesh {
     }
 
     const { bounds } = mesh;
-    bounds.min.setValue(-radius, -radius, -radius);
-    bounds.max.setValue(radius, radius, radius);
+    bounds.min.set(-radius, -radius, -radius);
+    bounds.max.set(radius, radius, radius);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;
@@ -206,8 +206,8 @@ export class PrimitiveMesh {
     indices[30] = 20, indices[31] = 22, indices[32] = 23, indices[33] = 22, indices[34] = 20, indices[35] = 21;
 
     const { bounds } = mesh;
-    bounds.min.setValue(-halfWidth, -halfHeight, -halfDepth);
-    bounds.max.setValue(halfWidth, halfHeight, halfDepth);
+    bounds.min.set(-halfWidth, -halfHeight, -halfDepth);
+    bounds.max.set(halfWidth, halfHeight, halfDepth);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;
@@ -283,8 +283,8 @@ export class PrimitiveMesh {
     }
 
     const { bounds } = mesh;
-    bounds.min.setValue(-halfWidth, 0, -halfHeight);
-    bounds.max.setValue(halfWidth, 0, halfHeight);
+    bounds.min.set(-halfWidth, 0, -halfHeight);
+    bounds.max.set(halfWidth, 0, halfHeight);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;
@@ -448,8 +448,8 @@ export class PrimitiveMesh {
 
     const { bounds } = mesh;
     const radiusMax = Math.max(radiusTop, radiusBottom);
-    bounds.min.setValue(-radiusMax, -halfHeight, -radiusMax);
-    bounds.max.setValue(radiusMax, halfHeight, radiusMax);
+    bounds.min.set(-radiusMax, -halfHeight, -radiusMax);
+    bounds.max.set(radiusMax, halfHeight, radiusMax);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;
@@ -535,8 +535,8 @@ export class PrimitiveMesh {
 
     const { bounds } = mesh;
     const outerRadius = radius + tubeRadius;
-    bounds.min.setValue(-outerRadius, -outerRadius, -tubeRadius);
-    bounds.max.setValue(outerRadius, outerRadius, tubeRadius);
+    bounds.min.set(-outerRadius, -outerRadius, -tubeRadius);
+    bounds.max.set(outerRadius, outerRadius, tubeRadius);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;
@@ -665,8 +665,8 @@ export class PrimitiveMesh {
     }
 
     const { bounds } = mesh;
-    bounds.min.setValue(-radius, -halfHeight, -radius);
-    bounds.max.setValue(radius, halfHeight, radius);
+    bounds.min.set(-radius, -halfHeight, -radius);
+    bounds.max.set(radius, halfHeight, radius);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;
@@ -786,8 +786,8 @@ export class PrimitiveMesh {
     );
 
     const { bounds } = mesh;
-    bounds.min.setValue(-radius, -radius - halfHeight, -radius);
-    bounds.max.setValue(radius, radius + halfHeight, radius);
+    bounds.min.set(-radius, -radius - halfHeight, -radius);
+    bounds.max.set(radius, radius + halfHeight, radius);
 
     PrimitiveMesh._initialize(mesh, positions, normals, uvs, indices, noLongerAccessible);
     return mesh;

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -160,7 +160,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
         if (joints[i]) {
           Matrix.multiply(joints[i].transform.worldMatrix, ibms[i], mat);
         } else {
-          ibms[i].cloneTo(mat);
+          mat.copyFrom(ibms[i]);
         }
         Matrix.multiply(worldToLocal, mat, mat);
         matrixPalette.set(mat.elements, i * 16);

--- a/packages/core/src/physics/CharacterController.ts
+++ b/packages/core/src/physics/CharacterController.ts
@@ -25,9 +25,9 @@ export class CharacterController extends Collider {
     return this._stepOffset;
   }
 
-  set stepOffset(newValue: number) {
-    this._stepOffset = newValue;
-    (<ICharacterController>this._nativeCollider).setStepOffset(newValue);
+  set stepOffset(value: number) {
+    this._stepOffset = value;
+    (<ICharacterController>this._nativeCollider).setStepOffset(value);
   }
 
   /**
@@ -37,9 +37,9 @@ export class CharacterController extends Collider {
     return this._nonWalkableMode;
   }
 
-  set nonWalkableMode(newValue: ControllerNonWalkableMode) {
-    this._nonWalkableMode = newValue;
-    (<ICharacterController>this._nativeCollider).setNonWalkableMode(newValue);
+  set nonWalkableMode(value: ControllerNonWalkableMode) {
+    this._nonWalkableMode = value;
+    (<ICharacterController>this._nativeCollider).setNonWalkableMode(value);
   }
 
   /**
@@ -49,9 +49,9 @@ export class CharacterController extends Collider {
     return this._upDirection;
   }
 
-  set upDirection(newValue: Vector3) {
-    if (this._upDirection !== newValue) {
-      newValue.cloneTo(this._upDirection);
+  set upDirection(value: Vector3) {
+    if (this._upDirection !== value) {
+      this._upDirection.copyFrom(value);
     }
     (<ICharacterController>this._nativeCollider).setUpDirection(this._upDirection);
   }
@@ -63,9 +63,9 @@ export class CharacterController extends Collider {
     return this._slopeLimit;
   }
 
-  set slopeLimit(newValue: number) {
-    this._slopeLimit = newValue;
-    (<ICharacterController>this._nativeCollider).setSlopeLimit(newValue);
+  set slopeLimit(value: number) {
+    this._slopeLimit = value;
+    (<ICharacterController>this._nativeCollider).setSlopeLimit(value);
   }
 
   /**

--- a/packages/core/src/physics/DynamicCollider.ts
+++ b/packages/core/src/physics/DynamicCollider.ts
@@ -56,7 +56,7 @@ export class DynamicCollider extends Collider {
 
   set linearVelocity(value: Vector3) {
     if (this._linearVelocity !== value) {
-      value.cloneTo(this._linearVelocity);
+      this._linearVelocity.copyFrom(value);
     }
     (<IDynamicCollider>this._nativeCollider).setLinearVelocity(this._linearVelocity);
   }
@@ -70,7 +70,7 @@ export class DynamicCollider extends Collider {
 
   set angularVelocity(value: Vector3) {
     if (this._angularVelocity !== value) {
-      value.cloneTo(this._angularVelocity);
+      this._angularVelocity.copyFrom(value);
     }
     (<IDynamicCollider>this._nativeCollider).setAngularVelocity(this._angularVelocity);
   }
@@ -96,7 +96,7 @@ export class DynamicCollider extends Collider {
 
   set centerOfMass(value: Vector3) {
     if (this._centerOfMass !== value) {
-      value.cloneTo(this._centerOfMass);
+      this._centerOfMass.copyFrom(value);
     }
     (<IDynamicCollider>this._nativeCollider).setCenterOfMass(this._centerOfMass);
   }
@@ -110,7 +110,7 @@ export class DynamicCollider extends Collider {
 
   set inertiaTensor(value: Vector3) {
     if (this._inertiaTensor !== value) {
-      value.cloneTo(this._inertiaTensor);
+      this._inertiaTensor.copyFrom(value);
     }
     (<IDynamicCollider>this._nativeCollider).setInertiaTensor(this._inertiaTensor);
   }

--- a/packages/core/src/physics/PhysicsManager.ts
+++ b/packages/core/src/physics/PhysicsManager.ts
@@ -140,7 +140,7 @@ export class PhysicsManager {
   set gravity(value: Vector3) {
     const gravity = this._gravity;
     if (gravity !== value) {
-      value.cloneTo(gravity);
+      gravity.copyFrom(value);
     }
     this._nativePhysicsManager.setGravity(gravity);
   }
@@ -250,8 +250,8 @@ export class PhysicsManager {
       const result = this._nativePhysicsManager.raycast(ray, distance, (idx, distance, position, normal) => {
         hitResult.entity = this._physicalObjectsMap[idx]._collider.entity;
         hitResult.distance = distance;
-        normal.cloneTo(hitResult.normal);
-        position.cloneTo(hitResult.point);
+        hitResult.normal.copyFrom(normal);
+        hitResult.point.copyFrom(position);
       });
 
       if (result) {
@@ -260,8 +260,8 @@ export class PhysicsManager {
         } else {
           hitResult.entity = null;
           hitResult.distance = 0;
-          hitResult.point.setValue(0, 0, 0);
-          hitResult.normal.setValue(0, 0, 0);
+          hitResult.point.set(0, 0, 0);
+          hitResult.normal.set(0, 0, 0);
           return false;
         }
       }

--- a/packages/core/src/physics/shape/BoxColliderShape.ts
+++ b/packages/core/src/physics/shape/BoxColliderShape.ts
@@ -17,7 +17,7 @@ export class BoxColliderShape extends ColliderShape {
 
   set size(value: Vector3) {
     if (this._size != value) {
-      value.cloneTo(this._size);
+      this._size.copyFrom(value);
     }
     (<IBoxColliderShape>this._nativeShape).setSize(value);
   }

--- a/packages/core/src/physics/shape/ColliderShape.ts
+++ b/packages/core/src/physics/shape/ColliderShape.ts
@@ -68,7 +68,7 @@ export abstract class ColliderShape {
 
   set position(value: Vector3) {
     if (this._position !== value) {
-      value.cloneTo(this._position);
+      this._position.copyFrom(value);
     }
     this._nativeShape.setPosition(value);
   }
@@ -97,7 +97,7 @@ export abstract class ColliderShape {
    * @param z - The z component of the vector, default 0
    */
   setPosition(x: number, y: number, z: number): void {
-    this._position.setValue(x, y, z);
+    this._position.set(x, y, z);
     this._nativeShape.setPosition(this._position);
   }
 

--- a/packages/core/src/physics/shape/PlaneColliderShape.ts
+++ b/packages/core/src/physics/shape/PlaneColliderShape.ts
@@ -1,7 +1,7 @@
-import { ColliderShape } from "./ColliderShape";
-import { PhysicsManager } from "../PhysicsManager";
-import { Vector3 } from "@oasis-engine/math";
 import { IPlaneColliderShape } from "@oasis-engine/design";
+import { Vector3 } from "@oasis-engine/math";
+import { PhysicsManager } from "../PhysicsManager";
+import { ColliderShape } from "./ColliderShape";
 
 /**
  * Physical collider shape plane.
@@ -18,7 +18,7 @@ export class PlaneColliderShape extends ColliderShape {
 
   set rotation(value: Vector3) {
     if (this._rotation != value) {
-      value.cloneTo(this._rotation);
+      this._rotation.copyFrom(value);
     }
     (<IPlaneColliderShape>this._nativeShape).setRotation(value);
   }
@@ -38,7 +38,7 @@ export class PlaneColliderShape extends ColliderShape {
    * @param z - Radian of roll
    */
   setRotation(x: number, y: number, z: number): void {
-    this._rotation.setValue(x, y, z);
+    this._rotation.set(x, y, z);
     (<IPlaneColliderShape>this._nativeShape).setRotation(this._rotation);
   }
 }

--- a/packages/core/src/shader/ShaderData.ts
+++ b/packages/core/src/shader/ShaderData.ts
@@ -586,7 +586,7 @@ export class ShaderData implements IRefObject, IClone {
         } else {
           const targetProperty = targetProperties[k];
           if (targetProperty) {
-            property.cloneTo(targetProperty);
+            targetProperty.copyFrom(property);
           } else {
             targetProperties[k] = property.clone();
           }

--- a/packages/core/src/shader/state/BlendState.ts
+++ b/packages/core/src/shader/state/BlendState.ts
@@ -143,7 +143,7 @@ export class BlendState {
       const blendColor = this.blendColor;
       if (!Color.equals(lastState.blendColor, blendColor)) {
         gl.blendColor(blendColor.r, blendColor.g, blendColor.b, blendColor.a);
-        blendColor.cloneTo(lastState.blendColor);
+        lastState.blendColor.copyFrom(blendColor);
       }
     }
 

--- a/packages/core/src/trail/TrailRenderer.ts
+++ b/packages/core/src/trail/TrailRenderer.ts
@@ -76,7 +76,7 @@ export class TrailRenderer extends MeshRenderer {
         this._pointStates[newIdx] = this._pointStates[i];
 
         // Move point
-        this._points[i].cloneTo(this._points[newIdx]);
+        this._points[newIdx].copyFrom(this._points[i]);
       }
     }
     this._curPointNum -= mov;
@@ -95,7 +95,7 @@ export class TrailRenderer extends MeshRenderer {
 
     if (appendNewPoint) {
       this._pointStates[this._curPointNum] = this._lifetime;
-      this.entity.transform.worldPosition.cloneTo(this._points[this._curPointNum]);
+      this._points[this._curPointNum].copyFrom(this.entity.transform.worldPosition);
 
       this._curPointNum++;
     }

--- a/packages/loader/src/EnvLoader.ts
+++ b/packages/loader/src/EnvLoader.ts
@@ -47,7 +47,7 @@ class EnvLoader extends Loader<AmbientLight> {
           const sh = new SphericalHarmonics3();
 
           ambientLight.diffuseMode = DiffuseMode.SphericalHarmonics;
-          sh.setValueByArray(shArray);
+          sh.copyFromArray(shArray);
           ambientLight.diffuseSphericalHarmonics = sh;
           ambientLight.specularTexture = texture;
           ambientLight.specularTextureDecodeRGBM = true;

--- a/packages/loader/src/HDRLoader.ts
+++ b/packages/loader/src/HDRLoader.ts
@@ -114,12 +114,12 @@ class HDRLoader extends Loader<TextureCube> {
   ): Uint8ClampedArray {
     const textureArray = new Uint8ClampedArray(texSize * texSize * 4);
     const rotDX1 = this._tempVector3
-      .setValue(0, 0, 0)
+      .set(0, 0, 0)
       .add(faceData[1])
       .subtract(faceData[0])
       .scale(1 / texSize);
     const rotDX2 = this._temp2Vector3
-      .setValue(0, 0, 0)
+      .set(0, 0, 0)
       .add(faceData[3])
       .subtract(faceData[2])
       .scale(1 / texSize);
@@ -128,11 +128,11 @@ class HDRLoader extends Loader<TextureCube> {
     let fy = 0;
 
     for (let y = 0; y < texSize; y++) {
-      let xv1 = this._temp3Vector3.setValue(0, 0, 0).add(faceData[0]);
-      let xv2 = this._temp4Vector3.setValue(0, 0, 0).add(faceData[2]);
+      let xv1 = this._temp3Vector3.set(0, 0, 0).add(faceData[0]);
+      let xv2 = this._temp4Vector3.set(0, 0, 0).add(faceData[2]);
 
       for (let x = 0; x < texSize; x++) {
-        const v = this._temp5Vector3.setValue(0, 0, 0).add(xv2).subtract(xv1).scale(fy).add(xv1);
+        const v = this._temp5Vector3.set(0, 0, 0).add(xv2).subtract(xv1).scale(fy).add(xv1);
         v.normalize();
 
         const color = this._calcProjectionSpherical(v, pixels, inputWidth, inputHeight);

--- a/packages/loader/src/SpriteAtlasLoader.ts
+++ b/packages/loader/src/SpriteAtlasLoader.ts
@@ -1,13 +1,7 @@
 import {
-  resourceLoader,
-  Loader,
   AssetPromise,
-  AssetType,
-  LoadItem,
-  ResourceManager,
-  Texture2D,
-  Sprite,
-  SpriteAtlas
+  AssetType, Loader, LoadItem, resourceLoader, ResourceManager, Sprite,
+  SpriteAtlas, Texture2D
 } from "@oasis-engine/core";
 import { AtlasConfig } from "@oasis-engine/core/types/2d/atlas/types";
 import { Rect, Vector2 } from "@oasis-engine/math";
@@ -55,12 +49,12 @@ class SpriteAtlasLoader extends Loader<SpriteAtlas> {
                 const sprite = new Sprite(
                   engine,
                   texture,
-                  region ? tempRect.setValue(region.x, region.y, region.w, region.h) : undefined,
-                  pivot ? tempVect2.setValue(pivot.x, pivot.y) : undefined,
+                  region ? tempRect.set(region.x, region.y, region.w, region.h) : undefined,
+                  pivot ? tempVect2.set(pivot.x, pivot.y) : undefined,
                   atlasSprite.pixelsPerUnit || undefined,
                   atlasSprite.name
                 );
-                sprite.atlasRegion.setValue(
+                sprite.atlasRegion.set(
                   atlasRegion.x * sourceWidthReciprocal,
                   atlasRegion.y * sourceHeightReciprocal,
                   atlasRegion.w * sourceWidthReciprocal,
@@ -77,7 +71,7 @@ class SpriteAtlasLoader extends Loader<SpriteAtlas> {
                     originalWReciprocal = 1 / (offsetLeft + atlasRegion.w + offsetRight);
                     originalHReciprocal = 1 / (offsetTop + atlasRegion.h + offsetBottom);
                   }
-                  sprite.atlasRegionOffset.setValue(
+                  sprite.atlasRegionOffset.set(
                     offsetLeft * originalWReciprocal,
                     offsetTop * originalHReciprocal,
                     offsetRight * originalWReciprocal,

--- a/packages/loader/src/gltf/extensions/KHR_lights_punctual.ts
+++ b/packages/loader/src/gltf/extensions/KHR_lights_punctual.ts
@@ -19,7 +19,7 @@ class KHR_lights_punctual extends ExtensionParser {
     }
 
     if (color) {
-      light.color.setValue(color[0], color[1], color[2], 1);
+      light.color.set(color[0], color[1], color[2], 1);
     }
 
     light.intensity = intensity;

--- a/packages/loader/src/gltf/parser/EntityParser.ts
+++ b/packages/loader/src/gltf/parser/EntityParser.ts
@@ -23,7 +23,7 @@ export class EntityParser extends Parser {
       const { transform } = entity;
       if (matrix) {
         const localMatrix = transform.localMatrix;
-        localMatrix.setValueByArray(matrix);
+        localMatrix.copyFromArray(matrix);
         transform.localMatrix = localMatrix;
       } else {
         if (translation) {

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -121,19 +121,19 @@ export class MeshParser extends Parser {
     const { bounds } = mesh;
     vertexCount = accessor.count;
     if (accessor.min && accessor.max) {
-      bounds.min.setValueByArray(accessor.min);
-      bounds.max.setValueByArray(accessor.max);
+      bounds.min.copyFromArray(accessor.min);
+      bounds.max.copyFromArray(accessor.max);
     } else {
       const position = MeshParser._tempVector3;
       const { min, max } = bounds;
 
-      min.setValue(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
-      max.setValue(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
+      min.set(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
+      max.set(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
 
       const stride = positionBuffer.length / vertexCount;
       for (let j = 0; j < vertexCount; j++) {
         const offset = j * stride;
-        position.setValueByArray(positionBuffer, offset);
+        position.copyFromArray(positionBuffer, offset);
         Vector3.min(min, position, min);
         Vector3.max(max, position, max);
       }

--- a/packages/loader/src/gltf/parser/SkinParser.ts
+++ b/packages/loader/src/gltf/parser/SkinParser.ts
@@ -25,7 +25,7 @@ export class SkinParser extends Parser {
       const buffer = GLTFUtil.getAccessorData(gltf, accessor, buffers);
       for (let i = 0; i < jointCount; i++) {
         const inverseBindMatrix = new Matrix();
-        inverseBindMatrix.setValueByArray(buffer, i * 16);
+        inverseBindMatrix.copyFromArray(buffer, i * 16);
         skin.inverseBindMatrices[i] = inverseBindMatrix;
       }
 

--- a/packages/math/src/BoundingBox.ts
+++ b/packages/math/src/BoundingBox.ts
@@ -1,12 +1,13 @@
 import { BoundingSphere } from "./BoundingSphere";
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { Matrix } from "./Matrix";
 import { Vector3 } from "./Vector3";
 
 /**
  * Axis Aligned Bound Box (AABB).
  */
-export class BoundingBox implements IClone {
+export class BoundingBox implements IClone<BoundingBox>, ICopy<BoundingBox, BoundingBox> {
   private static _tempVec30: Vector3 = new Vector3();
   private static _tempVec31: Vector3 = new Vector3();
 

--- a/packages/math/src/BoundingBox.ts
+++ b/packages/math/src/BoundingBox.ts
@@ -1,5 +1,5 @@
-import { IClone } from "./IClone";
 import { BoundingSphere } from "./BoundingSphere";
+import { IClone } from "./IClone";
 import { Matrix } from "./Matrix";
 import { Vector3 } from "./Vector3";
 
@@ -108,27 +108,8 @@ export class BoundingBox implements IClone {
    * @param max - The maximum point of the box
    */
   constructor(min: Vector3 = null, max: Vector3 = null) {
-    min && min.cloneTo(this.min);
-    max && max.cloneTo(this.max);
-  }
-
-  /**
-   * Creates a clone of this box.
-   * @returns A clone of this box
-   */
-  clone(): BoundingBox {
-    return new BoundingBox(this.min, this.max);
-  }
-
-  /**
-   * Clones this box to the specified box.
-   * @param out - The specified box
-   * @returns The specified box
-   */
-  cloneTo(out: BoundingBox): BoundingBox {
-    this.min.cloneTo(out.min);
-    this.max.cloneTo(out.max);
-    return out;
+    min && this.min.copyFrom(min);
+    max && this.max.copyFrom(max);
   }
 
   /**
@@ -175,14 +156,14 @@ export class BoundingBox implements IClone {
       }
     }
 
-    out[0].setValue(minX, maxY, maxZ);
-    out[1].setValue(maxX, maxY, maxZ);
-    out[2].setValue(maxX, minY, maxZ);
-    out[3].setValue(minX, minY, maxZ);
-    out[4].setValue(minX, maxY, minZ);
-    out[5].setValue(maxX, maxY, minZ);
-    out[6].setValue(maxX, minY, minZ);
-    out[7].setValue(minX, minY, minZ);
+    out[0].set(minX, maxY, maxZ);
+    out[1].set(maxX, maxY, maxZ);
+    out[2].set(maxX, minY, maxZ);
+    out[3].set(minX, minY, maxZ);
+    out[4].set(minX, maxY, minZ);
+    out[5].set(maxX, maxY, minZ);
+    out[6].set(maxX, minY, minZ);
+    out[7].set(minX, minY, minZ);
 
     return out;
   }
@@ -194,6 +175,25 @@ export class BoundingBox implements IClone {
    */
   public transform(matrix: Matrix): BoundingBox {
     BoundingBox.transform(this, matrix, this);
+    return this;
+  }
+
+  /**
+   * Creates a clone of this box.
+   * @returns A clone of this box
+   */
+  clone(): BoundingBox {
+    return new BoundingBox(this.min, this.max);
+  }
+
+  /**
+   * Copy this bounding box from the specified box.
+   * @param source - The specified box
+   * @returns This bounding box
+   */
+  copyFrom(source: BoundingBox): BoundingBox {
+    this.min.copyFrom(source.min);
+    this.max.copyFrom(source.max);
     return this;
   }
 }

--- a/packages/math/src/BoundingFrustum.ts
+++ b/packages/math/src/BoundingFrustum.ts
@@ -39,31 +39,6 @@ export class BoundingFrustum implements IClone {
   }
 
   /**
-   * Creates a clone of this frustum.
-   * @returns A clone of this frustum
-   */
-  clone(): BoundingFrustum {
-    const bf = new BoundingFrustum();
-    this.cloneTo(bf);
-    return bf;
-  }
-
-  /**
-   * Clones this frustum to the specified frustum.
-   * @param out - The specified frustum
-   * @returns The specified frustum
-   */
-  cloneTo(out: BoundingFrustum): BoundingFrustum {
-    this.near.cloneTo(out.near);
-    this.far.cloneTo(out.far);
-    this.left.cloneTo(out.left);
-    this.right.cloneTo(out.right);
-    this.top.cloneTo(out.top);
-    this.bottom.cloneTo(out.bottom);
-    return out;
-  }
-
-  /**
    * Get the plane by the given index.
    * 0: near
    * 1: far
@@ -118,38 +93,38 @@ export class BoundingFrustum implements IClone {
 
     // near
     const nearNormal = this.near.normal;
-    nearNormal.setValue(-m14 - m13, -m24 - m23, -m34 - m33);
+    nearNormal.set(-m14 - m13, -m24 - m23, -m34 - m33);
     this.near.distance = -m44 - m43;
     this.near.normalize();
 
     // far
     const farNormal = this.far.normal;
-    farNormal.setValue(m13 - m14, m23 - m24, m33 - m34);
+    farNormal.set(m13 - m14, m23 - m24, m33 - m34);
     this.far.distance = m43 - m44;
 
     this.far.normalize();
 
     // left
     const leftNormal = this.left.normal;
-    leftNormal.setValue(-m14 - m11, -m24 - m21, -m34 - m31);
+    leftNormal.set(-m14 - m11, -m24 - m21, -m34 - m31);
     this.left.distance = -m44 - m41;
     this.left.normalize();
 
     // right
     const rightNormal = this.right.normal;
-    rightNormal.setValue(m11 - m14, m21 - m24, m31 - m34);
+    rightNormal.set(m11 - m14, m21 - m24, m31 - m34);
     this.right.distance = m41 - m44;
     this.right.normalize();
 
     // top
     const topNormal = this.top.normal;
-    topNormal.setValue(m12 - m14, m22 - m24, m32 - m34);
+    topNormal.set(m12 - m14, m22 - m24, m32 - m34);
     this.top.distance = m42 - m44;
     this.top.normalize();
 
     // bottom
     const bottomNormal = this.bottom.normal;
-    bottomNormal.setValue(-m14 - m12, -m24 - m22, -m34 - m32);
+    bottomNormal.set(-m14 - m12, -m24 - m22, -m34 - m32);
     this.bottom.distance = -m44 - m42;
     this.bottom.normalize();
   }
@@ -170,5 +145,30 @@ export class BoundingFrustum implements IClone {
    */
   public intersectsSphere(sphere: BoundingSphere): boolean {
     return CollisionUtil.frustumContainsSphere(this, sphere) !== ContainmentType.Disjoint;
+  }
+
+  /**
+   * Creates a clone of this frustum.
+   * @returns A clone of this frustum
+   */
+  clone(): BoundingFrustum {
+    const out = new BoundingFrustum();
+    out.copyFrom(this);
+    return out;
+  }
+
+  /**
+   * Copy this frustum from the specified frustum.
+   * @param source - The specified frustum
+   * @returns This frustum
+   */
+  copyFrom(source: BoundingFrustum): BoundingFrustum {
+    this.near.copyFrom(source.near);
+    this.far.copyFrom(source.far);
+    this.left.copyFrom(source.left);
+    this.right.copyFrom(source.right);
+    this.top.copyFrom(source.top);
+    this.bottom.copyFrom(source.bottom);
+    return this;
   }
 }

--- a/packages/math/src/BoundingFrustum.ts
+++ b/packages/math/src/BoundingFrustum.ts
@@ -3,13 +3,14 @@ import { BoundingSphere } from "./BoundingSphere";
 import { CollisionUtil } from "./CollisionUtil";
 import { ContainmentType } from "./enums/ContainmentType";
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { Matrix } from "./Matrix";
 import { Plane } from "./Plane";
 
 /**
  * A bounding frustum.
  */
-export class BoundingFrustum implements IClone {
+export class BoundingFrustum implements IClone<BoundingFrustum>, ICopy<BoundingFrustum, BoundingFrustum> {
   /** The near plane of this frustum. */
   public near: Plane;
   /** The far plane of this frustum. */

--- a/packages/math/src/BoundingSphere.ts
+++ b/packages/math/src/BoundingSphere.ts
@@ -1,11 +1,12 @@
 import { BoundingBox } from "./BoundingBox";
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { Vector3 } from "./Vector3";
 
 /**
  * A bounding sphere.
  * */
-export class BoundingSphere implements IClone {
+export class BoundingSphere implements IClone<BoundingSphere>, ICopy<BoundingSphere, BoundingSphere> {
   private static _tempVec30: Vector3 = new Vector3();
 
   /**

--- a/packages/math/src/BoundingSphere.ts
+++ b/packages/math/src/BoundingSphere.ts
@@ -1,5 +1,5 @@
-import { IClone } from "./IClone";
 import { BoundingBox } from "./BoundingBox";
+import { IClone } from "./IClone";
 import { Vector3 } from "./Vector3";
 
 /**
@@ -66,7 +66,7 @@ export class BoundingSphere implements IClone {
    * @param radius - The radius of the sphere
    */
   constructor(center: Vector3 = null, radius: number = 0) {
-    center && center.cloneTo(this.center);
+    center && this.center.copyFrom(center);
     this.radius = radius;
   }
 
@@ -79,13 +79,13 @@ export class BoundingSphere implements IClone {
   }
 
   /**
-   * Clones this sphere to the specified sphere.
-   * @param out - The specified sphere
-   * @returns The specified sphere
+   * Copy this sphere from the specified sphere.
+   * @param source - The specified sphere
+   * @returns This sphere
    */
-  cloneTo(out: BoundingSphere): BoundingSphere {
-    this.center.cloneTo(out.center);
-    out.radius = this.radius;
-    return out;
+  copyFrom(source: BoundingSphere): BoundingSphere {
+    this.center.copyFrom(source.center);
+    this.radius = source.radius;
+    return this;
   }
 }

--- a/packages/math/src/CollisionUtil.ts
+++ b/packages/math/src/CollisionUtil.ts
@@ -299,7 +299,7 @@ export class CollisionUtil {
     const min = box.min;
 
     const closestPoint = CollisionUtil._tempVec30;
-    closestPoint.setValue(
+    closestPoint.set(
       Math.max(min.x, Math.min(center.x, max.x)),
       Math.max(min.y, Math.min(center.y, max.y)),
       Math.max(min.z, Math.min(center.z, max.z))
@@ -323,7 +323,7 @@ export class CollisionUtil {
       const plane = frustum.getPlane(i);
       const normal = plane.normal;
 
-      back.setValue(normal.x >= 0 ? min.x : max.x, normal.y >= 0 ? min.y : max.y, normal.z >= 0 ? min.z : max.z);
+      back.set(normal.x >= 0 ? min.x : max.x, normal.y >= 0 ? min.y : max.y, normal.z >= 0 ? min.z : max.z);
       if (Vector3.dot(plane.normal, back) > -plane.distance) {
         return false;
       }

--- a/packages/math/src/Color.ts
+++ b/packages/math/src/Color.ts
@@ -1,10 +1,11 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 
 /**
  * Describes a color in the from of RGBA (in order: R, G, B, A).
  */
-export class Color implements IClone {
+export class Color implements IClone<Color>, ICopy<ColorLike, Color> {
   /**
    * Modify a value from the gamma space to the linear space.
    * @param value - The value in gamma space

--- a/packages/math/src/Color.ts
+++ b/packages/math/src/Color.ts
@@ -113,7 +113,7 @@ export class Color implements IClone {
    * @param a - The alpha component of the color
    * @returns This color.
    */
-  setValue(r: number, g: number, b: number, a: number): Color {
+  set(r: number, g: number, b: number, a: number): Color {
     this.r = r;
     this.g = g;
     this.b = b;
@@ -159,16 +159,16 @@ export class Color implements IClone {
   }
 
   /**
-   * Clones this color to the specified color.
-   * @param out - The specified color
-   * @returns The specified color
+   * Copy from color like object.
+   * @param source - Color like object.
+   * @returns This vector
    */
-  cloneTo(out: Color): Color {
-    out.r = this.r;
-    out.g = this.g;
-    out.b = this.b;
-    out.a = this.a;
-    return out;
+  copyFrom(source: ColorLike): Color {
+    this.r = source.r;
+    this.g = source.g;
+    this.b = source.b;
+    this.a = source.a;
+    return this;
   }
 
   /**
@@ -194,4 +194,15 @@ export class Color implements IClone {
     out.b = Color.linearToGammaSpace(this.b);
     return out;
   }
+}
+
+interface ColorLike {
+  /** {@inheritDoc Color.r} */
+  r: number;
+  /** {@inheritDoc Color.g} */
+  g: number;
+  /** {@inheritDoc Color.b} */
+  b: number;
+  /** {@inheritDoc Color.a} */
+  a: number;
 }

--- a/packages/math/src/IClone.ts
+++ b/packages/math/src/IClone.ts
@@ -7,10 +7,4 @@ export interface IClone {
    * @returns Clone object
    */
   clone(): Object;
-
-  /**
-   * Clone to the target object.
-   * @param target - Target object
-   */
-  cloneTo(target: Object): Object;
 }

--- a/packages/math/src/IClone.ts
+++ b/packages/math/src/IClone.ts
@@ -1,10 +1,10 @@
 /**
  * Clone interface.
  */
-export interface IClone {
+export interface IClone<T> {
   /**
    * Clone and return object.
    * @returns Clone object
    */
-  clone(): Object;
+  clone(): T;
 }

--- a/packages/math/src/ICopy.ts
+++ b/packages/math/src/ICopy.ts
@@ -1,0 +1,10 @@
+/**
+ * Copy interface.
+ */
+export interface ICopy<S, T> {
+  /**
+   * Copy from source object.
+   * @returns This object
+   */
+  copyFrom(source: S): T;
+}

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -1,4 +1,5 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 import { Matrix3x3 } from "./Matrix3x3";
 import { Quaternion } from "./Quaternion";
@@ -7,7 +8,7 @@ import { Vector3 } from "./Vector3";
 /**
  * Represents a 4x4 mathematical matrix.
  */
-export class Matrix implements IClone {
+export class Matrix implements IClone<Matrix>, ICopy<Matrix, Matrix> {
   private static readonly _tempVec30: Vector3 = new Vector3();
   private static readonly _tempVec31: Vector3 = new Vector3();
   private static readonly _tempVec32: Vector3 = new Vector3();

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -846,7 +846,7 @@ export class Matrix implements IClone {
    * @param m44 - column 4, row 4
    * @returns This matrix
    */
-  setValue(
+  set(
     m11: number,
     m12: number,
     m13: number,
@@ -887,105 +887,6 @@ export class Matrix implements IClone {
     e[15] = m44;
 
     return this;
-  }
-
-  /**
-   * Set the value of this matrix by an array.
-   * @param array - The array
-   * @param offset - The start offset of the array
-   * @returns This matrix
-   */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): Matrix {
-    const srce = this.elements;
-    for (let i = 0; i < 16; i++) {
-      srce[i] = array[i + offset];
-    }
-    return this;
-  }
-
-  /**
-   * Clone the value of this matrix to an array.
-   * @param out - The array
-   * @param outOffset - The start offset of the array
-   */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
-    const e = this.elements;
-
-    out[outOffset] = e[0];
-    out[outOffset + 1] = e[1];
-    out[outOffset + 2] = e[2];
-    out[outOffset + 3] = e[3];
-    out[outOffset + 4] = e[4];
-    out[outOffset + 5] = e[5];
-    out[outOffset + 6] = e[6];
-    out[outOffset + 7] = e[7];
-    out[outOffset + 8] = e[8];
-    out[outOffset + 9] = e[9];
-    out[outOffset + 10] = e[10];
-    out[outOffset + 11] = e[11];
-    out[outOffset + 12] = e[12];
-    out[outOffset + 13] = e[13];
-    out[outOffset + 14] = e[14];
-    out[outOffset + 15] = e[15];
-  }
-
-  /**
-   * Creates a clone of this matrix.
-   * @returns A clone of this matrix
-   */
-  clone(): Matrix {
-    const e = this.elements;
-    let ret = new Matrix(
-      e[0],
-      e[1],
-      e[2],
-      e[3],
-      e[4],
-      e[5],
-      e[6],
-      e[7],
-      e[8],
-      e[9],
-      e[10],
-      e[11],
-      e[12],
-      e[13],
-      e[14],
-      e[15]
-    );
-    return ret;
-  }
-
-  /**
-   * Clones this matrix to the specified matrix.
-   * @param out - The specified matrix
-   * @returns The specified matrix
-   */
-  cloneTo(out: Matrix): Matrix {
-    const e = this.elements;
-    const oe = out.elements;
-
-    oe[0] = e[0];
-    oe[1] = e[1];
-    oe[2] = e[2];
-    oe[3] = e[3];
-
-    oe[4] = e[4];
-    oe[5] = e[5];
-    oe[6] = e[6];
-    oe[7] = e[7];
-
-    oe[8] = e[8];
-    oe[9] = e[9];
-    oe[10] = e[10];
-    oe[11] = e[11];
-
-    oe[12] = e[12];
-    oe[13] = e[13];
-    oe[14] = e[14];
-    oe[15] = e[15];
-
-    return out;
   }
 
   /**
@@ -1064,7 +965,7 @@ export class Matrix implements IClone {
     const m32 = e[9];
     const m33 = e[10];
     const m34 = e[11];
-    translation.setValue(e[12], e[13], e[14]);
+    translation.set(e[12], e[13], e[14]);
 
     const xs = Math.sign(m11 * m12 * m13 * m14) < 0 ? -1 : 1;
     const ys = Math.sign(m21 * m22 * m23 * m24) < 0 ? -1 : 1;
@@ -1073,7 +974,7 @@ export class Matrix implements IClone {
     const sx = xs * Math.sqrt(m11 * m11 + m12 * m12 + m13 * m13);
     const sy = ys * Math.sqrt(m21 * m21 + m22 * m22 + m23 * m23);
     const sz = zs * Math.sqrt(m31 * m31 + m32 * m32 + m33 * m33);
-    scale.setValue(sx, sy, sz);
+    scale.set(sx, sy, sz);
 
     if (
       Math.abs(sx) < MathUtil.zeroTolerance ||
@@ -1158,7 +1059,11 @@ export class Matrix implements IClone {
       m32 = e[9],
       m33 = e[10];
 
-    out.setValue(Math.sqrt(m11 * m11 + m12 * m12 + m13 * m13), Math.sqrt(m21 * m21 + m22 * m22 + m23 * m23), Math.sqrt(m31 * m31 + m32 * m32 + m33 * m33));
+    out.set(
+      Math.sqrt(m11 * m11 + m12 * m12 + m13 * m13),
+      Math.sqrt(m21 * m21 + m22 * m22 + m23 * m23),
+      Math.sqrt(m31 * m31 + m32 * m32 + m33 * m33)
+    );
 
     return out;
   }
@@ -1170,7 +1075,7 @@ export class Matrix implements IClone {
    */
   getTranslation(out: Vector3): Vector3 {
     const e = this.elements;
-    out.setValue(e[12], e[13], e[14]);
+    out.set(e[12], e[13], e[14]);
     return out;
   }
 
@@ -1251,5 +1156,104 @@ export class Matrix implements IClone {
   transpose(): Matrix {
     Matrix.transpose(this, this);
     return this;
+  }
+
+  /**
+   * Creates a clone of this matrix.
+   * @returns A clone of this matrix
+   */
+  clone(): Matrix {
+    const e = this.elements;
+    let ret = new Matrix(
+      e[0],
+      e[1],
+      e[2],
+      e[3],
+      e[4],
+      e[5],
+      e[6],
+      e[7],
+      e[8],
+      e[9],
+      e[10],
+      e[11],
+      e[12],
+      e[13],
+      e[14],
+      e[15]
+    );
+    return ret;
+  }
+
+  /**
+   * Copy this matrix from the specified matrix.
+   * @param source - The specified matrix
+   * @returns This matrix
+   */
+  copyFrom(source: Matrix): Matrix {
+    const e = this.elements;
+    const se = source.elements;
+
+    e[0] = se[0];
+    e[1] = se[1];
+    e[2] = se[2];
+    e[3] = se[3];
+
+    e[4] = se[4];
+    e[5] = se[5];
+    e[6] = se[6];
+    e[7] = se[7];
+
+    e[8] = se[8];
+    e[9] = se[9];
+    e[10] = se[10];
+    e[11] = se[11];
+
+    e[12] = se[12];
+    e[13] = se[13];
+    e[14] = se[14];
+    e[15] = se[15];
+
+    return this;
+  }
+
+  /**
+   * Copy the value of this matrix from an array.
+   * @param array - The array
+   * @param offset - The start offset of the array
+   * @returns This matrix
+   */
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): Matrix {
+    const srce = this.elements;
+    for (let i = 0; i < 16; i++) {
+      srce[i] = array[i + offset];
+    }
+    return this;
+  }
+
+  /**
+   * Copy the value of this matrix to an array.
+   * @param out - The array
+   * @param outOffset - The start offset of the array
+   */
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0): void {
+    const e = this.elements;
+
+    out[outOffset] = e[0];
+    out[outOffset + 1] = e[1];
+    out[outOffset + 2] = e[2];
+    out[outOffset + 3] = e[3];
+    out[outOffset + 4] = e[4];
+    out[outOffset + 5] = e[5];
+    out[outOffset + 6] = e[6];
+    out[outOffset + 7] = e[7];
+    out[outOffset + 8] = e[8];
+    out[outOffset + 9] = e[9];
+    out[outOffset + 10] = e[10];
+    out[outOffset + 11] = e[11];
+    out[outOffset + 12] = e[12];
+    out[outOffset + 13] = e[13];
+    out[outOffset + 14] = e[14];
+    out[outOffset + 15] = e[15];
   }
 }

--- a/packages/math/src/Matrix3x3.ts
+++ b/packages/math/src/Matrix3x3.ts
@@ -515,7 +515,7 @@ export class Matrix3x3 implements IClone {
    * @param m33
    * @returns This matrix
    */
-  setValue(
+  set(
     m11: number,
     m12: number,
     m13: number,
@@ -541,98 +541,6 @@ export class Matrix3x3 implements IClone {
     e[8] = m33;
 
     return this;
-  }
-
-  /**
-   * Set the value of this matrix by an array.
-   * @param array - The array
-   * @param offset - The start offset of the array
-   * @returns This matrix
-   */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): Matrix3x3 {
-    const srce = this.elements;
-    for (let i = 0; i < 12; i++) {
-      srce[i] = array[i + offset];
-    }
-    return this;
-  }
-
-  /**
-   * Set the value of this 3x3 matrix by the specified 4x4 matrix.
-   * upper-left principle
-   * @param a - The specified 4x4 matrix
-   * @returns This 3x3 matrix
-   */
-  setValueByMatrix(a: Matrix): Matrix3x3 {
-    const ae = a.elements;
-    const e = this.elements;
-
-    e[0] = ae[0];
-    e[1] = ae[1];
-    e[2] = ae[2];
-
-    e[3] = ae[4];
-    e[4] = ae[5];
-    e[5] = ae[6];
-
-    e[6] = ae[8];
-    e[7] = ae[9];
-    e[8] = ae[10];
-
-    return this;
-  }
-
-  /**
-   * Clone the value of this matrix to an array.
-   * @param out - The array
-   * @param outOffset - The start offset of the array
-   */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
-    const e = this.elements;
-
-    out[outOffset] = e[0];
-    out[outOffset + 1] = e[1];
-    out[outOffset + 2] = e[2];
-    out[outOffset + 3] = e[3];
-    out[outOffset + 4] = e[4];
-    out[outOffset + 5] = e[5];
-    out[outOffset + 6] = e[6];
-    out[outOffset + 7] = e[7];
-    out[outOffset + 8] = e[8];
-  }
-
-  /**
-   * Creates a clone of this matrix.
-   * @returns A clone of this matrix
-   */
-  clone(): Matrix3x3 {
-    const e = this.elements;
-    let ret = new Matrix3x3(e[0], e[1], e[2], e[3], e[4], e[5], e[6], e[7], e[8]);
-    return ret;
-  }
-
-  /**
-   * Clones this matrix to the specified matrix.
-   * @param out - The specified matrix
-   * @returns The specified matrix
-   */
-  cloneTo(out: Matrix3x3): Matrix3x3 {
-    const e = this.elements;
-    const oe = out.elements;
-
-    oe[0] = e[0];
-    oe[1] = e[1];
-    oe[2] = e[2];
-
-    oe[3] = e[3];
-    oe[4] = e[4];
-    oe[5] = e[5];
-
-    oe[6] = e[6];
-    oe[7] = e[7];
-    oe[8] = e[8];
-
-    return out;
   }
 
   /**
@@ -756,6 +664,98 @@ export class Matrix3x3 implements IClone {
    */
   transpose(): Matrix3x3 {
     Matrix3x3.transpose(this, this);
+    return this;
+  }
+
+  /**
+   * Creates a clone of this matrix.
+   * @returns A clone of this matrix
+   */
+  clone(): Matrix3x3 {
+    const e = this.elements;
+    let ret = new Matrix3x3(e[0], e[1], e[2], e[3], e[4], e[5], e[6], e[7], e[8]);
+    return ret;
+  }
+
+  /**
+   * Copy this matrix from the specified matrix.
+   * @param source - The specified matrix
+   * @returns This matrix
+   */
+  cloneTo(source: Matrix3x3): Matrix3x3 {
+    const e = this.elements;
+    const se = source.elements;
+
+    e[0] = se[0];
+    e[1] = se[1];
+    e[2] = se[2];
+
+    e[3] = se[3];
+    e[4] = se[4];
+    e[5] = se[5];
+
+    e[6] = se[6];
+    e[7] = se[7];
+    e[8] = se[8];
+
+    return this;
+  }
+
+  /**
+   * Copy the value of this matrix from an array.
+   * @param array - The array
+   * @param offset - The start offset of the array
+   * @returns This matrix
+   */
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): Matrix3x3 {
+    const srce = this.elements;
+    for (let i = 0; i < 12; i++) {
+      srce[i] = array[i + offset];
+    }
+    return this;
+  }
+
+  /**
+   * Copy the value of this matrix to an array.
+   * @param out - The array
+   * @param outOffset - The start offset of the array
+   */
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0): void {
+    const e = this.elements;
+
+    out[outOffset] = e[0];
+    out[outOffset + 1] = e[1];
+    out[outOffset + 2] = e[2];
+    out[outOffset + 3] = e[3];
+    out[outOffset + 4] = e[4];
+    out[outOffset + 5] = e[5];
+    out[outOffset + 6] = e[6];
+    out[outOffset + 7] = e[7];
+    out[outOffset + 8] = e[8];
+  }
+
+  /**
+   * Copy the value of this 3x3 matrix from the specified 4x4 matrix.
+   * upper-left principle
+   * @param source - The specified 4x4 matrix
+   * @returns This 3x3 matrix
+   */
+  copyFromMatrix(source: Matrix): Matrix3x3 {
+    const ae = source.elements;
+    const e = this.elements;
+
+    e[0] = ae[0];
+    e[1] = ae[1];
+    e[2] = ae[2];
+
+    e[3] = ae[4];
+    e[4] = ae[5];
+    e[5] = ae[6];
+
+    e[6] = ae[8];
+    e[7] = ae[9];
+    e[8] = ae[10];
+
     return this;
   }
 }

--- a/packages/math/src/Matrix3x3.ts
+++ b/packages/math/src/Matrix3x3.ts
@@ -1,4 +1,5 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 import { Matrix } from "./Matrix";
 import { Quaternion } from "./Quaternion";
@@ -7,7 +8,7 @@ import { Vector2 } from "./Vector2";
 /**
  * Represents a 3x3 mathematical matrix.
  */
-export class Matrix3x3 implements IClone {
+export class Matrix3x3 implements IClone<Matrix3x3>, ICopy<Matrix3x3, Matrix3x3> {
   /**
    * Determines the sum of two matrices.
    * @param left - The first matrix to add
@@ -682,7 +683,7 @@ export class Matrix3x3 implements IClone {
    * @param source - The specified matrix
    * @returns This matrix
    */
-  cloneTo(source: Matrix3x3): Matrix3x3 {
+  copyFrom(source: Matrix3x3): Matrix3x3 {
     const e = this.elements;
     const se = source.elements;
 

--- a/packages/math/src/Plane.ts
+++ b/packages/math/src/Plane.ts
@@ -1,10 +1,11 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { Vector3 } from "./Vector3";
 
 /**
  * Represents a plane in three dimensional space.
  */
-export class Plane implements IClone {
+export class Plane implements IClone<Plane>, ICopy<Plane, Plane> {
   /**
    * Normalize the normal vector of the specified plane.
    * @param p - The specified plane

--- a/packages/math/src/Plane.ts
+++ b/packages/math/src/Plane.ts
@@ -63,7 +63,7 @@ export class Plane implements IClone {
    * @param distance - The distance of the plane along its normal to the origin
    */
   constructor(normal: Vector3 = null, distance: number = 0) {
-    normal && normal.cloneTo(this.normal);
+    normal && this.normal.copyFrom(normal);
     this.distance = distance;
   }
 
@@ -82,18 +82,18 @@ export class Plane implements IClone {
    */
   clone(): Plane {
     const out = new Plane();
-    this.cloneTo(out);
+    out.copyFrom(this);
     return out;
   }
 
   /**
-   * Clones this plane to the specified plane.
-   * @param out - The specified plane
-   * @returns The specified plane
+   * Copy this plane from the specified plane.
+   * @param source - The specified plane
+   * @returns This plane
    */
-  cloneTo(out: Plane): Plane {
-    this.normal.cloneTo(out.normal);
-    out.distance = this.distance;
-    return out;
+  copyFrom(source: Plane): Plane {
+    this.normal.copyFrom(source.normal);
+    this.distance = source.distance;
+    return this;
   }
 }

--- a/packages/math/src/Quaternion.ts
+++ b/packages/math/src/Quaternion.ts
@@ -1,4 +1,5 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 import { Matrix3x3 } from "./Matrix3x3";
 import { Vector3 } from "./Vector3";
@@ -6,7 +7,7 @@ import { Vector3 } from "./Vector3";
 /**
  * Represents a four dimensional mathematical quaternion.
  */
-export class Quaternion implements IClone {
+export class Quaternion implements IClone<Quaternion>, ICopy<QuaternionLike, Quaternion> {
   /** @internal */
   static readonly _tempVector3 = new Vector3();
   /** @internal */

--- a/packages/math/src/Quaternion.ts
+++ b/packages/math/src/Quaternion.ts
@@ -522,26 +522,11 @@ export class Quaternion implements IClone {
    * @param w - The w component of the quaternion
    * @returns This quaternion
    */
-  setValue(x: number, y: number, z: number, w: number): Quaternion {
+  set(x: number, y: number, z: number, w: number): Quaternion {
     this._x = x;
     this._y = y;
     this._z = z;
     this._w = w;
-    this._onValueChanged && this._onValueChanged();
-    return this;
-  }
-
-  /**
-   * Set the value of this quaternion by an array.
-   * @param array - The array
-   * @param offset - The start offset of the array
-   * @returns This quaternion
-   */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): Quaternion {
-    this._x = array[offset];
-    this._y = array[offset + 1];
-    this._z = array[offset + 2];
-    this._w = array[offset + 3];
     this._onValueChanged && this._onValueChanged();
     return this;
   }
@@ -650,40 +635,6 @@ export class Quaternion implements IClone {
   }
 
   /**
-   * Clone the value of this quaternion to an array.
-   * @param out - The array
-   * @param outOffset - The start offset of the array
-   */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
-    out[outOffset] = this._x;
-    out[outOffset + 1] = this._y;
-    out[outOffset + 2] = this._z;
-    out[outOffset + 3] = this._w;
-  }
-
-  /**
-   * Creates a clone of this quaternion.
-   * @returns A clone of this quaternion
-   */
-  clone(): Quaternion {
-    return new Quaternion(this._x, this._y, this._z, this._w);
-  }
-
-  /**
-   * Clones this quaternion to the specified quaternion.
-   * @param out - The specified quaternion
-   * @returns The specified quaternion
-   */
-  cloneTo(out: Quaternion): Quaternion {
-    out._x = this._x;
-    out._y = this._y;
-    out._z = this._z;
-    out._w = this._w;
-    out._onValueChanged && out._onValueChanged();
-    return out;
-  }
-
-  /**
    * Calculate this quaternion rotate around X axis.
    * @param rad - The rotation angle in radians
    * @returns This quaternion
@@ -775,6 +726,55 @@ export class Quaternion implements IClone {
     return this;
   }
 
+  /**
+   * Creates a clone of this quaternion.
+   * @returns A clone of this quaternion
+   */
+  clone(): Quaternion {
+    return new Quaternion(this._x, this._y, this._z, this._w);
+  }
+
+  /**
+   * Copy this quaternion from the specified quaternion.
+   * @param source - The specified quaternion
+   * @returns This quaternion
+   */
+  copyFrom(source: QuaternionLike): Quaternion {
+    this._x = source.x;
+    this._y = source.y;
+    this._z = source.z;
+    this._w = source.w;
+    this._onValueChanged && this._onValueChanged();
+    return this;
+  }
+
+  /**
+   * Copy the value of this quaternion from an array.
+   * @param array - The array
+   * @param offset - The start offset of the array
+   * @returns This quaternion
+   */
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): Quaternion {
+    this._x = array[offset];
+    this._y = array[offset + 1];
+    this._z = array[offset + 2];
+    this._w = array[offset + 3];
+    this._onValueChanged && this._onValueChanged();
+    return this;
+  }
+
+  /**
+   * Copy the value of this quaternion to an array.
+   * @param out - The array
+   * @param outOffset - The start offset of the array
+   */
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
+    out[outOffset] = this._x;
+    out[outOffset + 1] = this._y;
+    out[outOffset + 2] = this._z;
+    out[outOffset + 3] = this._w;
+  }
+
   private _toYawPitchRoll(out: Vector3): Vector3 {
     const { _x, _y, _z, _w } = this;
     const xx = _x * _x;
@@ -797,4 +797,15 @@ export class Quaternion implements IClone {
     }
     return out;
   }
+}
+
+interface QuaternionLike {
+  /** {@inheritDoc Quaternion.x} */
+  x: number;
+  /** {@inheritDoc Quaternion.y} */
+  y: number;
+  /** {@inheritDoc Quaternion.z} */
+  z: number;
+  /** {@inheritDoc Quaternion.w} */
+  w: number;
 }

--- a/packages/math/src/Ray.ts
+++ b/packages/math/src/Ray.ts
@@ -19,8 +19,8 @@ export class Ray {
    * @param direction - The direction vector
    */
   constructor(origin: Vector3 = null, direction: Vector3 = null) {
-    origin && origin.cloneTo(this.origin);
-    direction && direction.cloneTo(this.direction);
+    origin && this.origin.copyFrom(origin);
+    direction && this.direction.copyFrom(direction);
   }
 
   /**

--- a/packages/math/src/Rect.ts
+++ b/packages/math/src/Rect.ts
@@ -1,7 +1,8 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 
 // A 2d rectangle defined by x and y position, width and height.
-export class Rect implements IClone {
+export class Rect implements IClone<Rect>, ICopy<Rect, Rect> {
   /** The x coordinate of the rectangle. */
   public x: number;
   /** The y coordinate of the rectangle. */

--- a/packages/math/src/Rect.ts
+++ b/packages/math/src/Rect.ts
@@ -33,7 +33,7 @@ export class Rect implements IClone {
    * @param height - The height of the rectangle, measured from the y position
    * @returns This rectangle
    */
-  setValue(x: number, y: number, width: number, height: number): Rect {
+  set(x: number, y: number, width: number, height: number): Rect {
     this.x = x;
     this.y = y;
     this.width = width;
@@ -50,15 +50,15 @@ export class Rect implements IClone {
   }
 
   /**
-   * Clones this rect to the specified rect.
-   * @param out - The specified rect
-   * @returns The specified rect
+   * Copy this rect from the specified rect.
+   * @param source - The specified rect
+   * @returns This rect
    */
-  cloneTo(out: Rect): Rect {
-    out.x = this.x;
-    out.y = this.y;
-    out.width = this.width;
-    out.height = this.height;
-    return out;
+  copyFrom(source: Rect): Rect {
+    this.x = source.x;
+    this.y = source.y;
+    this.width = source.width;
+    this.height = source.height;
+    return this;
   }
 }

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -1,5 +1,5 @@
-import { IClone } from "./IClone";
 import { Color } from "./Color";
+import { IClone } from "./IClone";
 import { Vector3 } from "./Vector3";
 
 /**
@@ -125,7 +125,7 @@ export class SphericalHarmonics3 implements IClone {
     g += coe[13] * bv4 + coe[16] * bv5 + coe[19] * bv6 + coe[22] * bv7 + coe[25] * bv8;
     b += coe[14] * bv4 + coe[17] * bv5 + coe[20] * bv6 + coe[23] * bv7 + coe[26] * bv8;
 
-    out.setValue(r, g, b, 1.0);
+    out.set(r, g, b, 1.0);
     return out;
   }
 
@@ -148,11 +148,31 @@ export class SphericalHarmonics3 implements IClone {
   }
 
   /**
-   * Set the value of this spherical harmonics by an array.
+   * Creates a clone of this SphericalHarmonics3.
+   * @returns A clone of this SphericalHarmonics3
+   */
+  clone(): SphericalHarmonics3 {
+    const sh = new SphericalHarmonics3();
+    sh.copyFrom(this);
+    return sh;
+  }
+
+  /**
+   * Copy this SphericalHarmonics3 from the specified SphericalHarmonics3.
+   * @param source - The specified SphericalHarmonics3
+   * @returns This SphericalHarmonics3
+   */
+  copyFrom(source: SphericalHarmonics3): SphericalHarmonics3 {
+    source.copyToArray(this.coefficients);
+    return this;
+  }
+
+  /**
+   * Copy the value of this spherical harmonics from an array.
    * @param array - The array
    * @param offset - The start offset of the array
    */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): void {
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): void {
     const s = this.coefficients;
 
     (s[0] = array[offset]), (s[1] = array[1 + offset]), (s[2] = array[2 + offset]);
@@ -167,11 +187,11 @@ export class SphericalHarmonics3 implements IClone {
   }
 
   /**
-   * Clone the value of this spherical harmonics to an array.
+   * Copy the value of this spherical harmonics to an array.
    * @param out - The array
    * @param outOffset - The start offset of the array
    */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0): void {
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0): void {
     const s = this.coefficients;
 
     (out[0 + outOffset] = s[0]), (out[1 + outOffset] = s[1]), (out[2 + outOffset] = s[2]);
@@ -185,26 +205,5 @@ export class SphericalHarmonics3 implements IClone {
     (out[18 + outOffset] = s[18]), (out[19 + outOffset] = s[19]), (out[20 + outOffset] = s[20]);
     (out[21 + outOffset] = s[21]), (out[22 + outOffset] = s[22]), (out[23 + outOffset] = s[23]);
     (out[24 + outOffset] = s[24]), (out[25 + outOffset] = s[25]), (out[26 + outOffset] = s[26]);
-  }
-
-  /**
-   * Creates a clone of this SphericalHarmonics3.
-   * @returns A clone of this SphericalHarmonics3
-   */
-  clone(): SphericalHarmonics3 {
-    const v = new SphericalHarmonics3();
-    this.cloneTo(v);
-
-    return v;
-  }
-
-  /**
-   * Clones this SphericalHarmonics3 to the specified SphericalHarmonics3.
-   * @param out - The specified SphericalHarmonics3
-   * @returns The specified SphericalHarmonics3
-   */
-  cloneTo(out: SphericalHarmonics3): SphericalHarmonics3 {
-    this.toArray(out.coefficients);
-    return out;
   }
 }

--- a/packages/math/src/SphericalHarmonics3.ts
+++ b/packages/math/src/SphericalHarmonics3.ts
@@ -1,5 +1,6 @@
 import { Color } from "./Color";
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { Vector3 } from "./Vector3";
 
 /**
@@ -9,7 +10,9 @@ import { Vector3 } from "./Vector3";
  * http://www.ppsloan.org/publications/StupidSH36.pdf
  * https://google.github.io/filament/Filament.md.html#annex/sphericalharmonics
  */
-export class SphericalHarmonics3 implements IClone {
+export class SphericalHarmonics3
+  implements IClone<SphericalHarmonics3>, ICopy<SphericalHarmonics3, SphericalHarmonics3>
+{
   /** The coefficients of SphericalHarmonics3. */
   coefficients: Float32Array = new Float32Array(27);
 

--- a/packages/math/src/Vector2.ts
+++ b/packages/math/src/Vector2.ts
@@ -1,10 +1,11 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 
 /**
  * Describes a 2D-vector.
  */
-export class Vector2 implements IClone {
+export class Vector2 implements IClone<Vector2>, ICopy<Vector2Like, Vector2> {
   /** @internal */
   static readonly _zero = new Vector2(0.0, 0.0);
   /** @internal */

--- a/packages/math/src/Vector2.ts
+++ b/packages/math/src/Vector2.ts
@@ -226,22 +226,9 @@ export class Vector2 implements IClone {
    * @param y - The y component of the vector
    * @returns This vector
    */
-  setValue(x: number, y: number): Vector2 {
+  set(x: number, y: number): Vector2 {
     this._x = x;
     this._y = y;
-    this._onValueChanged && this._onValueChanged();
-    return this;
-  }
-
-  /**
-   * Set the value of this vector by an array.
-   * @param array - The array
-   * @param offset - The start offset of the array
-   * @returns This vector
-   */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): Vector2 {
-    this._x = array[offset];
-    this._y = array[offset + 1];
     this._onValueChanged && this._onValueChanged();
     return this;
   }
@@ -345,16 +332,6 @@ export class Vector2 implements IClone {
   }
 
   /**
-   * Clone the value of this vector to an array.
-   * @param out - The array
-   * @param outOffset - The start offset of the array
-   */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
-    out[outOffset] = this._x;
-    out[outOffset + 1] = this._y;
-  }
-
-  /**
    * Creates a clone of this vector.
    * @returns A clone of this vector
    */
@@ -363,14 +340,44 @@ export class Vector2 implements IClone {
   }
 
   /**
-   * Clones this vector to the specified vector.
-   * @param out - The specified vector
-   * @returns The specified vector
+   * Copy from vector2 like object.
+   * @param source - Vector2 like object
+   * @returns This vector
    */
-  cloneTo(out: Vector2): Vector2 {
-    out._x = this._x;
-    out._y = this._y;
-    out._onValueChanged && out._onValueChanged();
-    return out;
+  copyFrom(source: Vector2Like): Vector2 {
+    this._x = source.x;
+    this._y = source.y;
+    this._onValueChanged && this._onValueChanged();
+    return this;
   }
+
+  /**
+   * Copy the value of this vector from an array.
+   * @param array - The array
+   * @param offset - The start offset of the array
+   * @returns This vector
+   */
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): Vector2 {
+    this._x = array[offset];
+    this._y = array[offset + 1];
+    this._onValueChanged && this._onValueChanged();
+    return this;
+  }
+
+  /**
+   * Copy the value of this vector to an array.
+   * @param out - The array
+   * @param outOffset - The start offset of the array
+   */
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
+    out[outOffset] = this._x;
+    out[outOffset + 1] = this._y;
+  }
+}
+
+interface Vector2Like {
+  /** {@inheritDoc Vector2.x} */
+  x: number;
+  /** {@inheritDoc Vector2.y} */
+  y: number;
 }

--- a/packages/math/src/Vector3.ts
+++ b/packages/math/src/Vector3.ts
@@ -89,7 +89,7 @@ export class Vector3 implements IClone {
     const by = right._y;
     const bz = right._z;
 
-    out.setValue(ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx);
+    out.set(ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx);
   }
 
   /**
@@ -193,7 +193,7 @@ export class Vector3 implements IClone {
     let len = Math.sqrt(_x * _x + _y * _y + _z * _z);
     if (len > MathUtil.zeroTolerance) {
       len = 1 / len;
-      out.setValue(_x * len, _y * len, _z * len);
+      out.set(_x * len, _y * len, _z * len);
     }
   }
 
@@ -375,24 +375,10 @@ export class Vector3 implements IClone {
    * @param z - The z component of the vector
    * @returns This vector
    */
-  setValue(x: number, y: number, z: number): Vector3 {
+  set(x: number, y: number, z: number): Vector3 {
     this._x = x;
     this._y = y;
     this._z = z;
-    this._onValueChanged && this._onValueChanged();
-    return this;
-  }
-
-  /**
-   * Set the value of this vector by an array.
-   * @param array - The array
-   * @param offset - The start offset of the array
-   * @returns This vector
-   */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): Vector3 {
-    this._x = array[offset];
-    this._y = array[offset + 1];
-    this._z = array[offset + 2];
     this._onValueChanged && this._onValueChanged();
     return this;
   }
@@ -502,38 +488,6 @@ export class Vector3 implements IClone {
   }
 
   /**
-   * Clone the value of this vector to an array.
-   * @param out - The array
-   * @param outOffset - The start offset of the array
-   */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
-    out[outOffset] = this._x;
-    out[outOffset + 1] = this._y;
-    out[outOffset + 2] = this._z;
-  }
-
-  /**
-   * Creates a clone of this vector.
-   * @returns A clone of this vector
-   */
-  clone(): Vector3 {
-    return new Vector3(this._x, this._y, this._z);
-  }
-
-  /**
-   * Clones this vector to the specified vector.
-   * @param out - The specified vector
-   * @returns The specified vector
-   */
-  cloneTo(out: Vector3): Vector3 {
-    out._x = this._x;
-    out._y = this._y;
-    out._z = this._z;
-    out._onValueChanged && out._onValueChanged();
-    return out;
-  }
-
-  /**
    * This vector performs a normal transformation using the given 4x4 matrix.
    * @remarks
    * A normal transform performs the transformation with the assumption that the w component
@@ -584,4 +538,59 @@ export class Vector3 implements IClone {
     Vector3.transformByQuat(this, quaternion, this);
     return this;
   }
+
+  /**
+   * Creates a clone of this vector.
+   * @returns A clone of this vector
+   */
+  clone(): Vector3 {
+    return new Vector3(this._x, this._y, this._z);
+  }
+
+  /**
+   * Copy from vector3 like object.
+   * @param source - Vector3 like object.
+   * @returns This vector
+   */
+  copyFrom(source: Vector3Like): Vector3 {
+    this._x = source.x;
+    this._y = source.y;
+    this._z = source.z;
+    this._onValueChanged && this._onValueChanged();
+    return this;
+  }
+
+  /**
+   * Copy the value of this vector from an array.
+   * @param array - The array
+   * @param offset - The start offset of the array
+   * @returns This vector
+   */
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): Vector3 {
+    this._x = array[offset];
+    this._y = array[offset + 1];
+    this._z = array[offset + 2];
+    this._onValueChanged && this._onValueChanged();
+    return this;
+  }
+
+  /**
+   * Copy the value of this vector to an array.
+   * @param out - The array
+   * @param outOffset - The start offset of the array
+   */
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
+    out[outOffset] = this._x;
+    out[outOffset + 1] = this._y;
+    out[outOffset + 2] = this._z;
+  }
+}
+
+interface Vector3Like {
+  /** {@inheritDoc Vector3.x} */
+  x: number;
+  /** {@inheritDoc Vector3.y} */
+  y: number;
+  /** {@inheritDoc Vector3.z} */
+  z: number;
 }

--- a/packages/math/src/Vector3.ts
+++ b/packages/math/src/Vector3.ts
@@ -1,4 +1,5 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 import { Matrix } from "./Matrix";
 import { Quaternion } from "./Quaternion";
@@ -7,7 +8,7 @@ import { Vector4 } from "./Vector4";
 /**
  * Describes a 3D-vector.
  */
-export class Vector3 implements IClone {
+export class Vector3 implements IClone<Vector3>, ICopy<Vector3Like, Vector3> {
   /** @internal */
   static readonly _zero = new Vector3(0.0, 0.0, 0.0);
   /** @internal */

--- a/packages/math/src/Vector4.ts
+++ b/packages/math/src/Vector4.ts
@@ -334,26 +334,11 @@ export class Vector4 implements IClone {
    * @param w - The w component of the vector
    * @returns This vector
    */
-  setValue(x: number, y: number, z: number, w: number): Vector4 {
+  set(x: number, y: number, z: number, w: number): Vector4 {
     this._x = x;
     this._y = y;
     this._z = z;
     this._w = w;
-    this._onValueChanged && this._onValueChanged();
-    return this;
-  }
-
-  /**
-   * Set the value of this vector by an array.
-   * @param array - The array
-   * @param offset - The start offset of the array
-   * @returns This vector
-   */
-  setValueByArray(array: ArrayLike<number>, offset: number = 0): Vector4 {
-    this._x = array[offset];
-    this._y = array[offset + 1];
-    this._z = array[offset + 2];
-    this._w = array[offset + 3];
     this._onValueChanged && this._onValueChanged();
     return this;
   }
@@ -469,18 +454,6 @@ export class Vector4 implements IClone {
   }
 
   /**
-   * Clone the value of this vector to an array.
-   * @param out - The array
-   * @param outOffset - The start offset of the array
-   */
-  toArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
-    out[outOffset] = this._x;
-    out[outOffset + 1] = this._y;
-    out[outOffset + 2] = this._z;
-    out[outOffset + 3] = this._w;
-  }
-
-  /**
    * Creates a clone of this vector.
    * @returns A clone of this vector
    */
@@ -490,16 +463,54 @@ export class Vector4 implements IClone {
   }
 
   /**
-   * Clones this vector to the specified vector.
-   * @param out - The specified vector
-   * @returns The specified vector
+   * Copy from vector3 like object.
+   * @param source - Vector3 like object.
+   * @returns This vector
    */
-  cloneTo(out: Vector4): Vector4 {
-    out._x = this._x;
-    out._y = this._y;
-    out._z = this._z;
-    out._w = this._w;
-    out._onValueChanged && out._onValueChanged();
-    return out;
+  copyFrom(source: Vector4Like): Vector4 {
+    this._x = source.x;
+    this._y = source.y;
+    this._z = source.z;
+    this._w = source.w;
+    this._onValueChanged && this._onValueChanged();
+    return this;
   }
+
+  /**
+   * Copy the value of this vector by an array.
+   * @param array - The arrayƒ
+   * @param offset - The start offset of the array
+   * @returns This vector
+   */
+  copyFromArray(array: ArrayLike<number>, offset: number = 0): Vector4 {
+    this._x = array[offset];
+    this._y = array[offset + 1];
+    this._z = array[offset + 2];
+    this._w = array[offset + 3];
+    this._onValueChanged && this._onValueChanged();
+    return this;
+  }
+
+  /**
+   * Copy the value of this vector to an array.
+   * @param out - The array
+   * @param outOffset - The start offset of the array
+   */
+  copyToArray(out: number[] | Float32Array | Float64Array, outOffset: number = 0) {
+    out[outOffset] = this._x;
+    out[outOffset + 1] = this._y;
+    out[outOffset + 2] = this._z;
+    out[outOffset + 3] = this._w;
+  }
+}
+
+interface Vector4Like {
+  /** {@inheritDoc Vector4.x} */
+  x: number;
+  /** {@inheritDoc Vector4.y} */
+  y: number;
+  /** {@inheritDoc Vector4.z} */
+  z: number;
+  /** {@inheritDoc Vector4.w} */
+  w: number;
 }

--- a/packages/math/src/Vector4.ts
+++ b/packages/math/src/Vector4.ts
@@ -1,4 +1,5 @@
 import { IClone } from "./IClone";
+import { ICopy } from "./ICopy";
 import { MathUtil } from "./MathUtil";
 import { Matrix } from "./Matrix";
 import { Quaternion } from "./Quaternion";
@@ -6,7 +7,7 @@ import { Quaternion } from "./Quaternion";
 /**
  * Describes a 4D-vector.
  */
-export class Vector4 implements IClone {
+export class Vector4 implements IClone<Vector4>, ICopy<Vector4Like, Vector4> {
   /** @internal */
   static readonly _zero = new Vector4(0.0, 0.0, 0.0, 0.0);
   /** @internal */

--- a/packages/physics-lite/src/LiteCollider.ts
+++ b/packages/physics-lite/src/LiteCollider.ts
@@ -55,8 +55,8 @@ export abstract class LiteCollider implements ICollider {
    */
   getWorldTransform(outPosition: Vector3, outRotation: Quaternion): void {
     const { position, rotationQuaternion } = this._transform;
-    outPosition.setValue(position.x, position.y, position.z);
-    outRotation.setValue(rotationQuaternion.x, rotationQuaternion.y, rotationQuaternion.z, rotationQuaternion.w);
+    outPosition.set(position.x, position.y, position.z);
+    outRotation.set(rotationQuaternion.x, rotationQuaternion.y, rotationQuaternion.z, rotationQuaternion.w);
   }
 
   /**

--- a/packages/physics-lite/src/LitePhysicsManager.ts
+++ b/packages/physics-lite/src/LitePhysicsManager.ts
@@ -1,12 +1,11 @@
 import { ICharacterController, IPhysicsManager } from "@oasis-engine/design";
-import { BoundingBox, BoundingSphere, Ray, Vector3, CollisionUtil } from "oasis-engine";
+import { BoundingBox, BoundingSphere, CollisionUtil, Ray, Vector3 } from "oasis-engine";
+import { DisorderedArray } from "./DisorderedArray";
 import { LiteCollider } from "./LiteCollider";
 import { LiteHitResult } from "./LiteHitResult";
 import { LiteBoxColliderShape } from "./shape/LiteBoxColliderShape";
-import { LiteSphereColliderShape } from "./shape/LiteSphereColliderShape";
 import { LiteColliderShape } from "./shape/LiteColliderShape";
-import { DisorderedArray } from "./DisorderedArray";
-import { IColliderShape } from "@oasis-engine/design/src";
+import { LiteSphereColliderShape } from "./shape/LiteSphereColliderShape";
 
 /**
  * A manager is a collection of bodies and constraints which can interact.
@@ -130,8 +129,8 @@ export class LitePhysicsManager implements IPhysicsManager {
         isHit = true;
         if (curHit.distance < distance) {
           if (hitResult) {
-            curHit.normal.cloneTo(hitResult.normal);
-            curHit.point.cloneTo(hitResult.point);
+            hitResult.normal.copyFrom(curHit.normal);
+            hitResult.point.copyFrom(curHit.point);
             hitResult.distance = curHit.distance;
             hitResult.shapeID = curHit.shapeID;
           } else {
@@ -145,8 +144,8 @@ export class LitePhysicsManager implements IPhysicsManager {
     if (!isHit && hitResult) {
       hitResult.shapeID = -1;
       hitResult.distance = 0;
-      hitResult.point.setValue(0, 0, 0);
-      hitResult.normal.setValue(0, 0, 0);
+      hitResult.point.set(0, 0, 0);
+      hitResult.normal.set(0, 0, 0);
     } else if (isHit && hitResult) {
       hit(hitResult.shapeID, hitResult.distance, hitResult.point, hitResult.normal);
     }
@@ -174,8 +173,8 @@ export class LitePhysicsManager implements IPhysicsManager {
    */
   private static _updateWorldBox(boxCollider: LiteBoxColliderShape, out: BoundingBox): void {
     const mat = boxCollider._transform.worldMatrix;
-    boxCollider._boxMax.cloneTo(out.max);
-    boxCollider._boxMin.cloneTo(out.min);
+    out.min.copyFrom(boxCollider._boxMin);
+    out.max.copyFrom(boxCollider._boxMax);
     BoundingBox.transform(out, mat, out);
   }
 

--- a/packages/physics-lite/src/LiteTransform.ts
+++ b/packages/physics-lite/src/LiteTransform.ts
@@ -1,8 +1,8 @@
 import { MathUtil, Matrix, Quaternion, Vector3 } from "oasis-engine";
-import { LiteUpdateFlagManager } from "./LiteUpdateFlagManager";
-import { LiteUpdateFlag } from "./LiteUpdateFlag";
-import { LiteColliderShape } from "./shape/LiteColliderShape";
 import { LiteCollider } from "./LiteCollider";
+import { LiteUpdateFlag } from "./LiteUpdateFlag";
+import { LiteUpdateFlagManager } from "./LiteUpdateFlagManager";
+import { LiteColliderShape } from "./shape/LiteColliderShape";
 
 /**
  * Used to implement transformation related functions.
@@ -39,7 +39,7 @@ export class LiteTransform {
 
   set position(value: Vector3) {
     if (this._position !== value) {
-      value.cloneTo(this._position);
+      this._position.copyFrom(value);
     }
     this._setDirtyFlagTrue(TransformFlag.LocalMatrix);
     this._updateWorldPositionFlag();
@@ -64,7 +64,7 @@ export class LiteTransform {
 
   set rotationQuaternion(value: Quaternion) {
     if (this._rotationQuaternion !== value) {
-      value.cloneTo(this._rotationQuaternion);
+      this._rotationQuaternion.copyFrom(value);
     }
     this._setDirtyFlagTrue(TransformFlag.LocalMatrix | TransformFlag.LocalEuler);
     this._setDirtyFlagFalse(TransformFlag.LocalQuat);
@@ -81,7 +81,7 @@ export class LiteTransform {
       if (parent != null) {
         Quaternion.multiply(parent.worldRotationQuaternion, this.rotationQuaternion, this._worldRotationQuaternion);
       } else {
-        this.rotationQuaternion.cloneTo(this._worldRotationQuaternion);
+        this._worldRotationQuaternion.copyFrom(this.rotationQuaternion);
       }
       this._setDirtyFlagFalse(TransformFlag.WorldQuat);
     }
@@ -90,14 +90,14 @@ export class LiteTransform {
 
   set worldRotationQuaternion(value: Quaternion) {
     if (this._worldRotationQuaternion !== value) {
-      value.cloneTo(this._worldRotationQuaternion);
+      this._worldRotationQuaternion.copyFrom(value);
     }
     const parent = this._getParentTransform();
     if (parent) {
       Quaternion.invert(parent.worldRotationQuaternion, LiteTransform._tempQuat0);
       Quaternion.multiply(value, LiteTransform._tempQuat0, this._rotationQuaternion);
     } else {
-      value.cloneTo(this._rotationQuaternion);
+      this._rotationQuaternion.copyFrom(value);
     }
     this.rotationQuaternion = this._rotationQuaternion;
     this._setDirtyFlagFalse(TransformFlag.WorldQuat);
@@ -113,7 +113,7 @@ export class LiteTransform {
 
   set scale(value: Vector3) {
     if (this._scale !== value) {
-      value.cloneTo(this._scale);
+      this._scale.copyFrom(value);
     }
     this._setDirtyFlagTrue(TransformFlag.LocalMatrix);
     this._updateWorldScaleFlag();
@@ -133,7 +133,7 @@ export class LiteTransform {
 
   set localMatrix(value: Matrix) {
     if (this._localMatrix !== value) {
-      value.cloneTo(this._localMatrix);
+      this._localMatrix.copyFrom(value);
     }
     this._localMatrix.decompose(this._position, this._rotationQuaternion, this._scale);
     this._setDirtyFlagTrue(TransformFlag.LocalEuler);
@@ -151,7 +151,7 @@ export class LiteTransform {
       if (parent) {
         Matrix.multiply(parent.worldMatrix, this.localMatrix, this._worldMatrix);
       } else {
-        this.localMatrix.cloneTo(this._worldMatrix);
+        this._worldMatrix.copyFrom(this.localMatrix);
       }
       this._setDirtyFlagFalse(TransformFlag.WorldMatrix);
     }
@@ -160,14 +160,14 @@ export class LiteTransform {
 
   set worldMatrix(value: Matrix) {
     if (this._worldMatrix !== value) {
-      value.cloneTo(this._worldMatrix);
+      this._worldMatrix.copyFrom(value);
     }
     const parent = this._getParentTransform();
     if (parent) {
       Matrix.invert(parent.worldMatrix, LiteTransform._tempMat42);
       Matrix.multiply(value, LiteTransform._tempMat42, this._localMatrix);
     } else {
-      value.cloneTo(this._localMatrix);
+      this._localMatrix.copyFrom(value);
     }
     this.localMatrix = this._localMatrix;
     this._setDirtyFlagFalse(TransformFlag.WorldMatrix);
@@ -180,7 +180,7 @@ export class LiteTransform {
    * @param z - Z coordinate
    */
   setPosition(x: number, y: number, z: number): void {
-    this._position.setValue(x, y, z);
+    this._position.set(x, y, z);
     this.position = this._position;
   }
 
@@ -192,7 +192,7 @@ export class LiteTransform {
    * @param w - W component of quaternion
    */
   setRotationQuaternion(x: number, y: number, z: number, w: number): void {
-    this._rotationQuaternion.setValue(x, y, z, w);
+    this._rotationQuaternion.set(x, y, z, w);
     this.rotationQuaternion = this._rotationQuaternion;
   }
 
@@ -203,7 +203,7 @@ export class LiteTransform {
    * @param z - Scaling along Z axis
    */
   setScale(x: number, y: number, z: number): void {
-    this._scale.setValue(x, y, z);
+    this._scale.set(x, y, z);
     this.scale = this._scale;
   }
 

--- a/packages/physics-lite/src/shape/LiteBoxColliderShape.ts
+++ b/packages/physics-lite/src/shape/LiteBoxColliderShape.ts
@@ -25,7 +25,7 @@ export class LiteBoxColliderShape extends LiteColliderShape implements IBoxColli
   constructor(uniqueID: number, size: Vector3, material: LitePhysicsMaterial) {
     super();
     this._id = uniqueID;
-    this._halfSize.setValue(size.x * 0.5, size.y * 0.5, size.z * 0.5);
+    this._halfSize.set(size.x * 0.5, size.y * 0.5, size.z * 0.5);
     this._setBondingBox();
   }
 
@@ -49,7 +49,7 @@ export class LiteBoxColliderShape extends LiteColliderShape implements IBoxColli
    * {@inheritDoc IBoxColliderShape.setSize }
    */
   setSize(value: Vector3): void {
-    this._halfSize.setValue(value.x * 0.5, value.y * 0.5, value.z * 0.5);
+    this._halfSize.set(value.x * 0.5, value.y * 0.5, value.z * 0.5);
     this._setBondingBox();
   }
 
@@ -60,8 +60,8 @@ export class LiteBoxColliderShape extends LiteColliderShape implements IBoxColli
     const localRay = this._getLocalRay(ray);
 
     const boundingBox = LiteBoxColliderShape._tempBox;
-    boundingBox.min.setValue(-this._halfSize.x, -this._halfSize.y, -this._halfSize.z);
-    boundingBox.max.setValue(this._halfSize.x, this._halfSize.y, this._halfSize.z);
+    boundingBox.min.set(-this._halfSize.x, -this._halfSize.y, -this._halfSize.z);
+    boundingBox.max.set(this._halfSize.x, this._halfSize.y, this._halfSize.z);
     const rayDistance = localRay.intersectBox(boundingBox);
     if (rayDistance !== -1) {
       this._updateHitResult(localRay, rayDistance, hit, ray.origin);

--- a/packages/physics-lite/src/shape/LiteColliderShape.ts
+++ b/packages/physics-lite/src/shape/LiteColliderShape.ts
@@ -1,8 +1,8 @@
 import { IColliderShape, IPhysicsMaterial } from "@oasis-engine/design";
 import { Matrix, Ray, Vector3 } from "oasis-engine";
+import { LiteCollider } from "../LiteCollider";
 import { LiteHitResult } from "../LiteHitResult";
 import { LiteTransform } from "../LiteTransform";
-import { LiteCollider } from "../LiteCollider";
 import { LiteUpdateFlag } from "../LiteUpdateFlag";
 
 /**
@@ -101,7 +101,7 @@ export abstract class LiteColliderShape implements IColliderShape {
     const distance = Vector3.distance(origin, hitPoint);
 
     if (distance < outHit.distance) {
-      hitPoint.cloneTo(outHit.point);
+      outHit.point.copyFrom(hitPoint);
       outHit.distance = distance;
       outHit.shapeID = this._id;
     }

--- a/packages/physics-physx/src/PhysXCharacterController.ts
+++ b/packages/physics-physx/src/PhysXCharacterController.ts
@@ -35,12 +35,8 @@ export class PhysXCharacterController implements ICharacterController {
   /**
    * {@inheritDoc ICharacterController.getWorldPosition }
    */
-  getWorldPosition(position: Vector3): void {
-    position.set(
-      this._pxController.getPosition().x,
-      this._pxController.getPosition().y,
-      this._pxController.getPosition().z
-    );
+  getWorldPosition(position: Vector3): void {ƒ
+    position.copyFrom(this._pxController.getPosition());
   }
 
   /**

--- a/packages/physics-physx/src/PhysXCharacterController.ts
+++ b/packages/physics-physx/src/PhysXCharacterController.ts
@@ -36,7 +36,7 @@ export class PhysXCharacterController implements ICharacterController {
    * {@inheritDoc ICharacterController.getWorldPosition }
    */
   getWorldPosition(position: Vector3): void {
-    position.setValue(
+    position.set(
       this._pxController.getPosition().x,
       this._pxController.getPosition().y,
       this._pxController.getPosition().z

--- a/packages/physics-physx/src/PhysXCharacterController.ts
+++ b/packages/physics-physx/src/PhysXCharacterController.ts
@@ -35,7 +35,7 @@ export class PhysXCharacterController implements ICharacterController {
   /**
    * {@inheritDoc ICharacterController.getWorldPosition }
    */
-  getWorldPosition(position: Vector3): void {ƒ
+  getWorldPosition(position: Vector3): void {
     position.copyFrom(this._pxController.getPosition());
   }
 

--- a/packages/physics-physx/src/PhysXCollider.ts
+++ b/packages/physics-physx/src/PhysXCollider.ts
@@ -40,8 +40,8 @@ export abstract class PhysXCollider implements ICollider {
    */
   getWorldTransform(outPosition: Vector3, outRotation: Quaternion): void {
     const transform = this._pxActor.getGlobalPose();
-    outPosition.setValue(transform.translation.x, transform.translation.y, transform.translation.z);
-    outRotation.setValue(transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w);
+    outPosition.set(transform.translation.x, transform.translation.y, transform.translation.z);
+    outRotation.set(transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w);
   }
 
   /**

--- a/packages/physics-physx/src/PhysXDynamicCollider.ts
+++ b/packages/physics-physx/src/PhysXDynamicCollider.ts
@@ -1,7 +1,7 @@
-import { PhysXPhysics } from "./PhysXPhysics";
-import { Quaternion, Vector3 } from "oasis-engine";
 import { IDynamicCollider } from "@oasis-engine/design";
+import { Quaternion, Vector3 } from "oasis-engine";
 import { PhysXCollider } from "./PhysXCollider";
+import { PhysXPhysics } from "./PhysXPhysics";
 
 /**
  * The collision detection mode constants used for PhysXDynamicCollider.collisionDetectionMode.
@@ -48,14 +48,14 @@ export class PhysXDynamicCollider extends PhysXCollider implements IDynamicColli
    * {@inheritDoc IDynamicCollider.setLinearVelocity }
    */
   setLinearVelocity(value: Vector3): void {
-    this._pxActor.setLinearVelocity({ x: value.x, y: value.y, z: value.z }, true);
+    this._pxActor.setLinearVelocity(value, true);
   }
 
   /**
    * {@inheritDoc IDynamicCollider.setAngularVelocity }
    */
   setAngularVelocity(value: Vector3): void {
-    this._pxActor.setAngularVelocity({ x: value.x, y: value.y, z: value.z }, true);
+    this._pxActor.setAngularVelocity(value, true);
   }
 
   /**

--- a/packages/physics-physx/src/PhysXPhysicsManager.ts
+++ b/packages/physics-physx/src/PhysXPhysicsManager.ts
@@ -203,8 +203,8 @@ export class PhysXPhysicsManager implements IPhysicsManager {
     if (result && hit != undefined) {
       const { _tempPosition: position, _tempNormal: normal } = PhysXPhysicsManager;
       const { position: pxPosition, normal: pxNormal } = pxHitResult;
-      position.setValue(pxPosition.x, pxPosition.y, pxPosition.z);
-      normal.setValue(pxNormal.x, pxNormal.y, pxNormal.z);
+      position.set(pxPosition.x, pxPosition.y, pxPosition.z);
+      normal.set(pxNormal.x, pxNormal.y, pxNormal.z);
 
       hit(pxHitResult.getShape().getQueryFilterData().word0, pxHitResult.distance, position, normal);
     }

--- a/packages/physics-physx/src/shape/PhysXBoxColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXBoxColliderShape.ts
@@ -21,7 +21,7 @@ export class PhysXBoxColliderShape extends PhysXColliderShape implements IBoxCol
   constructor(uniqueID: number, size: Vector3, material: PhysXPhysicsMaterial) {
     super();
 
-    this._halfSize.setValue(size.x * 0.5, size.y * 0.5, size.z * 0.5);
+    this._halfSize.set(size.x * 0.5, size.y * 0.5, size.z * 0.5);
 
     this._pxGeometry = new PhysXPhysics._physX.PxBoxGeometry(
       this._halfSize.x * this._scale.x,
@@ -36,7 +36,7 @@ export class PhysXBoxColliderShape extends PhysXColliderShape implements IBoxCol
    * {@inheritDoc IBoxColliderShape.setSize }
    */
   setSize(value: Vector3): void {
-    this._halfSize.setValue(value.x * 0.5, value.y * 0.5, value.z * 0.5);
+    this._halfSize.set(value.x * 0.5, value.y * 0.5, value.z * 0.5);
     Vector3.multiply(this._halfSize, this._scale, PhysXBoxColliderShape._tempHalfExtents);
     this._pxGeometry.halfExtents = PhysXBoxColliderShape._tempHalfExtents;
     this._pxShape.setGeometry(this._pxGeometry);
@@ -54,7 +54,7 @@ export class PhysXBoxColliderShape extends PhysXColliderShape implements IBoxCol
    * {@inheritDoc IColliderShape.setWorldScale }
    */
   setWorldScale(scale: Vector3): void {
-    scale.cloneTo(this._scale);
+    this._scale.copyFrom(scale);
     this._setLocalPose();
 
     Vector3.multiply(this._halfSize, this._scale, PhysXBoxColliderShape._tempHalfExtents);

--- a/packages/physics-physx/src/shape/PhysXCapsuleColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXCapsuleColliderShape.ts
@@ -87,13 +87,13 @@ export class PhysXCapsuleColliderShape extends PhysXColliderShape implements ICa
     this._upAxis = upAxis;
     switch (this._upAxis) {
       case ColliderShapeUpAxis.X:
-        this._rotation.setValue(0, 0, 0, 1);
+        this._rotation.set(0, 0, 0, 1);
         break;
       case ColliderShapeUpAxis.Y:
-        this._rotation.setValue(0, 0, PhysXColliderShape.halfSqrt, PhysXColliderShape.halfSqrt);
+        this._rotation.set(0, 0, PhysXColliderShape.halfSqrt, PhysXColliderShape.halfSqrt);
         break;
       case ColliderShapeUpAxis.Z:
-        this._rotation.setValue(0, PhysXColliderShape.halfSqrt, 0, PhysXColliderShape.halfSqrt);
+        this._rotation.set(0, PhysXColliderShape.halfSqrt, 0, PhysXColliderShape.halfSqrt);
         break;
     }
     this._setLocalPose();
@@ -103,7 +103,7 @@ export class PhysXCapsuleColliderShape extends PhysXColliderShape implements ICa
    * {@inheritDoc IColliderShape.setWorldScale }
    */
   setWorldScale(scale: Vector3): void {
-    scale.cloneTo(this._scale);
+    this._scale.copyFrom(scale);
     this._setLocalPose();
 
     switch (this._upAxis) {

--- a/packages/physics-physx/src/shape/PhysXColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXColliderShape.ts
@@ -52,7 +52,7 @@ export abstract class PhysXColliderShape implements IColliderShape {
    */
   setPosition(value: Vector3): void {
     if (value !== this._position) {
-      value.cloneTo(this._position);
+      this._position.copyFrom(value);
     }
     this._setLocalPose();
   }

--- a/packages/physics-physx/src/shape/PhysXPlaneColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXPlaneColliderShape.ts
@@ -1,8 +1,8 @@
-import { PhysXColliderShape } from "./PhysXColliderShape";
 import { IPlaneColliderShape } from "@oasis-engine/design";
-import { PhysXPhysicsMaterial } from "../PhysXPhysicsMaterial";
-import { PhysXPhysics } from "../PhysXPhysics";
 import { Quaternion, Vector3 } from "oasis-engine";
+import { PhysXPhysics } from "../PhysXPhysics";
+import { PhysXPhysicsMaterial } from "../PhysXPhysicsMaterial";
+import { PhysXColliderShape } from "./PhysXColliderShape";
 
 /**
  * Plane collider shape in PhysX.
@@ -15,7 +15,7 @@ export class PhysXPlaneColliderShape extends PhysXColliderShape implements IPlan
    */
   constructor(uniqueID: number, material: PhysXPhysicsMaterial) {
     super();
-    this._rotation.setValue(0, 0, PhysXColliderShape.halfSqrt, PhysXColliderShape.halfSqrt);
+    this._rotation.set(0, 0, PhysXColliderShape.halfSqrt, PhysXColliderShape.halfSqrt);
 
     this._pxGeometry = new PhysXPhysics._physX.PxPlaneGeometry();
     this._initialize(material, uniqueID);
@@ -36,7 +36,7 @@ export class PhysXPlaneColliderShape extends PhysXColliderShape implements IPlan
    * {@inheritDoc IColliderShape.setWorldScale }
    */
   setWorldScale(scale: Vector3): void {
-    scale.cloneTo(this._scale);
+    this._scale.copyFrom(scale);
     this._setLocalPose();
   }
 }

--- a/packages/physics-physx/src/shape/PhysXSphereColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXSphereColliderShape.ts
@@ -40,7 +40,7 @@ export class PhysXSphereColliderShape extends PhysXColliderShape implements ISph
    * {@inheritDoc IColliderShape.setWorldScale }
    */
   setWorldScale(scale: Vector3): void {
-    scale.cloneTo(this._scale);
+    this._scale.copyFrom(scale);
     this._setLocalPose();
 
     this._maxScale = Math.max(scale.x, Math.max(scale.x, scale.y));

--- a/packages/rhi-webgl/src/WebCanvas.ts
+++ b/packages/rhi-webgl/src/WebCanvas.ts
@@ -48,7 +48,7 @@ export class WebCanvas implements Canvas {
   get scale(): Vector2 {
     const webCanvas = this._webCanvas;
     if (webCanvas instanceof HTMLCanvasElement) {
-      this._scale.setValue(
+      this._scale.set(
         (webCanvas.clientWidth * devicePixelRatio) / webCanvas.width,
         (webCanvas.clientHeight * devicePixelRatio) / webCanvas.height
       );
@@ -94,7 +94,7 @@ export class WebCanvas implements Canvas {
    * @param y - Scale along the Y axis
    */
   setScale(x: number, y: number): void {
-    this._scale.setValue(x, y);
+    this._scale.set(x, y);
     this.scale = this._scale;
   }
 }

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -189,7 +189,7 @@ export class WebGLRenderer implements IHardwareRenderer {
 
     if (x !== lv.x || y !== lv.y || width !== lv.z || height !== lv.w) {
       gl.viewport(x, y, width, height);
-      lv.setValue(x, y, width, height);
+      lv.set(x, y, width, height);
     }
   }
 
@@ -219,7 +219,7 @@ export class WebGLRenderer implements IHardwareRenderer {
 
       if (clearColor && (r !== lc.r || g !== lc.g || b !== lc.b || a !== lc.a)) {
         gl.clearColor(r, g, b, a);
-        lc.setValue(r, g, b, a);
+        lc.set(r, g, b, a);
       }
 
       if (targetBlendState.colorWriteMask !== ColorWriteMask.All) {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

*feat: refactor `cloneTo` to `copyFrom` for math library, and adjust param type  to `xxLike`, this ismore powerful.
*feat: rename `setValue` to `set`, this is More concise


```ts
vector3.copyFrom(new Vector3());
vector3.copyFrom({x:1, y:2, z:3});
```