### PR TITLE
Fix transform`translate` and `rotate` space bug

### DIFF
--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -429,7 +429,7 @@ export class Transform extends Component {
   /**
    * Translate in the direction and distance of the translation.
    * @param translation - Direction and distance of translation
-   * @param relativeToLocal - Is relative to the local coordinate system
+   * @param relativeToLocal = `true` - Is relative to the local coordinate system
    */
   translate(translation: Vector3, relativeToLocal?: boolean): void;
 
@@ -438,7 +438,7 @@ export class Transform extends Component {
    * @param x - Distance along the x axis
    * @param y - Distance along the y axis
    * @param z - Distance along the z axis
-   * @param relativeToLocal - Is relative to the local coordinate system
+   * @param relativeToLocal = `true` - Is relative to the local coordinate system
    */
   translate(x: number, y: number, z: number, relativeToLocal?: boolean): void;
 

--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -460,7 +460,7 @@ export class Transform extends Component {
   /**
    * Rotate around the passed Vector3.
    * @param rotation - Euler angle in degrees
-   * @param relativeToLocal - Is relative to the local coordinate system
+   * @param relativeToLocal = `true` - Is relative to the local coordinate system
    */
   rotate(rotation: Vector3, relativeToLocal?: boolean): void;
 
@@ -469,7 +469,7 @@ export class Transform extends Component {
    * @param x - Rotation along x axis, in degrees
    * @param y - Rotation along y axis, in degrees
    * @param z - Rotation along z axis, in degrees
-   * @param relativeToLocal - Is relative to the local coordinate system
+   * @param relativeToLocal = `true` - Is relative to the local coordinate system
    */
   rotate(x: number, y: number, z: number, relativeToLocal?: boolean): void;
 
@@ -490,7 +490,7 @@ export class Transform extends Component {
    * Rotate around the specified axis according to the specified angle.
    * @param axis - Rotate axis
    * @param angle - Rotate angle in degrees
-   * @param relativeToLocal - Relative to local space
+   * @param relativeToLocal = `true` - Relative to local space
    */
   rotateByAxis(axis: Vector3, angle: number, relativeToLocal: boolean = true): void {
     const rad = angle * MathUtil.degreeToRadFactor;
@@ -719,7 +719,7 @@ export class Transform extends Component {
     }
   }
 
-  private _translate(translation: Vector3, relativeToLocal: boolean): void {
+  private _translate(translation: Vector3, relativeToLocal: boolean = true): void {
     if (relativeToLocal) {
       const { _tempVec30 } = Transform;
       Vector3.transformByQuat(translation, this.worldRotationQuaternion, _tempVec30);
@@ -729,7 +729,7 @@ export class Transform extends Component {
     }
   }
 
-  private _rotateXYZ(x: number, y: number, z: number, relativeToLocal: boolean): void {
+  private _rotateXYZ(x: number, y: number, z: number, relativeToLocal: boolean = true): void {
     const radFactor = MathUtil.degreeToRadFactor;
     const rotQuat = Transform._tempQuat0;
     Quaternion.rotationEuler(x * radFactor, y * radFactor, z * radFactor, rotQuat);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

- Transform `translate` and `rotate` default space should local
- Optimization comments by function default value issue of TSDoc https://github.com/microsoft/tsdoc/issues/151