### PR TITLE
Fix: Null protection for `SpriteRenderer.sprite`.

### DIFF
--- a/packages/core/src/2d/assembler/IAssembler.ts
+++ b/packages/core/src/2d/assembler/IAssembler.ts
@@ -5,7 +5,6 @@ import { Renderer } from "../../Renderer";
  */
 export interface IAssembler {
   resetData(renderer: Renderer): void;
-  updateData(renderer: Renderer): void;
   updatePositions?(renderer: Renderer): void;
   updateUVs?(renderer: Renderer): void;
 }

--- a/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
@@ -28,11 +28,7 @@ export class SimpleSpriteAssembler {
   static updateData(renderer: SpriteRenderer | SpriteMask): void {}
 
   static updatePositions(renderer: SpriteRenderer | SpriteMask): void {
-    const { width, height } = renderer;
-    if (width === 0 || height === 0) {
-      return;
-    }
-    const { sprite } = renderer;
+    const { width, height, sprite } = renderer;
     const { x: pivotX, y: pivotY } = sprite.pivot;
     // Renderer's worldMatrix;
     const { _worldMatrix: worldMatrix } = SimpleSpriteAssembler;

--- a/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
@@ -25,8 +25,6 @@ export class SimpleSpriteAssembler {
     renderData.triangles = SimpleSpriteAssembler._rectangleTriangles;
   }
 
-  static updateData(renderer: SpriteRenderer | SpriteMask): void {}
-
   static updatePositions(renderer: SpriteRenderer | SpriteMask): void {
     const { width, height, sprite } = renderer;
     const { x: pivotX, y: pivotY } = sprite.pivot;

--- a/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
@@ -10,7 +10,7 @@ import { StaticInterfaceImplement } from "./StaticInterfaceImplement";
 @StaticInterfaceImplement<IAssembler>()
 export class SlicedSpriteAssembler {
   static _worldMatrix: Matrix = new Matrix();
-  static resetData(renderer: SpriteRenderer | SpriteMask): void {
+  static resetData(renderer: SpriteRenderer): void {
     const { _renderData: renderData } = renderer;
     const { positions, uvs } = renderData;
     if (positions.length < 16) {
@@ -22,9 +22,7 @@ export class SlicedSpriteAssembler {
     renderData.triangles = [];
   }
 
-  static updateData(renderer: SpriteRenderer | SpriteMask): void {}
-
-  static updatePositions(renderer: SpriteRenderer | SpriteMask): void {
+  static updatePositions(renderer: SpriteRenderer): void {
     const { width, height, sprite } = renderer;
     const { positions, uvs, triangles } = renderer._renderData;
     const { border } = sprite;
@@ -143,5 +141,5 @@ export class SlicedSpriteAssembler {
     renderer._bounds.transform(worldMatrix);
   }
 
-  static updateUVs(renderer: SpriteRenderer | SpriteMask): void {}
+  static updateUVs(renderer: SpriteRenderer): void {}
 }

--- a/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
@@ -25,11 +25,7 @@ export class SlicedSpriteAssembler {
   static updateData(renderer: SpriteRenderer | SpriteMask): void {}
 
   static updatePositions(renderer: SpriteRenderer | SpriteMask): void {
-    const { width, height } = renderer;
-    if (width === 0 || height === 0) {
-      return;
-    }
-    const { sprite } = renderer;
+    const { width, height, sprite } = renderer;
     const { positions, uvs, triangles } = renderer._renderData;
     const { border } = sprite;
     const spriteUVs = sprite._getUVs();

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -17,6 +17,7 @@ import { SpriteDrawMode } from "../enums/SpriteDrawMode";
 import { SimpleSpriteAssembler } from "../assembler/SimpleSpriteAssembler";
 import { ListenerUpdateFlag } from "../../ListenerUpdateFlag";
 import { SlicedSpriteAssembler } from "../assembler/SlicedSpriteAssembler";
+import { Engine } from "../../Engine";
 
 /**
  * Renders a Sprite for 2D graphics.
@@ -98,8 +99,11 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
         this._spriteChangeFlag = value._registerUpdateFlag();
         this._spriteChangeFlag.listener = this._onSpriteChange;
         this._dirtyFlag |= DirtyFlag.All;
+        this.shaderData.setTexture(SpriteRenderer._textureProperty, value.texture);
+      } else {
+        this._spriteChangeFlag = null;
+        this.shaderData.setTexture(SpriteRenderer._textureProperty, null);
       }
-      this.shaderData.setTexture(SpriteRenderer._textureProperty, value.texture);
     }
   }
 
@@ -182,7 +186,9 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
    * The bounding volume of the spriteRenderer.
    */
   get bounds(): BoundingBox {
-    if (this._transformChangeFlag.flag || this._dirtyFlag & DirtyFlag.Position) {
+    if (!this.sprite?.texture || !this.width || !this.height) {
+      return Engine._defaultBoundingBox;
+    } else if (this._transformChangeFlag.flag || this._dirtyFlag & DirtyFlag.Position) {
       this._assembler.updatePositions(this);
       this._dirtyFlag &= ~DirtyFlag.Position;
       this._transformChangeFlag.flag = false;
@@ -230,7 +236,7 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
    * @internal
    */
   _render(camera: Camera): void {
-    if (!this.sprite?.texture) {
+    if (!this.sprite?.texture || !this.width || !this.height) {
       return;
     }
 
@@ -268,7 +274,10 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
     this._sprite = null;
     this._assembler = null;
     this._renderData = null;
-    this._spriteChangeFlag && this._spriteChangeFlag.destroy();
+    if (this._spriteChangeFlag) {
+      this._spriteChangeFlag.destroy();
+      this._spriteChangeFlag = null;
+    }
     super._onDestroy();
   }
 
@@ -298,12 +307,7 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
   private _onSpriteChange(dirtyFlag: SpritePropertyDirtyFlag): void {
     switch (dirtyFlag) {
       case SpritePropertyDirtyFlag.texture:
-        const { _sprite: sprite } = this;
-        if (this._width === undefined && this._height === undefined) {
-          this.width = sprite.width;
-          this.height = sprite.height;
-        }
-        this.shaderData.setTexture(SpriteRenderer._textureProperty, sprite.texture);
+        this.shaderData.setTexture(SpriteRenderer._textureProperty, this.sprite.texture);
         break;
       case SpritePropertyDirtyFlag.size:
         this._drawMode === SpriteDrawMode.Sliced && (this._dirtyFlag |= DirtyFlag.Position);

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -1,3 +1,4 @@
+import { BoundingBox, Vector3 } from "@oasis-engine/math";
 import { ColorSpace } from ".";
 import { ResourceManager } from "./asset/ResourceManager";
 import { Event, EventDispatcher, Logger, Time } from "./base";
@@ -45,6 +46,8 @@ export class Engine extends EventDispatcher {
   static _gammaMacro: ShaderMacro = Shader.getMacroByName("OASIS_COLORSPACE_GAMMA");
   /** @internal Conversion of space units to pixel units for 2D. */
   static _pixelsPerUnit: number = 100;
+  /** @internal */
+  static _defaultBoundingBox: BoundingBox = new BoundingBox(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
 
   /** Physics manager of Engine. */
   readonly physicsManager: PhysicsManager;


### PR DESCRIPTION
When setting sprite to null, the code below will throw an error.
```
this.shaderData.setTexture(SpriteMask._textureProperty, value.texture);
```