### PR TITLE
Fix InputManager need to stop the default touch behavior of canvas

### DIFF
--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -169,7 +169,6 @@ export class PointerManager implements IInput {
   }
 
   private _onPointerEvent(evt: PointerEvent) {
-    evt.stopPropagation();
     evt.cancelable && evt.preventDefault();
     this._nativeEvents.push(evt);
   }

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -64,7 +64,6 @@ export class PointerManager implements IInput {
     this._engine = engine;
     this._canvas = engine.canvas;
     this._htmlCanvas = htmlCanvas;
-    htmlCanvas.style.touchAction = "none";
     htmlCanvas.oncontextmenu = (event: UIEvent) => {
       return false;
     };
@@ -170,6 +169,8 @@ export class PointerManager implements IInput {
   }
 
   private _onPointerEvent(evt: PointerEvent) {
+    evt.stopPropagation();
+    evt.cancelable && evt.preventDefault();
     this._nativeEvents.push(evt);
   }
 

--- a/packages/core/src/input/wheel/WheelManager.ts
+++ b/packages/core/src/input/wheel/WheelManager.ts
@@ -75,6 +75,8 @@ export class WheelManager implements IInput {
   }
 
   private _onWheelEvent(evt: WheelEvent): void {
+    evt.stopPropagation();
+    evt.cancelable && evt.preventDefault();
     this._nativeEvents.push(evt);
   }
 }

--- a/packages/core/src/input/wheel/WheelManager.ts
+++ b/packages/core/src/input/wheel/WheelManager.ts
@@ -75,7 +75,6 @@ export class WheelManager implements IInput {
   }
 
   private _onWheelEvent(evt: WheelEvent): void {
-    evt.stopPropagation();
     evt.cancelable && evt.preventDefault();
     this._nativeEvents.push(evt);
   }


### PR DESCRIPTION
When the scroll wheel event is triggered, other elements of the document will also bubble and trigger.