### PR TITLE
Fix `blendShapeWeights` never set bug when Mesh blendShape count is large than 0

### DIFF
--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -99,10 +99,9 @@ export class BlendShapeManager {
    * @internal
    */
   _updateShaderData(shaderData: ShaderData, skinnedMeshRenderer: SkinnedMeshRenderer): void {
-    const blendShapeCount = this._blendShapeCount;
+    let blendShapeCount = this._blendShapeCount;
     if (blendShapeCount > 0) {
       shaderData.enableMacro(BlendShapeManager._blendShapeMacro);
-      shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeCount.toString());
       if (this._useTextureMode()) {
         shaderData.enableMacro(BlendShapeManager._blendShapeTextureMacro);
         shaderData.setTexture(BlendShapeManager._blendShapeTextureProperty, this._vertexTexture);
@@ -119,6 +118,7 @@ export class BlendShapeManager {
           this._filterCondensedBlendShapeWeights(skinnedMeshRenderer._blendShapeWeights, condensedBlendShapeWeights);
           shaderData.setFloatArray(BlendShapeManager._blendShapeWeightsProperty, condensedBlendShapeWeights);
           this._modelMesh._enableVAO = false;
+          blendShapeCount = maxBlendCount;
         } else {
           shaderData.setFloatArray(
             BlendShapeManager._blendShapeWeightsProperty,
@@ -128,6 +128,7 @@ export class BlendShapeManager {
         }
         shaderData.disableMacro(BlendShapeManager._blendShapeTextureMacro);
       }
+      shaderData.enableMacro("OASIS_BLENDSHAPE_COUNT", blendShapeCount.toString());
 
       if (this._useBlendNormal) {
         shaderData.enableMacro(BlendShapeManager._blendShapeNormalMacro);

--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -36,7 +36,10 @@ export class SkinnedMeshRenderer extends MeshRenderer {
   /** Whether to use joint texture. Automatically used when the device can't support the maximum number of bones. */
   private _useJointTexture: boolean = false;
   private _skin: Skin;
-  _blendShapeWeights: Float32Array;
+
+  /** @internal */
+  _blendShapeWeights: Float32Array = new Float32Array(0);
+  /** @internal */
   _condensedBlendShapeWeights: Float32Array;
 
   /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
