### PR TITLE
feat: remove throw in physics-lite

### DIFF
--- a/packages/physics-lite/src/LitePhysicsManager.ts
+++ b/packages/physics-lite/src/LitePhysicsManager.ts
@@ -51,7 +51,7 @@ export class LitePhysicsManager implements IPhysicsManager {
    * {@inheritDoc IPhysicsManager.setGravity }
    */
   setGravity(value: Vector3): void {
-    throw "Physics-lite don't support gravity. Use Physics-PhysX instead!";
+    console.log("Physics-lite don't support gravity. Use Physics-PhysX instead!");
   }
 
   /**

--- a/packages/physics-lite/src/shape/LiteColliderShape.ts
+++ b/packages/physics-lite/src/shape/LiteColliderShape.ts
@@ -44,14 +44,14 @@ export abstract class LiteColliderShape implements IColliderShape {
    * {@inheritDoc IColliderShape.setContactOffset }
    */
   setContactOffset(offset: number): void {
-    throw "Physics-lite don't support setContactOffset. Use Physics-PhysX instead!";
+    console.log("Physics-lite don't support setContactOffset. Use Physics-PhysX instead!");
   }
 
   /**
    * {@inheritDoc IColliderShape.setMaterial }
    */
   setMaterial(material: IPhysicsMaterial): void {
-    throw "Physics-lite don't support setMaterial. Use Physics-PhysX instead!";
+    console.log("Physics-lite don't support setMaterial. Use Physics-PhysX instead!");
   }
 
   /**
@@ -65,14 +65,14 @@ export abstract class LiteColliderShape implements IColliderShape {
    * {@inheritDoc IColliderShape.setIsTrigger }
    */
   setIsTrigger(value: boolean): void {
-    throw "Physics-lite don't support setIsTrigger. Use Physics-PhysX instead!";
+    console.log("Physics-lite don't support setIsTrigger. Use Physics-PhysX instead!");
   }
 
   /**
    * {@inheritDoc IColliderShape.setIsSceneQuery }
    */
   setIsSceneQuery(value: boolean): void {
-    throw "Physics-lite don't support setIsSceneQuery. Use Physics-PhysX instead!";
+    console.log("Physics-lite don't support setIsSceneQuery. Use Physics-PhysX instead!");
   }
 
   /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
In editor, physx is used default, but when downloads and turn to physics-lite, some default settings will cause throw error, which will stall the whole application.

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information: