### PR TITLE
fix: sprite transform error when rotates.

### DIFF
--- a/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SimpleSpriteAssembler.ts
@@ -40,7 +40,7 @@ export class SimpleSpriteAssembler {
     (wE[8] = pWE[8]), (wE[9] = pWE[9]), (wE[10] = pWE[10]);
     wE[12] = pWE[12] - pivotX * wE[0] - pivotY * wE[4];
     wE[13] = pWE[13] - pivotX * wE[1] - pivotY * wE[5];
-    wE[14] = pWE[14];
+    wE[14] = pWE[14] - pivotX * wE[2] - pivotY * wE[6];
 
     // ---------------
     //  2 - 3

--- a/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
@@ -89,7 +89,7 @@ export class SlicedSpriteAssembler {
     (wE[8] = pWE[8]), (wE[9] = pWE[9]), (wE[10] = pWE[10]);
     wE[12] = pWE[12] - localTransX * wE[0] - localTransY * wE[4];
     wE[13] = pWE[13] - localTransX * wE[1] - localTransY * wE[5];
-    wE[14] = pWE[14];
+    wE[14] = pWE[14] - localTransX * wE[2] - localTransY * wE[6];
 
     // ------------------------
     //  3 - 7 - 11 - 15


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7768919/190350010-f3857362-d4fb-4982-98c8-e3cb03cf7311.png)
An operator was missed when synchronizing Z.