### PR TITLE
Fix set color invalid in `TextRenderer` and fix component _phasedActive clone error

### DIFF
--- a/packages/core/src/2d/text/TextRenderer.ts
+++ b/packages/core/src/2d/text/TextRenderer.ts
@@ -287,7 +287,7 @@ export class TextRenderer extends Renderer implements ICustomClone {
     if (!engine.supportTintColor) {
       //@ts-ignore
       this._color._onValueChanged = () => {
-        this._setDirtyFlagTrue(DirtyFlag.StyleFont);
+        this._setDirtyFlagTrue(DirtyFlag.Font);
       };
     }
   }

--- a/packages/core/src/Component.ts
+++ b/packages/core/src/Component.ts
@@ -17,7 +17,7 @@ export abstract class Component extends EngineObject {
   @ignoreClone
   _destroyed: boolean = false;
 
-  @assignmentClone
+  @ignoreClone
   private _phasedActive: boolean = false;
   @assignmentClone
   private _enabled: boolean = true;

--- a/packages/physics-lite/package.json
+++ b/packages/physics-lite/package.json
@@ -23,6 +23,6 @@
     "oasis-engine": "0.9.0-canvas.1"
   },
   "peerDependencies": {
-    "oasis-engine": "0.9.0-canvas.0"
+    "oasis-engine": "0.9.0-canvas.1"
   }
 }

--- a/packages/physics-physx/package.json
+++ b/packages/physics-physx/package.json
@@ -24,6 +24,6 @@
     "oasis-engine": "0.9.0-canvas.1"
   },
   "peerDependencies": {
-    "oasis-engine": "0.9.0-canvas.0"
+    "oasis-engine": "0.9.0-canvas.1"
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

