### PR TITLE
Fix call `engine.destroy()` crash  in `Script`

### DIFF
--- a/packages/core/src/2d/sprite/Sprite.ts
+++ b/packages/core/src/2d/sprite/Sprite.ts
@@ -161,7 +161,7 @@ export class Sprite extends RefObject {
    *  x      y       z     w
    *  |      |       |     |
    * Left, bottom, right, top.
-   * @remark only use in sliced mode.
+   * @remarks only use in sliced mode.
    */
   get border(): Vector4 {
     return this._border;

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -315,9 +315,12 @@ export class Engine extends EventDispatcher {
 
     // Engine is complete delayed destruction mechanism
     if (this._waittingDestroy) {
-      this._destroy();
+      this._sceneManager._destroyAllScene();
     }
     componentsManager.handlingInvalidScripts();
+    if (this._waittingDestroy) {
+      this._destroy();
+    }
   }
 
   /**
@@ -345,6 +348,7 @@ export class Engine extends EventDispatcher {
    * @internal
    */
   _destroy(): void {
+    this._resourceManager._destroy();
     this._magentaTexture2D.destroy(true);
     this._magentaTextureCube.destroy(true);
     this.inputManager._destroy();
@@ -356,8 +360,6 @@ export class Engine extends EventDispatcher {
 
     this._animate = null;
 
-    this._sceneManager._destroy();
-    this._resourceManager._destroy();
     this._sceneManager = null;
     this._resourceManager = null;
 

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -186,7 +186,7 @@ export class Engine extends EventDispatcher {
   }
 
   /**
-   * Indicates whether the engin is destroyed.
+   * Indicates whether the engine is destroyed.
    */
   get destroyed(): boolean {
     return this._destroyed;

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -314,6 +314,9 @@ export class Engine extends EventDispatcher {
 
     engineFeatureManager.callFeatureMethod(this, "postTick", [this, this._sceneManager._activeScene]);
 
+
+    // Engine is complete delayed destruction mechanism, entity/compoment incomplete delayed destruction mechanism
+    // @todo: can consider use true complete destruction mechanism in entity/compoment
     if (this._waittingDestroy) {
       this._destroy();
     }

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -309,17 +309,15 @@ export class Engine extends EventDispatcher {
       componentsManager.callAnimationUpdate(deltaTime);
       componentsManager.callScriptOnLateUpdate(deltaTime);
       this._render(scene);
-      componentsManager.handlingInvalidScripts();
     }
 
     engineFeatureManager.callFeatureMethod(this, "postTick", [this, this._sceneManager._activeScene]);
 
-
-    // Engine is complete delayed destruction mechanism, entity/compoment incomplete delayed destruction mechanism
-    // @todo: can consider use true complete destruction mechanism in entity/compoment
+    // Engine is complete delayed destruction mechanism
     if (this._waittingDestroy) {
       this._destroy();
     }
+    componentsManager.handlingInvalidScripts();
   }
 
   /**
@@ -334,6 +332,7 @@ export class Engine extends EventDispatcher {
 
   /**
    * Destroy engine.
+   * @remarks The timing of engine destruction is at the end of the current frame
    */
   destroy(): void {
     if (this._destroyed) {
@@ -359,8 +358,6 @@ export class Engine extends EventDispatcher {
 
     this._sceneManager._destroy();
     this._resourceManager._destroy();
-    // If engine destroy, handlingInvalidScripts() maybe will not call anymore.
-    this._componentsManager.handlingInvalidScripts();
     this._sceneManager = null;
     this._resourceManager = null;
 

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -165,9 +165,7 @@ export class Entity extends EngineObject {
     ComponentsDependencies._addCheck(this, type);
     const component = new type(this);
     this._components.push(component);
-    if (this._isActiveInHierarchy) {
-      component._setActive(true);
-    }
+    component._setActive(true);
     return component;
   }
 

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -373,7 +373,9 @@ export class Entity extends EngineObject {
    * Destroy self.
    */
   destroy(): void {
-    if (this._destroyed) return;
+    if (this._destroyed) {
+      return;
+    }
 
     super.destroy();
     const components = this._components;

--- a/packages/core/src/SceneManager.ts
+++ b/packages/core/src/SceneManager.ts
@@ -66,7 +66,7 @@ export class SceneManager {
   /**
    * @internal
    */
-  _destroy(): void {
+  _destroyAllScene(): void {
     const allScenes = this._allScenes;
     for (let i = 0, n = allScenes.length; i < n; i++) {
       allScenes[i]._destroy();

--- a/packages/core/src/Script.ts
+++ b/packages/core/src/Script.ts
@@ -219,20 +219,11 @@ export class Script extends Component {
    */
   _handlingInValid(): void {
     const componentsManager = this.engine._componentsManager;
-    // Use "xxIndex !== -1" to project.
-    // Maybe call onDisable it is still not in script queue, for example write "entity.isActive = false" in onWake().
-    if (this._onUpdateIndex !== -1) {
-      componentsManager.removeOnUpdateScript(this);
-    }
-    if (this._onLateUpdateIndex !== -1) {
-      componentsManager.removeOnLateUpdateScript(this);
-    }
-    if (this._onPhysicsUpdateIndex !== -1) {
-      componentsManager.removeOnPhysicsUpdateScript(this);
-    }
-    if (this._entityScriptsIndex !== -1) {
-      this._entity._removeScript(this);
-    }
+    componentsManager.removeOnUpdateScript(this);
+    componentsManager.removeOnLateUpdateScript(this);
+    componentsManager.removeOnPhysicsUpdateScript(this);
+
+    this._entity._removeScript(this);
     this._waitHandlingInValid = false;
   }
 }

--- a/packages/core/src/Script.ts
+++ b/packages/core/src/Script.ts
@@ -219,9 +219,16 @@ export class Script extends Component {
    */
   _handlingInValid(): void {
     const componentsManager = this.engine._componentsManager;
-    componentsManager.removeOnUpdateScript(this);
-    componentsManager.removeOnLateUpdateScript(this);
-    componentsManager.removeOnPhysicsUpdateScript(this);
+    const { prototype } = Script;
+    if (this.onUpdate !== prototype.onUpdate) {
+      componentsManager.removeOnUpdateScript(this);
+    }
+    if (this.onLateUpdate !== prototype.onLateUpdate) {
+      componentsManager.removeOnLateUpdateScript(this);
+    }
+    if (this.onPhysicsUpdate !== prototype.onPhysicsUpdate) {
+      componentsManager.removeOnPhysicsUpdateScript(this);
+    }
 
     this._entity._removeScript(this);
     this._waitHandlingInValid = false;

--- a/packages/core/src/input/pointer/Pointer.ts
+++ b/packages/core/src/input/pointer/Pointer.ts
@@ -7,7 +7,7 @@ import { PointerPhase } from "../enums/PointerPhase";
 export class Pointer {
   /**
    * Unique id.
-   * @remark Start from 0.
+   * @remarks Start from 0.
    */
   readonly id: number;
   /** The phase of pointer. */

--- a/tests/src/core/Script.test.ts
+++ b/tests/src/core/Script.test.ts
@@ -54,6 +54,17 @@ describe("Scene", () => {
         onDisable() {
           console.log("ParentScript___onDisable");
         }
+        onUpdate() {
+          console.log("ParentScript___onUpdate");
+        }
+
+        onLateUpdate() {
+          console.log("ParentScript___onLateUpdate");
+        }
+
+        onDestroy() {
+          console.log("ParentScript___onDestroy");
+        }
       }
       ParentScript.prototype.onAwake = chai.spy(ParentScript.prototype.onAwake);
       ParentScript.prototype.onEnable = chai.spy(ParentScript.prototype.onEnable);
@@ -69,6 +80,19 @@ describe("Scene", () => {
 
         onDisable() {
           console.log("ChildScript___onDisable");
+        }
+
+        onUpdate() {
+          console.log("ChildScript___onUpdate");
+          this.engine.destroy();
+        }
+
+        onLateUpdate() {
+          console.log("ChildScript___onLateUpdate");
+        }
+
+        onDestroy() {
+          console.log("ChildScript___onDestroy");
         }
       }
       ChildScript.prototype.onAwake = chai.spy(ChildScript.prototype.onAwake);

--- a/tests/src/core/Script.test.ts
+++ b/tests/src/core/Script.test.ts
@@ -10,6 +10,36 @@ describe("Scene", () => {
   engine.run();
 
   describe("onEnable/onDisable/onAwake", () => {
+    it("Add script to Entity", () => {
+      class TestScript extends Script {
+        onAwake() {
+          console.log("ParentScript___onAwake");
+        }
+        onEnable() {
+          console.log("ParentScript___onEnable");
+        }
+
+        onDisable() {
+          console.log("ParentScript___onDisable");
+        }
+      }
+      TestScript.prototype.onAwake = chai.spy(TestScript.prototype.onAwake);
+      TestScript.prototype.onEnable = chai.spy(TestScript.prototype.onEnable);
+      TestScript.prototype.onDisable = chai.spy(TestScript.prototype.onDisable);
+
+      const scene = engine.sceneManager.activeScene;
+      const rootEntity = scene.createRootEntity();
+
+      const testEntity = new Entity(engine);
+      rootEntity.addChild(testEntity);
+
+      const testScript = testEntity.addComponent(TestScript);
+
+      expect(testScript.onAwake).to.have.been.called.exactly(1);
+      expect(testScript.onEnable).to.have.been.called.exactly(1);
+      expect(testScript.onDisable).to.have.been.called.exactly(0);
+    });
+
     it("Parent onAwakeb call inAtive child", () => {
       class ParentScript extends Script {
         onAwake() {
@@ -25,6 +55,9 @@ describe("Scene", () => {
           console.log("ParentScript___onDisable");
         }
       }
+      ParentScript.prototype.onAwake = chai.spy(ParentScript.prototype.onAwake);
+      ParentScript.prototype.onEnable = chai.spy(ParentScript.prototype.onEnable);
+      ParentScript.prototype.onDisable = chai.spy(ParentScript.prototype.onDisable);
 
       class ChildScript extends Script {
         onAwake() {
@@ -38,21 +71,18 @@ describe("Scene", () => {
           console.log("ChildScript___onDisable");
         }
       }
+      ChildScript.prototype.onAwake = chai.spy(ChildScript.prototype.onAwake);
+      ChildScript.prototype.onEnable = chai.spy(ChildScript.prototype.onEnable);
+      ChildScript.prototype.onDisable = chai.spy(ChildScript.prototype.onDisable);
 
       const scene = engine.sceneManager.activeScene;
       const rootEntity = scene.createRootEntity();
 
       const parent = new Entity(engine);
       const parentScript = parent.addComponent(ParentScript);
-      parentScript.onAwake = chai.spy(parentScript.onAwake);
-      parentScript.onEnable = chai.spy(parentScript.onEnable);
-      parentScript.onDisable = chai.spy(parentScript.onDisable);
 
       const child = parent.createChild("child");
       const childScript = child.addComponent(ChildScript);
-      childScript.onAwake = chai.spy(childScript.onAwake);
-      childScript.onEnable = chai.spy(childScript.onEnable);
-      childScript.onDisable = chai.spy(childScript.onDisable);
 
       rootEntity.addChild(parent);
 

--- a/tests/src/rhi-webgl/WebGLEngine.test.ts
+++ b/tests/src/rhi-webgl/WebGLEngine.test.ts
@@ -1,11 +1,73 @@
+import { Camera, Entity, Script } from "@oasis-engine/core";
+import { WebGLEngine } from "@oasis-engine/rhi-webgl";
 import { expect } from "chai";
-import { WebGLEngine, WebCanvas } from "@oasis-engine/rhi-webgl";
+import { Vector3 } from "@oasis-engine/math";
+
 
 describe("webgl engine test", () => {
   it("create a webgl engine", () => {
     const canvas = document.createElement("canvas");
     const engine = new WebGLEngine(canvas);
     expect(engine).not.be.null;
+  });
+
+  it("engine destroy", () => {
+    class ParentScript extends Script {
+      onAwake() {
+        console.log("ParentScript___onAwake");
+      }
+      onEnable() {
+        console.log("ParentScript___onEnable");
+      }
+
+      onDisable() {
+        console.log("ParentScript___onDisable");
+      }
+
+      onUpdate() {
+        console.log("ParentScript___onUpdate");
+        this.engine.destroy();
+      }
+    }
+
+    class ChildScript extends Script {
+      onAwake() {
+        console.log("ChildScript___onAwake");
+      }
+      onEnable() {
+        console.log("ChildScript___onEnable");
+      }
+
+      onDisable() {
+        console.log("ChildScript___onDisable");
+      }
+
+      onUpdate() {
+        console.log("ChildScript___onUpdate");
+      }
+    }
+
+    const canvas = document.createElement("canvas");
+    const engine = new WebGLEngine(canvas);
+    engine.canvas.resizeByClientSize();
+    const scene = engine.sceneManager.activeScene;
+    const rootEntity = scene.createRootEntity();
+    engine.run();
+
+    // init camera
+    const cameraEntity = rootEntity.createChild("camera");
+    const camera = cameraEntity.addComponent(Camera);
+    camera.isOrthographic = true;
+    const pos = cameraEntity.transform.position;
+    pos.set(0, 0, 50);
+    cameraEntity.transform.position = pos;
+    cameraEntity.transform.lookAt(new Vector3(0, 0, 0));
+
+    const parentEntity = new Entity(engine);
+    parentEntity.addComponent(ParentScript);
+    const childEntity = parentEntity.createChild("test");
+    childEntity.addComponent(ChildScript);
+    rootEntity.addChild(parentEntity);
   });
 });
 // npx cross-env TS_NODE_PROJECT=tsconfig.tests.json nyc --reporter=lcov floss -p tests/src/*.test.ts -r ts-node/register


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Main modify:
- Use delay destroy rule to ignore crash bug
- Optimization Script logic.
