### PR TITLE
fix: wrong word recieveShadow to receiveShadow

### DIFF
--- a/packages/core/src/shadow/Extension.ts
+++ b/packages/core/src/shadow/Extension.ts
@@ -32,10 +32,10 @@ Object.defineProperty(Light.prototype, "enableShadow", {
  */
 Object.defineProperty(Component.prototype, "receiveShadow", {
   get: function () {
-    return this._recieveShadow;
+    return this._receiveShadow;
   },
   set: function (enabled) {
-    this._recieveShadow = enabled;
+    this._receiveShadow = enabled;
   }
 });
 

--- a/packages/core/src/shadow/ShadowFeature.ts
+++ b/packages/core/src/shadow/ShadowFeature.ts
@@ -92,7 +92,7 @@ export class ShadowFeature extends SceneFeature {
       const item = items[i];
       const component: Component = item.component;
 
-      const receiveShadow = (component as any).recieveShadow;
+      const receiveShadow = (component as any).receiveShadow;
       const castShadow = (component as any).castShadow;
       if (receiveShadow === true) {
         component.entity.layer |= Layer.Layer30; //SHADOW;


### PR DESCRIPTION
Ps： [官方示例文档](https://oasisengine.cn/0.8/examples#shadow) 中给出的 shadow 示例 `cubeRenderer["recieveShadow"] = !castShadow;` 也需要更改。