### PR TITLE
chore: build editor preload package with minified output file

### DIFF
--- a/scripts/build-editor-preload.js
+++ b/scripts/build-editor-preload.js
@@ -18,7 +18,7 @@ const outputDir = path.join(rootDir, "editor-preload");
 const outputDistDir = path.join(outputDir, "dist");
 const outputFile = path.join(outputDistDir, "browser.js");
 
-console.log(`Building editor-preload v${version}`);
+console.log(`Building editor-preload ${version}`);
 
 // Create output directories
 if (!fs.existsSync(outputDir)) {

--- a/scripts/editor-preload-config.js
+++ b/scripts/editor-preload-config.js
@@ -3,37 +3,37 @@ module.exports = {
     {
       name: "@galacean/engine",
       path: "packages/galacean",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     },
     {
       name: "@galacean/engine-xr",
       path: "packages/xr",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     },
     {
       name: "@galacean/engine-ui",
       path: "packages/ui",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     },
     {
       name: "@galacean/engine-physics-lite",
       path: "packages/physics-lite",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     },
     {
       name: "@galacean/engine-physics-physx",
       path: "packages/physics-physx",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     },
     {
       name: "@galacean/engine-shaderlab",
       path: "packages/shader-lab",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     },
     {
       name: "@galacean/engine-shader-shaderlab",
       path: "packages/shader-shaderlab",
-      browserPath: "dist/browser.js"
+      browserPath: "dist/browser.min.js"
     }
   ],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build output message to remove the 'v' prefix before the version number.
  - Updated configuration to use minified browser builds for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->