### PR TITLE
Fixe the `camera._pixelViewport` was incorrect in XR mode (#2840)

### DIFF
--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -673,7 +673,7 @@ export class Camera extends Component {
       Logger.error("mipLevel only take effect in WebGL2.0");
     }
     let ignoreClearFlags: CameraClearFlags;
-    if (this._cameraType !== CameraType.Normal && !this._renderTarget && !this._isIndependentCanvasEnabled()) {
+    if (this._cameraType !== CameraType.Normal && !this._renderTarget) {
       ignoreClearFlags = engine.xrManager._getCameraIgnoreClearFlags(this._cameraType);
     }
     this._renderPipeline.render(context, cubeFace, mipLevel, ignoreClearFlags);
@@ -872,6 +872,10 @@ export class Camera extends Component {
       height = canvas.height;
     }
 
+    this._adjustPixelViewport(width, height);
+  }
+
+  private _adjustPixelViewport(width: number, height: number): void {
     const viewport = this._viewport;
     this._pixelViewport.set(viewport.x * width, viewport.y * height, viewport.z * width, viewport.w * height);
     !this._customAspectRatio && this._dispatchModify(CameraModifyFlags.AspectRatio);

--- a/packages/core/src/postProcess/FinalPass.ts
+++ b/packages/core/src/postProcess/FinalPass.ts
@@ -74,12 +74,12 @@ export class FinalPass extends PipelinePass {
 
     // Should convert to sRGB when FXAA is enabled or camera's render target is not set
     const sourceTexture = <Texture2D>this._inputRenderTarget.getColorTexture();
-    const outputRenderTarget = enableFXAA ? this._srgbRenderTarget : renderTarget;
-    Blitter.blitTexture(engine, sourceTexture, outputRenderTarget, 0, viewport, this._sRGBmaterial);
-
     if (enableFXAA) {
+      Blitter.blitTexture(engine, sourceTexture, this._srgbRenderTarget, 0, undefined, this._sRGBmaterial);
       const sRGBTexture = <Texture2D>this._srgbRenderTarget.getColorTexture();
       Blitter.blitTexture(engine, sRGBTexture, renderTarget, 0, viewport, this._antiAliasingMaterial);
+    } else {
+      Blitter.blitTexture(engine, sourceTexture, renderTarget, 0, viewport, this._sRGBmaterial);
     }
   }
 

--- a/packages/core/src/postProcess/PostProcessUberPass.ts
+++ b/packages/core/src/postProcess/PostProcessUberPass.ts
@@ -9,6 +9,7 @@ import { ShaderLib } from "../shaderlib";
 import blitVs from "../shaderlib/extra/Blit.vs.glsl";
 import { RenderTarget, Texture2D, TextureFilterMode, TextureWrapMode } from "../texture";
 import { BloomDownScaleMode, BloomEffect, TonemappingEffect } from "./effects";
+import { PostProcessManager } from "./PostProcessManager";
 import { PostProcessPass, PostProcessPassEvent } from "./PostProcessPass";
 import Filtering from "./shaders/Filtering.glsl";
 import PostCommon from "./shaders/PostCommon.glsl";
@@ -19,7 +20,6 @@ import RRT from "./shaders/Tonemapping/ACES/RRT.glsl";
 import Tonescale from "./shaders/Tonemapping/ACES/Tonescale.glsl";
 import NeutralTonemapping from "./shaders/Tonemapping/NeutralTonemapping.glsl";
 import UberPost from "./shaders/UberPost.glsl";
-import { PostProcessManager } from "./PostProcessManager";
 
 export class PostProcessUberPass extends PostProcessPass {
   static readonly UBER_SHADER_NAME = "UberPost";
@@ -93,8 +93,8 @@ export class PostProcessUberPass extends PostProcessPass {
     } else {
       uberShaderData.disableMacro(TonemappingEffect._enableMacro);
     }
-
-    Blitter.blitTexture(camera.engine, srcTexture, destTarget, 0, camera.viewport, this._uberMaterial, undefined);
+    const viewport = destTarget === camera.renderTarget ? camera.viewport : undefined;
+    Blitter.blitTexture(camera.engine, srcTexture, destTarget, 0, viewport, this._uberMaterial, undefined);
   }
 
   /**
@@ -137,7 +137,7 @@ export class PostProcessUberPass extends PostProcessPass {
       uberShaderData.disableMacro(BloomEffect._hqMacro);
     }
     uberShaderData.setTexture(BloomEffect._dirtTextureProp, dirtTexture.value);
-    if (dirtTexture) {
+    if (dirtTexture.value) {
       uberShaderData.enableMacro(BloomEffect._dirtMacro);
     } else {
       uberShaderData.disableMacro(BloomEffect._dirtMacro);

--- a/packages/rhi-webgl/src/WebGLGraphicDevice.ts
+++ b/packages/rhi-webgl/src/WebGLGraphicDevice.ts
@@ -488,7 +488,7 @@ export class WebGLGraphicDevice implements IHardwareRenderer {
     const yStart = flipY ? srcHeight - viewport.y * srcHeight - copyHeight : viewport.y * srcHeight;
 
     // @ts-ignore
-    const frameBuffer = srcRT?._platformRenderTarget._frameBuffer ?? null;
+    const frameBuffer = srcRT?._platformRenderTarget._frameBuffer ?? this._mainFrameBuffer;
 
     // @ts-ignore
     gl.bindFramebuffer(gl.FRAMEBUFFER, frameBuffer);

--- a/packages/xr/src/feature/camera/XRCameraManager.ts
+++ b/packages/xr/src/feature/camera/XRCameraManager.ts
@@ -94,7 +94,8 @@ export class XRCameraManager {
    * @internal
    */
   _onUpdate(): void {
-    const { _cameras: cameras } = this._xrManager.inputManager;
+    const cameras = this._xrManager.inputManager._cameras;
+    const platformSession = this._xrManager.sessionManager._platformSession;
     for (let i = 0, n = cameras.length; i < n; i++) {
       const cameraDevice = cameras[i];
       const { _camera: camera } = cameraDevice;
@@ -114,13 +115,24 @@ export class XRCameraManager {
       if (!Matrix.equals(camera.projectionMatrix, cameraDevice.projectionMatrix)) {
         camera.projectionMatrix = cameraDevice.projectionMatrix;
       }
+      // sync pixel viewport (only when rendering to XR main framebuffer)
+      if (!camera.renderTarget) {
+        // @ts-ignore
+        camera._adjustPixelViewport(platformSession.framebufferWidth, platformSession.framebufferHeight);
+      }
     }
   }
 
   /**
    * @internal
    */
-  _onSessionExit(): void {}
+  _onSessionExit(): void {
+    const cameras = this._xrManager.inputManager._cameras;
+    for (let i = 0, n = cameras.length; i < n; i++) {
+      // @ts-ignore
+      cameras[i]._camera?._updatePixelViewport();
+    }
+  }
 
   /**
    * @internal


### PR DESCRIPTION
* fix: camera pixel viewport error in xr

### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected framebuffer fallback to prevent copy failures on some devices.
  - Fixed viewport handling during post-processing, ensuring accurate blits with and without FXAA.
  - Enabled bloom dirt effect only when a valid texture is provided.

- Improvements
  - More consistent aspect ratio and viewport updates, reducing stretching or scaling issues.
  - Refined FXAA and sRGB conversion flow for cleaner edges and more accurate color output.
  - Synchronized XR camera pixel viewports and refreshed them on session exit for stable rendering across transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->