### PR TITLE
 Add feature configuration to `XRSessionInit.optionalFeatures`

### DIFF
--- a/packages/xr-webxr/src/WebXRDevice.ts
+++ b/packages/xr-webxr/src/WebXRDevice.ts
@@ -45,7 +45,7 @@ export class WebXRDevice implements IXRDevice {
   requestSession(rhi: IHardwareRenderer, mode: XRSessionMode, platformFeatures: WebXRFeature[]): Promise<WebXRSession> {
     return new Promise((resolve, reject) => {
       const sessionMode = parseXRMode(mode);
-      const options: XRSessionInit = { requiredFeatures: ["local"] };
+      const options: XRSessionInit = { requiredFeatures: ["local"], optionalFeatures: [] };
       const promiseArr = [];
       for (let i = 0, n = platformFeatures.length; i < n; i++) {
         const promise = platformFeatures[i]._assembleOptions(options);

--- a/packages/xr-webxr/src/feature/WebXRAnchorTracking.ts
+++ b/packages/xr-webxr/src/feature/WebXRAnchorTracking.ts
@@ -66,7 +66,7 @@ export class WebXRAnchorTracking extends WebXRTrackableFeature<IXRTracked, IWebX
    * @internal
    */
   _assembleOptions(options: XRSessionInit): void {
-    options.requiredFeatures.push("anchors");
+    options.optionalFeatures.push("anchors");
   }
 
   private _addAnchor(session: WebXRSession, frame: WebXRFrame, requestTracking: IWebXRRequestTrackingAnchor): void {

--- a/packages/xr-webxr/src/feature/WebXRImageTracking.ts
+++ b/packages/xr-webxr/src/feature/WebXRImageTracking.ts
@@ -83,7 +83,7 @@ export class WebXRImageTracking extends WebXRTrackableFeature<IXRTrackedImage, I
    * @internal
    */
   _assembleOptions(options: XRSessionInit): Promise<void> | void {
-    options.requiredFeatures.push("image-tracking");
+    options.optionalFeatures.push("image-tracking");
     const { _images: images } = this;
     const promiseArr: Promise<ImageBitmap>[] = [];
     if (images) {

--- a/packages/xr-webxr/src/feature/WebXRPlaneTracking.ts
+++ b/packages/xr-webxr/src/feature/WebXRPlaneTracking.ts
@@ -66,7 +66,7 @@ export class WebXRPlaneTracking extends WebXRTrackableFeature<IWebXRTrackedPlane
    * @internal
    */
   _assembleOptions(options: XRSessionInit): void {
-    options.requiredFeatures.push("plane-detection");
+    options.optionalFeatures.push("plane-detection");
   }
 
   private _updatePlane(frame: XRFrame, space: XRSpace, trackedPlane: IWebXRTrackedPlane): void {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved XR session compatibility by treating anchors, image tracking, and plane detection as optional. Sessions now start reliably on devices/browsers that don’t support these capabilities, with graceful feature fallbacks.
- Refactor
  - Updated session initialization to include optional feature negotiation for broader device support without altering public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->