### PR TITLE
Clearer shader compilation results

### DIFF
--- a/packages/shader-lab/src/macroProcessor/Utils.ts
+++ b/packages/shader-lab/src/macroProcessor/Utils.ts
@@ -33,6 +33,9 @@ export class PpUtils {
       generatedIdx = generatedIdxEnd;
     }
     ret.push(source.slice(startIdx));
-    return ret.join("");
+    const result = ret.join("");
+
+    // Replace multiple consecutive newlines with a single newline to clean up the output
+    return result.replace(/\n\s*\n+/g, "\n");
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
before:
```
// 2^-14, the same value for 10, 11 and 16-bit: https://www.khronos.org/opengl/wiki/Small_Float_Formats

// 2^-11, machine epsilon: 1 + EPS = 1 (half of the ULP for 1.0f)





















uniform mat4 renderer_ModelMat;
uniform mat4 renderer_MVMat;
uniform mat4 renderer_MVPMat;
uniform mat4 renderer_NormalMat;



































in vec3 POSITION;











in vec3 NORMAL;









out vec2 uv;




out vec3 positionWS;



out vec3 normalWS;























































































































































struct VertexInputs { vec4 positionOS ; vec3 positionWS ; 

 
vec3 normalWS ; 

 
 } ;
uniform vec4 material_TilingOffset;
vec2 getUV0 (  ) { vec2 uv0 = vec2 ( 0 ) ;



return uv0 * material_TilingOffset.xy + material_TilingOffset.zw ; }
VertexInputs getVertexInputs (  ) { VertexInputs inputs ;
vec4 position = vec4 ( POSITION , 1.0 ) ;

vec3 normal = vec3 ( NORMAL ) ;


 








inputs.normalWS = normalize ( mat3 ( renderer_NormalMat ) * normal ) ;


 

inputs.positionOS = position ;
vec4 positionWS = renderer_ModelMat * position ;
inputs.positionWS = positionWS.xyz / positionWS.w ;



return inputs ; }



















































void main() { 
uv = getUV0() ;






VertexInputs vertexInputs = getVertexInputs() ;
positionWS = vertexInputs.positionWS ;




normalWS = vertexInputs.normalWS ;


 




gl_Position = renderer_MVPMat * vertexInputs.positionOS ;
 }
```
now:
<img width="1550" height="814" alt="image" src="https://github.com/user-attachments/assets/860724eb-7ad0-4727-8b63-986864773f87" />

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved output formatting by consolidating excessive blank lines in shader processing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->