### PR TITLE
Fix incorrect iOS version detection on Safari 26 due to UA reduction

### DIFF
--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -28,33 +28,14 @@ export class SystemInfo {
     return window.devicePixelRatio;
   }
 
-  private static _parseAppleOSVersion(userAgent: string, osPrefix: string): string {
-    // Detect if it's Safari browser (not Chrome/Firefox/other browsers or WebView)
-    const isSafariBrowser =
-      /Safari/i.test(userAgent) && /Version\/\d+/i.test(userAgent) && !/CriOS|FxiOS|EdgiOS|OPiOS/i.test(userAgent);
+  private static _parseAppleMobileOSVersion(userAgent: string, osPrefix: string): string {
+    // Since iOS 26, Safari freezes UA OS version at 18.6, so Version/xx is more reliable
+    // Use Version/ if available, otherwise fallback to OS version
+    let v = userAgent.match(/Version\/(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+    if (v) return `${osPrefix} ${v[1]}.${v[2] || 0}.${v[3] || 0}`;
 
-    if (isSafariBrowser) {
-      // Safari browser: Use Version/xx to infer iOS version
-      // Since iOS 26, Safari freezes UA OS version at 18.6, so Version/xx is the only reliable source
-      const versionMatch = userAgent.match(/Version\/(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
-      if (versionMatch) {
-        const major = parseInt(versionMatch[1]);
-        const minor = versionMatch[2] ? parseInt(versionMatch[2]) : 0;
-        const patch = versionMatch[3] ? parseInt(versionMatch[3]) : 0;
-        return `${osPrefix} ${major}.${minor}.${patch}`;
-      }
-    } else {
-      // Chrome/Firefox/WebView: Use OS version from UA (still accurate)
-      const osMatch = userAgent.match(/OS (\d+)_(\d+)(?:_(\d+))?/);
-      if (osMatch) {
-        const major = parseInt(osMatch[1]);
-        const minor = parseInt(osMatch[2]);
-        const patch = osMatch[3] ? parseInt(osMatch[3]) : 0;
-        return `${osPrefix} ${major}.${minor}.${patch}`;
-      }
-    }
-
-    return osPrefix;
+    v = userAgent.match(/OS (\d+)_(\d+)(?:_(\d+))?/);
+    return v ? `${osPrefix} ${v[1]}.${v[2]}.${v[3] || 0}` : osPrefix;
   }
 
   /**
@@ -82,10 +63,10 @@ export class SystemInfo {
       let v: RegExpMatchArray;
       switch (SystemInfo.platform) {
         case Platform.IPhone:
-          this.operatingSystem = this._parseAppleOSVersion(userAgent, "iPhone OS");
+          this.operatingSystem = this._parseAppleMobileOSVersion(userAgent, "iPhone OS");
           break;
         case Platform.IPad:
-          this.operatingSystem = this._parseAppleOSVersion(userAgent, "iPad OS");
+          this.operatingSystem = this._parseAppleMobileOSVersion(userAgent, "iPad OS");
           break;
         case Platform.Android:
           v = userAgent.match(/Android (\d+).?(\d+)?.?(\d+)?/);

--- a/tests/src/core/base/SystemInfo.test.ts
+++ b/tests/src/core/base/SystemInfo.test.ts
@@ -1,0 +1,136 @@
+import { Platform, SystemInfo } from "@galacean/engine-core";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+// Cast to access internal methods
+const SystemInfoInternal = SystemInfo as typeof SystemInfo & {
+  _initialize(): void;
+};
+
+describe("SystemInfo", () => {
+  let originalUserAgent: string;
+
+  beforeEach(() => {
+    originalUserAgent = navigator.userAgent;
+  });
+
+  afterEach(() => {
+    // Restore original userAgent
+    Object.defineProperty(navigator, "userAgent", {
+      value: originalUserAgent,
+      configurable: true
+    });
+    // Reset SystemInfo state
+    SystemInfo.platform = Platform.Unknown;
+    SystemInfo.operatingSystem = "";
+  });
+
+  const mockUserAgent = (ua: string) => {
+    Object.defineProperty(navigator, "userAgent", {
+      value: ua,
+      configurable: true
+    });
+  };
+
+  describe("_parseAppleMobileOSVersion for iPhone", () => {
+    // iOS 26+ Safari: UA freezes OS version at 18.6, use Version/xx to infer real iOS version
+    it("Safari on iOS 26 (UA frozen at 18.6)", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 26.0.0");
+    });
+
+    it("Safari on iOS 26.1.2 (UA frozen at 18.6)", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1.2 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 26.1.2");
+    });
+
+    // Chrome on iOS: OS version is accurate
+    it("Chrome on iOS 26", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/138.0.7204.119 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 26.0.0");
+    });
+
+    // Firefox on iOS: OS version is accurate
+    it("Firefox on iOS 26", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/140.2 Mobile/15E148 Safari/605.1.15"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 26.0.0");
+    });
+
+    // Edge on iOS: Use Version/ (may lose patch version, but acceptable)
+    it("Edge on iOS 26", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 EdgiOS/46.3.30 Mobile/15E148 Safari/605.1.15"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 26.0.0");
+    });
+
+    // Opera on iOS: OS version is accurate
+    it("Opera on iOS 26", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 OPiOS/16.0.14 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 26.0.0");
+    });
+
+    // Legacy Safari (before iOS 26): OS version is accurate
+    it("Safari on iOS 18.4", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 18.4.0");
+    });
+
+    // WebView or in-app browser: No Version/, fallback to OS version
+    it("WebView on iOS (no Version/)", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPhone);
+      expect(SystemInfo.operatingSystem).to.eq("iPhone OS 18.6.0");
+    });
+  });
+
+  describe("_parseAppleMobileOSVersion for iPad", () => {
+    // iPad Safari with frozen UA
+    it("Safari on iPadOS 26 (UA frozen at 18.6)", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPad; CPU OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPad);
+      expect(SystemInfo.operatingSystem).to.eq("iPad OS 26.0.0");
+    });
+
+    // Chrome on iPad
+    it("Chrome on iPadOS 26", () => {
+      mockUserAgent(
+        "Mozilla/5.0 (iPad; CPU OS 26_0_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/138.0.7204.156 Mobile/15E148 Safari/604.1"
+      );
+      SystemInfoInternal._initialize();
+      expect(SystemInfo.platform).to.eq(Platform.IPad);
+      expect(SystemInfo.operatingSystem).to.eq("iPad OS 26.0.0");
+    });
+  });
+});


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved iPhone and iPad OS version detection across browsers by introducing an internal parsing helper, while preserving fallback behavior when parsing fails.
* **Tests**
  * Added comprehensive unit tests simulating multiple browsers and iOS scenarios (including modern, legacy, WebView and UA-freeze cases) to validate platform and OS detection.
* **Chores**
  * Removed duplicate imports and tidied minor code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->