### PR TITLE
Merge to 1.5: Fix PrefabResource refCount was incorrect

### DIFF
--- a/packages/loader/src/prefab/PrefabParser.ts
+++ b/packages/loader/src/prefab/PrefabParser.ts
@@ -1,7 +1,7 @@
 import { Engine, Entity } from "@galacean/engine-core";
+import { IEntity, IHierarchyFile, ParserContext, ParserType } from "../resource-deserialize";
 import { HierarchyParser } from "../resource-deserialize/resources/parser/HierarchyParser";
 import { PrefabResource } from "./PrefabResource";
-import { IHierarchyFile, ParserContext, ParserType } from "../resource-deserialize";
 
 export class PrefabParser extends HierarchyParser<PrefabResource, ParserContext<IHierarchyFile, Entity>> {
   static parse(engine: Engine, url: string, data: IHierarchyFile): Promise<PrefabResource> {
@@ -18,6 +18,13 @@ export class PrefabParser extends HierarchyParser<PrefabResource, ParserContext<
     public readonly prefabResource: PrefabResource
   ) {
     super(data, context);
+  }
+
+  protected override _applyEntityData(entity: Entity, entityConfig: IEntity = {}): Entity {
+    super._applyEntityData(entity, entityConfig);
+    // @ts-ignore
+    entity._markAsTemplate(this.context.resource);
+    return entity;
   }
 
   protected override _handleRootEntity(id: string): void {

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -62,6 +62,23 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       .catch(this._reject);
   }
 
+  protected _applyEntityData(entity: Entity, entityConfig: IEntity = {}): Entity {
+    entity.isActive = entityConfig.isActive ?? entity.isActive;
+    entity.name = entityConfig.name ?? entity.name;
+    const transform = entity.transform;
+    const transformConfig = entityConfig.transform;
+    if (transformConfig) {
+      this._reflectionParser.parsePropsAndMethods(transform, transformConfig);
+    } else {
+      const { position, rotation, scale } = entityConfig;
+      if (position) transform.position.copyFrom(position);
+      if (rotation) transform.rotation.copyFrom(rotation);
+      if (scale) transform.scale.copyFrom(scale);
+    }
+    if (entityConfig.layer) entity.layer = entityConfig.layer;
+    return entity;
+  }
+
   protected abstract _handleRootEntity(id: string): void;
   protected abstract _clearAndResolve(): Scene | PrefabResource;
 
@@ -300,23 +317,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       componentConfigMap.set(componentId, componentConfig);
       this._addComponentPlugin(componentId, component);
     }
-  }
-
-  private _applyEntityData(entity: Entity, entityConfig: IEntity = {}): Entity {
-    entity.isActive = entityConfig.isActive ?? entity.isActive;
-    entity.name = entityConfig.name ?? entity.name;
-    const transform = entity.transform;
-    const transformConfig = entityConfig.transform;
-    if (transformConfig) {
-      this._reflectionParser.parsePropsAndMethods(transform, transformConfig);
-    } else {
-      const { position, rotation, scale } = entityConfig;
-      if (position) transform.position.copyFrom(position);
-      if (rotation) transform.rotation.copyFrom(rotation);
-      if (scale) transform.scale.copyFrom(scale);
-    }
-    if (entityConfig.layer) entity.layer = entityConfig.layer;
-    return entity;
   }
 
   private _generateInstanceContext(entity: Entity, context: ParserContext<IHierarchyFile, Entity>, path: string) {

--- a/tests/src/loader/PrefabResource.test.ts
+++ b/tests/src/loader/PrefabResource.test.ts
@@ -1,0 +1,54 @@
+import { expect, beforeAll, afterAll, describe, it } from "vitest";
+import { WebGLEngine } from "@galacean/engine-rhi-webgl";
+import type { IHierarchyFile } from "@galacean/engine-loader";
+import { PrefabParser } from "../../../packages/loader/src/prefab/PrefabParser";
+
+let engine: WebGLEngine;
+
+beforeAll(async () => {
+  const canvas = document.createElement("canvas");
+  canvas.width = 256;
+  canvas.height = 256;
+  engine = await WebGLEngine.create({ canvas });
+});
+
+afterAll(() => {
+  engine?.destroy();
+});
+
+describe("PrefabResource refCount", () => {
+  it("should increase and decrease with instantiated entities", async () => {
+    const prefabData: IHierarchyFile = {
+      entities: [
+        {
+          id: "0",
+          name: "root",
+          components: [],
+          children: ["1"]
+        },
+        {
+          id: "1",
+          name: "child",
+          parent: "0",
+          components: []
+        }
+      ]
+    };
+
+    const prefab = await PrefabParser.parse(engine, "prefab.json", prefabData);
+
+    expect(prefab.refCount).toBe(0);
+
+    const instance1 = prefab.instantiate();
+    const instance2 = prefab.instantiate();
+
+    // One ref count per templated entity in each instance (root + child).
+    expect(prefab.refCount).toBe(4);
+
+    instance1.destroy();
+    expect(prefab.refCount).toBe(2);
+
+    instance2.destroy();
+    expect(prefab.refCount).toBe(0);
+  });
+});


### PR DESCRIPTION
* fix: prefab refcount error

### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for prefab instantiation and lifecycle behavior, validating reference counting accuracy throughout instance creation and destruction cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->