### PR TITLE
AudioManager add `suspend`

### DIFF
--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -11,11 +11,10 @@ export class AudioManager {
   private static _needsUserGestureResume = false;
 
   /**
-   * Pause all audio processing.
-   * @remarks The audio can be resumed later using the `resume()` method.
-   * @returns A promise that resolves when the audio is paused
+   * Suspend the audio context.
+   * @returns A promise that resolves when the audio context is suspended
    */
-  static pause(): Promise<void> {
+  static suspend(): Promise<void> {
     return AudioManager._context.suspend();
   }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to explicitly suspend (pause) the global audio context, complementing the existing resume capability so applications can programmatically control audio playback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->