### PR TITLE
Fix WKWebview AudioContext "zombie" state in visibility change

### DIFF
--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -72,7 +72,7 @@ export class AudioManager {
 
   private static _onVisibilityChange(): void {
     if (!document.hidden && AudioManager._playingCount > 0 && !AudioManager.isAudioContextRunning()) {
-      // iOS WKWebView WebKit bug: AudioContext may be in a "zombie" state where
+      // iOS WKWebView WebKit bug(Triggered in LingGuang App): AudioContext may be in a "zombie" state where
       // state reports "suspended" but resume() alone won't restart audio rendering.
       // Calling suspend() first forces a clean internal state reset before user gesture triggers resume.
       // Related: https://bugs.webkit.org/show_bug.cgi?id=263627


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

What is the current behavior? (You can also link to an open issue here)
On iOS WKWebView, when the app switches to background and returns to foreground, AudioContext may be in a "zombie" state — state reports "suspended", but calling resume() alone won't restart audio rendering.

What is the new behavior (if this is a feature change)?
When visibilitychange event detects audio needs to be resumed, call suspend() first to force reset the AudioContext internal state, then trigger resume() via user gesture to ensure audio recovers correctly.

Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

Other information:
This is a known WebKit bug where AudioContext may enter a state where state appears normal but currentTime stops incrementing after returning from background. Calling suspend() first forces a clean internal state reset, which is a common workaround adopted by other audio libraries (PlayCanvas, Tone.js, etc.).

Related: https://bugs.webkit.org/show_bug.cgi?id=263627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio playback issues on iOS WebKit browsers when resuming from suspended state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->