### PR TITLE
Fix `isRoot` was not set correctly when set `entity.parent`

### DIFF
--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -349,51 +349,7 @@ export class Entity extends EngineObject {
       index = undefined;
       child = indexOrChild;
     }
-
-    if (child._isRoot) {
-      const oldScene = child._scene;
-      Entity._removeFromChildren(oldScene._rootEntities, child);
-      child._isRoot = false;
-
-      this._addToChildrenList(index, child);
-      child._parent = this;
-
-      const newScene = this._scene;
-
-      let inActiveChangeFlag = ActiveChangeFlag.None;
-      if (!this._isActiveInHierarchy) {
-        child._isActiveInHierarchy && (inActiveChangeFlag |= ActiveChangeFlag.Hierarchy);
-      }
-      if (child._isActiveInScene) {
-        if (this._isActiveInScene) {
-          // Cross scene should inActive first and then active
-          oldScene !== newScene && (inActiveChangeFlag |= ActiveChangeFlag.Scene);
-        } else {
-          inActiveChangeFlag |= ActiveChangeFlag.Scene;
-        }
-      }
-
-      inActiveChangeFlag && child._processInActive(inActiveChangeFlag);
-
-      if (child._scene !== newScene) {
-        Entity._traverseSetOwnerScene(child, newScene);
-      }
-
-      let activeChangeFlag = ActiveChangeFlag.None;
-      if (child._isActive) {
-        if (this._isActiveInHierarchy) {
-          !child._isActiveInHierarchy && (activeChangeFlag |= ActiveChangeFlag.Hierarchy);
-        }
-        if (this._isActiveInScene) {
-          (!child._isActiveInScene || oldScene !== newScene) && (activeChangeFlag |= ActiveChangeFlag.Scene);
-        }
-      }
-      activeChangeFlag && child._processActive(activeChangeFlag);
-
-      child._setParentChange();
-    } else {
-      child._setParent(this, index);
-    }
+    child._setParent(this, index);
   }
 
   /**
@@ -401,6 +357,7 @@ export class Entity extends EngineObject {
    * @param child - The child entity which want to be removed
    */
   removeChild(child: Entity): void {
+    if (child._parent !== this) return;
     child._setParent(null);
   }
 
@@ -677,7 +634,12 @@ export class Entity extends EngineObject {
   private _setParent(parent: Entity, siblingIndex?: number): void {
     const oldParent = this._parent;
     if (parent !== oldParent) {
-      this._removeFromParent();
+      if (this._isRoot) {
+        Entity._removeFromChildren(this._scene._rootEntities, this);
+        this._isRoot = false;
+      } else {
+        this._removeFromParent();
+      }
       this._parent = parent;
       if (parent) {
         this._isRoot = false;

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -406,16 +406,45 @@ describe("Entity", async () => {
     it("isRoot", () => {
       const parent = scene.createRootEntity("parent");
       const child = scene.createRootEntity("child");
+
+      // addChild should remove child from rootEntities
       parent.addChild(child);
+      // @ts-ignore
+      expect(child._isRoot).eq(false);
+      expect(scene.rootEntities).not.toContain(child);
+      expect(child.parent).eq(parent);
+
+      // addRootEntity should restore root status
       scene.addRootEntity(child);
       // @ts-ignore
       expect(child._isRoot).eq(true);
+      expect(scene.rootEntities).toContain(child);
+
+      // parent setter should remove child from rootEntities
       child.parent = parent;
       // @ts-ignore
       expect(child._isRoot).eq(false);
+      expect(scene.rootEntities).not.toContain(child);
+      expect(child.parent).eq(parent);
+
+      // addRootEntity should restore root status again
       scene.addRootEntity(child);
       // @ts-ignore
       expect(child._isRoot).eq(true);
+      expect(scene.rootEntities).toContain(child);
+    });
+
+    it("removeChild guard", () => {
+      const parentA = scene.createRootEntity("parentA");
+      const parentB = scene.createRootEntity("parentB");
+      const child = new Entity(engine, "child");
+      parentA.addChild(child);
+      expect(child.parent).eq(parentA);
+
+      // removeChild on wrong parent should be no-op
+      parentB.removeChild(child);
+      expect(child.parent).eq(parentA);
+      expect(parentA.children).toContain(child);
     });
 
     it("InActiveAndActive", () => {


### PR DESCRIPTION
### Problem

New version of PR: https://github.com/galacean/engine/pull/2597

When changing a root entity's parent via `entity.parent = newParent`, `_isRoot` is set to `false` but the entity is **not removed from `scene._rootEntities`**. 

Root cause: `_setParent()` calls `_removeFromParent()`, which only handles `_parent != null` (removing from parent's children). For root entities (`_parent` is `null`), it does nothing.

### Solution

- **`_setParent`**: Before setting new parent, use `if/else` to handle both cases: root entity removes from `scene._rootEntities`, non-root removes from `parent._children`
- **`addChild`**: Remove duplicated `_isRoot` special branch, unify through `_setParent()`
- **`removeChild`**: Add `child._parent !== this` guard

### Test plan

- `addChild` / `parent` setter on root entity correctly removes from `scene.rootEntities`
- Round-trip root → child → root → child works correctly
- `removeChild` on wrong parent is a no-op
- All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed entity parent reassignment to properly update root status and hierarchy relationships.
  * Added safety check to prevent invalid child removal operations.

* **Refactor**
  * Simplified entity parent-child management logic for improved reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->