### PR TITLE
Configure CDN default entry for bundled ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "rollup-plugin-jscc": "^2.0.0",
     "rollup-plugin-serve": "^1.1.0",
     "rollup-plugin-swc3": "^0.10.1",
-    "three": "^0.178.0",
     "ts-node": "^10",
     "typescript": "^5.1.6",
     "vitest": "2.1.3"

--- a/packages/galacean/package.json
+++ b/packages/galacean/package.json
@@ -13,6 +13,8 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "browser": "dist/browser.js",
+  "unpkg": "dist/bundled.module.min.js",
+  "jsdelivr": "dist/bundled.module.min.js",
   "files": [
     "dist/**/*",
     "types/**/*"


### PR DESCRIPTION
## Summary

Add `unpkg` and `jsdelivr` fields to `@galacean/engine` package.json, pointing to `dist/bundled.module.min.js`. This configures the default file that CDN platforms return when users access the bare package URL.

Without these fields, CDNs fall back to `main` (`dist/main.js`, CJS format), which is unusable in browsers.

### Before

https://cdn.jsdelivr.net/npm/@galacean/engine@2.0.0
→ returns dist/main.js (CJS, browser unusable)



### After

https://cdn.jsdelivr.net/npm/@galacean/engine@2.0.0
→ returns dist/bundled.module.min.js (self-contained ESM, browser ready)



## Usage

Bare URL now works directly — no need to specify the full file path:

```html
<script type="importmap">
{
  "imports": {
    "@galacean/engine": "https://cdn.jsdelivr.net/npm/@galacean/engine@2.0.0"
  }
}
</script>
<script type="module">
  import { WebGLEngine, Camera } from "@galacean/engine";
</script>
Other formats are still accessible via explicit paths:


/dist/bundled.module.js       (ESM, unminified)
/dist/browser.min.js          (UMD)
/dist/module.js               (ESM, external deps for bundlers)
Test plan
 Verify npm run b:bundled produces correct output
 Verify CDN bare URL resolves to bundled ESM after publish