### PR TITLE
fix: fix ray and plane when ray origin is on the plane and parallel

### DIFF
--- a/packages/math/src/CollisionUtil.ts
+++ b/packages/math/src/CollisionUtil.ts
@@ -145,12 +145,16 @@ export class CollisionUtil {
     const { zeroTolerance } = MathUtil;
 
     const dir = Vector3.dot(normal, ray.direction);
+    const position = Vector3.dot(normal, ray.origin);
     // Parallel
     if (Math.abs(dir) < zeroTolerance) {
+      // Check if ray origin is on the plane
+      if (Math.abs(position + plane.distance) < zeroTolerance) {
+        return 0;
+      }
       return -1;
     }
 
-    const position = Vector3.dot(normal, ray.origin);
     let distance = (-plane.distance - position) / dir;
 
     if (distance < 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision detection for ray-plane interactions by fixing behavior in a specific edge case scenario. When a ray is parallel to a plane and its origin lies on the plane surface, the system now correctly identifies and reports the collision result, enhancing the accuracy of geometric computations and physics simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->