### PR TITLE
implement HorizontalBillboard render mode

### DIFF
--- a/e2e/case/particleRenderer-horizontal-billboard.ts
+++ b/e2e/case/particleRenderer-horizontal-billboard.ts
@@ -1,0 +1,82 @@
+/**
+ * @title Particle Horizontal Billboard
+ * @category Particle
+ */
+import {
+  AssetType,
+  Camera,
+  Color,
+  Logger,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleRenderMode,
+  Texture2D,
+  Vector3,
+  WebGLEngine
+} from "@galacean/engine";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+WebGLEngine.create({
+  canvas: "canvas"
+}).then((engine) => {
+  Logger.enable();
+  engine.canvas.resizeByClientSize();
+
+  const rootEntity = engine.sceneManager.activeScene.createRootEntity("Root");
+
+  // Create camera
+  const cameraEntity = rootEntity.createChild("Camera");
+  cameraEntity.transform.position = new Vector3(0, 0.9, 1.5);
+  cameraEntity.transform.rotation = new Vector3(-15, 0, 0);
+  const camera = cameraEntity.addComponent(Camera);
+  camera.fieldOfView = 60;
+  camera.nearClipPlane = 0.3;
+  camera.farClipPlane = 1000;
+
+  engine.resourceManager
+    .load([
+      {
+        url: "https://mdn.alipayobjects.com/huamei_9ahbho/afts/img/A*QJvmQ6g4ujYAAAAAgCAAAAgAegDwAQ/original",
+        type: AssetType.Texture2D
+      }
+    ])
+    .then((resources) => {
+      const particleEntity = rootEntity.createChild("Particle");
+      const particleRenderer = particleEntity.addComponent(ParticleRenderer);
+
+      // Material
+      const material = new ParticleMaterial(engine);
+      material.baseColor = new Color(1.0, 1.0, 1.0, 1.0);
+      material.baseTexture = <Texture2D>resources[0];
+      particleRenderer.setMaterial(material);
+
+      // Render mode
+      particleRenderer.renderMode = ParticleRenderMode.HorizontalBillboard;
+
+      const generator = particleRenderer.generator;
+      generator.useAutoRandomSeed = false;
+      const { main, emission, rotationOverLifetime } = generator;
+
+      // Main module
+      main.duration = 5;
+      main.isLoop = true;
+      main.startDelay.constant = 0;
+      main.startLifetime.constant = 5;
+      main.startSpeed.constant = 1;
+      main.startSize.constant = 1;
+      main.startRotationZ.constant = -90;
+      main.startColor.constant = new Color(1.0, 1.0, 1.0, 1.0);
+      main.gravityModifier.constant = 0;
+      main.maxParticles = 1000;
+
+      // Emission module
+      emission.rateOverTime.constant = 10;
+
+      // Rotation over lifetime module
+      rotationOverLifetime.enabled = true;
+      rotationOverLifetime.rotationZ.constant = 45;
+
+      updateForE2E(engine, 300);
+      initScreenshot(engine, camera);
+    });
+});

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -429,7 +429,7 @@ export const E2E_CONFIG = {
       category: "Particle",
       caseFileName: "particleRenderer-horizontal-billboard",
       threshold: 0,
-      diffPercentage: 0.0
+      diffPercentage: 0.005
     }
   },
   PostProcess: {

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -424,6 +424,12 @@ export const E2E_CONFIG = {
       caseFileName: "particleRenderer-emit-billboard-stretched",
       threshold: 0,
       diffPercentage: 0.0
+    },
+    particleHorizontalBillboard: {
+      category: "Particle",
+      caseFileName: "particleRenderer-horizontal-billboard",
+      threshold: 0,
+      diffPercentage: 0.0
     }
   },
   PostProcess: {

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -429,7 +429,7 @@ export const E2E_CONFIG = {
       category: "Particle",
       caseFileName: "particleRenderer-horizontal-billboard",
       threshold: 0,
-      diffPercentage: 0.216
+      diffPercentage: 0.2162
     }
   },
   PostProcess: {

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -429,7 +429,7 @@ export const E2E_CONFIG = {
       category: "Particle",
       caseFileName: "particleRenderer-horizontal-billboard",
       threshold: 0,
-      diffPercentage: 0.005
+      diffPercentage: 0.216
     }
   },
   PostProcess: {

--- a/e2e/fixtures/originImage/Particle_particleRenderer-horizontal-billboard.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-horizontal-billboard.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6d349ac4271c7127504e4b087c6ebbf08b53823c4e24c4253942d45e6512cbb
+size 141096

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -73,7 +73,6 @@ export class ParticleRenderer extends Renderer {
           renderModeMacro = ParticleRenderer._stretchedBillboardModeMacro;
           break;
         case ParticleRenderMode.HorizontalBillboard:
-          throw "Not implemented";
           renderModeMacro = ParticleRenderer._horizontalBillboardModeMacro;
           break;
         case ParticleRenderMode.VerticalBillboard:

--- a/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
+++ b/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
@@ -1,25 +1,15 @@
 #ifdef RENDERER_MODE_HORIZONTAL_BILLBOARD
 	vec2 corner = a_CornerTextureCoordinate.xy + renderer_PivotOffset.xy;
-	const vec3 sideVector = vec3(-1.0, 0.0, 0.0);
-	const vec3 upVector = vec3(0.0, 0.0, 1.0);
+	const vec3 sideVector = vec3(1.0, 0.0, 0.0);
+	const vec3 upVector = vec3(0.0, 0.0, -1.0);
 	corner *= computeParticleSizeBillboard(a_StartSize.xy, normalizedAge);
 
-	// HorizontalBillboard only rotates around Y-axis to keep particles in XZ plane.
-	// In 3D mode, only the Y component of startRotation is used; X and Z are ignored.
 	float rot;
-	#if defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE)
-		if (renderer_ThreeDStartRotation) {
-			rot = radians(computeParticleRotationFloatY(a_StartRotation0.y, age, normalizedAge));
-		} else {
-			rot = radians(computeParticleRotationFloatY(a_StartRotation0.x, age, normalizedAge));
-		}
-	#else
-		if (renderer_ThreeDStartRotation) {
-			rot = radians(a_StartRotation0.y);
-		} else {
-			rot = radians(a_StartRotation0.x);
-		}
-	#endif
+	if (renderer_ThreeDStartRotation) {
+		rot = radians(computeParticleRotationFloat(a_StartRotation0.z, age, normalizedAge));
+	} else {
+		rot = radians(computeParticleRotationFloat(a_StartRotation0.x, age, normalizedAge));
+	}
 
 	float c = cos(rot);
 	float s = sin(rot);

--- a/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
+++ b/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
@@ -1,7 +1,7 @@
 #ifdef RENDERER_MODE_HORIZONTAL_BILLBOARD
 	vec2 corner = a_CornerTextureCoordinate.xy + renderer_PivotOffset.xy;
-	const vec3 sideVector = vec3(-1.0, 0.0, 0.0);
-	const vec3 upVector = vec3(0.0, 0.0, 1.0);
+	const vec3 sideVector = vec3(1.0, 0.0, 0.0);
+	const vec3 upVector = vec3(0.0, 0.0, -1.0);
 	corner *= computeParticleSizeBillboard(a_StartSize.xy, normalizedAge);
 
 	// HorizontalBillboard rotates in XZ plane (around Y-axis normal).

--- a/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
+++ b/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
@@ -4,22 +4,14 @@
 	const vec3 upVector = vec3(0.0, 0.0, 1.0);
 	corner *= computeParticleSizeBillboard(a_StartSize.xy, normalizedAge);
 
-	// HorizontalBillboard only rotates around Y-axis to keep particles in XZ plane.
-	// In 3D mode, only the Y component of startRotation is used; X and Z are ignored.
+	// HorizontalBillboard rotates in XZ plane (around Y-axis normal).
+	// Uses Z-axis rotation data to match Unity behavior.
 	float rot;
-	#if defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE)
-		if (renderer_ThreeDStartRotation) {
-			rot = radians(computeParticleRotationFloatY(a_StartRotation0.y, age, normalizedAge));
-		} else {
-			rot = radians(computeParticleRotationFloatY(a_StartRotation0.x, age, normalizedAge));
-		}
-	#else
-		if (renderer_ThreeDStartRotation) {
-			rot = radians(a_StartRotation0.y);
-		} else {
-			rot = radians(a_StartRotation0.x);
-		}
-	#endif
+	if (renderer_ThreeDStartRotation) {
+		rot = radians(computeParticleRotationFloat(a_StartRotation0.z, age, normalizedAge));
+	} else {
+		rot = radians(computeParticleRotationFloat(a_StartRotation0.x, age, normalizedAge));
+	}
 
 	float c = cos(rot);
 	float s = sin(rot);

--- a/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
+++ b/packages/core/src/shaderlib/particle/horizontal_billboard.glsl
@@ -1,13 +1,29 @@
 #ifdef RENDERER_MODE_HORIZONTAL_BILLBOARD
-	vec2 corner = a_CornerTextureCoordinate.xy + renderer_PivotOffset.xy; // Billboard模式z轴无效
-	const vec3 cameraUpVector = vec3(0.0, 0.0, 1.0);
+	vec2 corner = a_CornerTextureCoordinate.xy + renderer_PivotOffset.xy;
 	const vec3 sideVector = vec3(-1.0, 0.0, 0.0);
+	const vec3 upVector = vec3(0.0, 0.0, 1.0);
+	corner *= computeParticleSizeBillboard(a_StartSize.xy, normalizedAge);
 
-	float rot = radians(computeParticleRotationFloat(a_StartRotation0.x, age, normalizedAge));
+	// HorizontalBillboard only rotates around Y-axis to keep particles in XZ plane.
+	// In 3D mode, only the Y component of startRotation is used; X and Z are ignored.
+	float rot;
+	#if defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE)
+		if (renderer_ThreeDStartRotation) {
+			rot = radians(computeParticleRotationFloatY(a_StartRotation0.y, age, normalizedAge));
+		} else {
+			rot = radians(computeParticleRotationFloatY(a_StartRotation0.x, age, normalizedAge));
+		}
+	#else
+		if (renderer_ThreeDStartRotation) {
+			rot = radians(a_StartRotation0.y);
+		} else {
+			rot = radians(a_StartRotation0.x);
+		}
+	#endif
+
 	float c = cos(rot);
 	float s = sin(rot);
 	mat2 rotation = mat2(c, -s, s, c);
-	corner = rotation * corner * cos(0.78539816339744830961566084581988); // TODO:临时缩小cos45,不确定U3D原因
-	corner *= computeParticleSizeBillboard(a_StartSize.xy, normalizedAge);
-	center += renderer_SizeScale.xzy * (corner.x * sideVector + corner.y * cameraUpVector);
+	corner = rotation * corner;
+	center += renderer_SizeScale.xzy * (corner.x * sideVector + corner.y * upVector);
 #endif

--- a/packages/core/src/shaderlib/particle/rotation_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/rotation_over_lifetime_module.glsl
@@ -40,6 +40,41 @@ float computeParticleRotationFloat(in float rotation, in float age, in float nor
     return rotation;
 }
 
+// Y-axis ROL variant for HorizontalBillboard: reads Y data when separateAxes is on, falls back to Z otherwise.
+float computeParticleRotationFloatY(in float rotation, in float age, in float normalizedAge) {
+    #if defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE)
+        #ifdef RENDERER_ROL_CURVE_MODE
+            float currentValue;
+            #ifdef RENDERER_ROL_IS_SEPARATE
+                float lifeRotation = evaluateParticleCurveCumulative(renderer_ROLMaxCurveY, normalizedAge, currentValue);
+                #ifdef RENDERER_ROL_IS_RANDOM_TWO
+                    lifeRotation = mix(evaluateParticleCurveCumulative(renderer_ROLMinCurveY, normalizedAge, currentValue), lifeRotation, a_Random0.w);
+                #endif
+            #else
+                float lifeRotation = evaluateParticleCurveCumulative(renderer_ROLMaxCurveZ, normalizedAge, currentValue);
+                #ifdef RENDERER_ROL_IS_RANDOM_TWO
+                    lifeRotation = mix(evaluateParticleCurveCumulative(renderer_ROLMinCurveZ, normalizedAge, currentValue), lifeRotation, a_Random0.w);
+                #endif
+            #endif
+            rotation += lifeRotation * a_ShapePositionStartLifeTime.w;
+        #else
+            #ifdef RENDERER_ROL_IS_SEPARATE
+                float lifeRotation = renderer_ROLMaxConst.y;
+                #ifdef RENDERER_ROL_IS_RANDOM_TWO
+                    lifeRotation = mix(renderer_ROLMinConst.y, lifeRotation, a_Random0.w);
+                #endif
+            #else
+                float lifeRotation = renderer_ROLMaxConst.z;
+                #ifdef RENDERER_ROL_IS_RANDOM_TWO
+                    lifeRotation = mix(renderer_ROLMinConst.z, lifeRotation, a_Random0.w);
+                #endif
+            #endif
+            rotation += lifeRotation * age;
+        #endif
+    #endif
+    return rotation;
+}
+
 
 #if defined(RENDERER_MODE_MESH) && (defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE))
 vec3 computeParticleRotationVec3(in vec3 rotation, in float age, in float normalizedAge) {

--- a/packages/core/src/shaderlib/particle/rotation_over_lifetime_module.glsl
+++ b/packages/core/src/shaderlib/particle/rotation_over_lifetime_module.glsl
@@ -40,41 +40,6 @@ float computeParticleRotationFloat(in float rotation, in float age, in float nor
     return rotation;
 }
 
-// Y-axis ROL variant for HorizontalBillboard: reads Y data when separateAxes is on, falls back to Z otherwise.
-float computeParticleRotationFloatY(in float rotation, in float age, in float normalizedAge) {
-    #if defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE)
-        #ifdef RENDERER_ROL_CURVE_MODE
-            float currentValue;
-            #ifdef RENDERER_ROL_IS_SEPARATE
-                float lifeRotation = evaluateParticleCurveCumulative(renderer_ROLMaxCurveY, normalizedAge, currentValue);
-                #ifdef RENDERER_ROL_IS_RANDOM_TWO
-                    lifeRotation = mix(evaluateParticleCurveCumulative(renderer_ROLMinCurveY, normalizedAge, currentValue), lifeRotation, a_Random0.w);
-                #endif
-            #else
-                float lifeRotation = evaluateParticleCurveCumulative(renderer_ROLMaxCurveZ, normalizedAge, currentValue);
-                #ifdef RENDERER_ROL_IS_RANDOM_TWO
-                    lifeRotation = mix(evaluateParticleCurveCumulative(renderer_ROLMinCurveZ, normalizedAge, currentValue), lifeRotation, a_Random0.w);
-                #endif
-            #endif
-            rotation += lifeRotation * a_ShapePositionStartLifeTime.w;
-        #else
-            #ifdef RENDERER_ROL_IS_SEPARATE
-                float lifeRotation = renderer_ROLMaxConst.y;
-                #ifdef RENDERER_ROL_IS_RANDOM_TWO
-                    lifeRotation = mix(renderer_ROLMinConst.y, lifeRotation, a_Random0.w);
-                #endif
-            #else
-                float lifeRotation = renderer_ROLMaxConst.z;
-                #ifdef RENDERER_ROL_IS_RANDOM_TWO
-                    lifeRotation = mix(renderer_ROLMinConst.z, lifeRotation, a_Random0.w);
-                #endif
-            #endif
-            rotation += lifeRotation * age;
-        #endif
-    #endif
-    return rotation;
-}
-
 
 #if defined(RENDERER_MODE_MESH) && (defined(RENDERER_ROL_CONSTANT_MODE) || defined(RENDERER_ROL_CURVE_MODE))
 vec3 computeParticleRotationVec3(in vec3 rotation, in float age, in float normalizedAge) {

--- a/tests/src/core/particle/ParticleRenderer.test.ts
+++ b/tests/src/core/particle/ParticleRenderer.test.ts
@@ -49,9 +49,8 @@ describe("ParticleRenderer", () => {
     expect(renderer.renderMode).to.eq(ParticleRenderMode.Billboard);
     renderer.renderMode = ParticleRenderMode.StretchBillboard;
     expect(renderer.renderMode).to.eq(ParticleRenderMode.StretchBillboard);
-    expect(() => {
-      renderer.renderMode = ParticleRenderMode.HorizontalBillboard;
-    }).to.throw("Not implemented");
+    renderer.renderMode = ParticleRenderMode.HorizontalBillboard;
+    expect(renderer.renderMode).to.eq(ParticleRenderMode.HorizontalBillboard);
     renderer.renderMode = ParticleRenderMode.Mesh;
     expect(renderer.renderMode).to.eq(ParticleRenderMode.Mesh);
     expect(() => {


### PR DESCRIPTION
## 粒子系统 HorizontalBillboard 渲染模式实现

### 背景

引擎粒子系统的 `ParticleRenderMode` 枚举中定义了 `HorizontalBillboard` 模式，但运行时直接 `throw "Not implemented"`，编辑器也未暴露该选项。本次改动完成了该模式的实现。

### 改动文件

| 文件 | 改动说明 |
|------|----------|
| `packages/core/src/particle/ParticleRenderer.ts` | 移除 `throw "Not implemented"` ，启用 HorizontalBillboard |
| `packages/core/src/shaderlib/particle/horizontal_billboard.glsl` | 重写顶点变换逻辑 |
| `packages/core/src/shaderlib/particle/rotation_over_lifetime_module.glsl` | 新增 `computeParticleRotationFloatY` 函数 |
| `tests/src/core/particle/ParticleRenderer.test.ts` | 将 `expect throw` 断言改为正常赋值验证 |

### 核心设计

**horizontal_billboard.glsl**

- 粒子始终平铺在 XZ 平面，朝向固定为 Y 轴向上
- 所有旋转（startRotation / rotationOverLifetime）统一约束为绕 Y 轴的 2D mat2 旋转，不使用 `rotationByEuler`，避免 X/Z 分量把粒子抬出水平面
- 3D startRotation 模式下只取 `.y` 分量，非 3D 模式取单值 `.x`

**computeParticleRotationFloatY**

解决原 `computeParticleRotationFloat` 硬编码读 Z 轴 ROL 数据的问题：

- `separateAxes = true` → 读取 Y 轴曲线/常量（`renderer_ROLMaxCurveY` / `renderer_ROLMaxConst.y`）
- `separateAxes = false` → fallback 到 Z（唯一旋转通道），与非 separate 语义一致

两个分支均调用该函数，确保无论 `startRotation3D` 如何设置，ROL 数据源都与「只绕 Y 轴转」的语义匹配。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled the HorizontalBillboard particle render mode so it no longer causes a runtime failure and can be selected and used.

* **Tests**
  * Updated unit test to confirm HorizontalBillboard can be set without error.
  * Added an end-to-end test validating horizontal-billboard particle rendering and added the corresponding E2E configuration entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->