### PR TITLE
fix(rhi-webgl): complete sRGB format support for compressed textures

### DIFF
--- a/packages/core/src/2d/atlas/FontAtlas.ts
+++ b/packages/core/src/2d/atlas/FontAtlas.ts
@@ -21,7 +21,7 @@ export class FontAtlas extends ReferResource {
     super(engine);
     this.isGCIgnored = true;
     const format = engine._hardwareRenderer.isWebGL2 ? TextureFormat.R8 : TextureFormat.Alpha8;
-    const texture = new Texture2D(engine, 512, 512, format, false);
+    const texture = new Texture2D(engine, 512, 512, format, false, false);
     texture.filterMode = TextureFilterMode.Bilinear;
     texture.isGCIgnored = true;
     this.texture = texture;

--- a/packages/core/src/texture/TextureUtils.ts
+++ b/packages/core/src/texture/TextureUtils.ts
@@ -43,6 +43,12 @@ export class TextureUtils {
       case TextureFormat.ETC2_RGB:
       case TextureFormat.ETC2_RGBA8:
       case TextureFormat.ASTC_4x4:
+      case TextureFormat.ASTC_5x5:
+      case TextureFormat.ASTC_6x6:
+      case TextureFormat.ASTC_8x8:
+      case TextureFormat.ASTC_10x10:
+      case TextureFormat.ASTC_12x12:
+      case TextureFormat.ETC2_RGBA5:
         return true;
       default:
         return false;

--- a/packages/rhi-webgl/src/GLTexture.ts
+++ b/packages/rhi-webgl/src/GLTexture.ts
@@ -181,7 +181,9 @@ export class GLTexture implements IPlatformTexture {
         };
       case TextureFormat.ETC2_RGBA5:
         return {
-          internalFormat: GLCompressedTextureInternalFormat.RGB8_PUNCHTHROUGH_ALPHA1_ETC2,
+          internalFormat: isSRGBColorSpace
+            ? GLCompressedTextureInternalFormat.SRGB8_PUNCHTHROUGH_ALPHA1_ETC2
+            : GLCompressedTextureInternalFormat.RGB8_PUNCHTHROUGH_ALPHA1_ETC2,
           isCompressed: true
         };
       case TextureFormat.ETC2_RGBA8:
@@ -220,27 +222,37 @@ export class GLTexture implements IPlatformTexture {
         };
       case TextureFormat.ASTC_5x5:
         return {
-          internalFormat: GLCompressedTextureInternalFormat.RGBA_ASTC_5X5_KHR,
+          internalFormat: isSRGBColorSpace
+            ? GLCompressedTextureInternalFormat.SRGB8_ALPHA8_ASTC_5X5_KHR
+            : GLCompressedTextureInternalFormat.RGBA_ASTC_5X5_KHR,
           isCompressed: true
         };
       case TextureFormat.ASTC_6x6:
         return {
-          internalFormat: GLCompressedTextureInternalFormat.RGBA_ASTC_6X6_KHR,
+          internalFormat: isSRGBColorSpace
+            ? GLCompressedTextureInternalFormat.SRGB8_ALPHA8_ASTC_6X6_KHR
+            : GLCompressedTextureInternalFormat.RGBA_ASTC_6X6_KHR,
           isCompressed: true
         };
       case TextureFormat.ASTC_8x8:
         return {
-          internalFormat: GLCompressedTextureInternalFormat.RGBA_ASTC_8X8_KHR,
+          internalFormat: isSRGBColorSpace
+            ? GLCompressedTextureInternalFormat.SRGB8_ALPHA8_ASTC_8X8_KHR
+            : GLCompressedTextureInternalFormat.RGBA_ASTC_8X8_KHR,
           isCompressed: true
         };
       case TextureFormat.ASTC_10x10:
         return {
-          internalFormat: GLCompressedTextureInternalFormat.RGBA_ASTC_10X10_KHR,
+          internalFormat: isSRGBColorSpace
+            ? GLCompressedTextureInternalFormat.SRGB8_ALPHA8_ASTC_10X10_KHR
+            : GLCompressedTextureInternalFormat.RGBA_ASTC_10X10_KHR,
           isCompressed: true
         };
       case TextureFormat.ASTC_12x12:
         return {
-          internalFormat: GLCompressedTextureInternalFormat.RGBA_ASTC_12X12_KHR,
+          internalFormat: isSRGBColorSpace
+            ? GLCompressedTextureInternalFormat.SRGB8_ALPHA8_ASTC_12X12_KHR
+            : GLCompressedTextureInternalFormat.RGBA_ASTC_12X12_KHR,
           isCompressed: true
         };
 


### PR DESCRIPTION
   - 修复 FontAtlas 使用 R8 格式时误触 sRGB 警告的问题，显式传入 
  isSRGBColorSpace = false（R8 为灰度数据，WebGL2 无 SR8          
  内部格式）                         
  - 补全 supportSRGB 和 _getFormatDetail 中遗漏的 sRGB            
  压缩纹理格式：ASTC_5x5、ASTC_6x6、ASTC_8x8、ASTC_10x10、ASTC_12x
  12、ETC2_RGBA5                                                  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added sRGB color space support for ASTC (5x5, 6x6, 8x8, 10x10, 12x12) and ETC2_RGBA5 compressed texture formats for enhanced graphics quality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->