### PR TITLE
fix: use deepClone for Skin._skinMatrices to prevent undefined after clone

### DIFF
--- a/packages/core/src/mesh/Skin.ts
+++ b/packages/core/src/mesh/Skin.ts
@@ -15,7 +15,7 @@ export class Skin extends EngineObject {
   inverseBindMatrices = new Array<Matrix>();
 
   /** @internal */
-  @ignoreClone
+  @deepClone
   _skinMatrices: Float32Array;
   /** @internal */
   @ignoreClone


### PR DESCRIPTION
## Summary
- Change `@ignoreClone` to `@deepClone` for `Skin._skinMatrices` property
- This ensures cloned Skin objects have their own `Float32Array` for skin matrices instead of `undefined`

## Problem
When cloning a Skin object, `_skinMatrices` was decorated with `@ignoreClone`. According to the clone logic in `CloneManager.cloneProperty()`, when `CloneMode.Ignore` is set, the property is skipped entirely during cloning. This results in the cloned Skin object having `_skinMatrices` as `undefined`, which causes rendering issues when the cloned SkinnedMeshRenderer tries to update skin matrices.

## Solution
Use `@deepClone` instead to create a deep copy of the `Float32Array`, ensuring each cloned Skin instance has its own properly initialized skin matrices array.

## Test plan
- [ ] Verify Skin cloning creates independent `_skinMatrices`
- [ ] Verify cloned SkinnedMeshRenderer renders correctly
- [ ] Run existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)