### PR TITLE
fix(loader): always create GLTF_ROOT container for consistent animation paths

### DIFF
--- a/e2e/case/animator-blendShape.ts
+++ b/e2e/case/animator-blendShape.ts
@@ -38,7 +38,7 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
       const { defaultSceneRoot } = asset;
       rootEntity.addChild(defaultSceneRoot);
       const animator = defaultSceneRoot.getComponent(Animator);
-      const skinMeshRenderer = defaultSceneRoot.getComponent(SkinnedMeshRenderer);
+      const skinMeshRenderer = defaultSceneRoot.getComponentsIncludeChildren(SkinnedMeshRenderer, [])[0];
       skinMeshRenderer.blendShapeWeights[0] = 1.0;
       animator.play("TheWave");
 

--- a/e2e/case/animator-multiSubMeshBlendShape.ts
+++ b/e2e/case/animator-multiSubMeshBlendShape.ts
@@ -45,8 +45,8 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
     .then((asset) => {
       const { defaultSceneRoot } = asset;
       rootEntity.addChild(defaultSceneRoot);
-      const entity = defaultSceneRoot;
-      defaultSceneRoot.transform.rotation = new Vector3(-90, -0, 0);
+      const entity = defaultSceneRoot.children[0];
+      entity.transform.rotation = new Vector3(-90, -0, 0);
       const animator = entity.addComponent(Animator);
 
       animator.animatorController = new AnimatorController(engine);

--- a/packages/loader/src/gltf/parser/GLTFSceneParser.ts
+++ b/packages/loader/src/gltf/parser/GLTFSceneParser.ts
@@ -31,16 +31,11 @@ export class GLTFSceneParser extends GLTFParser {
     const sceneNodes = sceneInfo.nodes || [];
     let sceneRoot: Entity;
 
-    if (sceneNodes.length === 1) {
-      sceneRoot = context.get<Entity>(GLTFParserType.Entity, sceneNodes[0]);
-    } else {
-      sceneRoot = new Entity(engine, "GLTF_ROOT");
-      // @ts-ignore
-      sceneRoot._markAsTemplate(glTFResource);
-      for (let i = 0; i < sceneNodes.length; i++) {
-        const childEntity = context.get<Entity>(GLTFParserType.Entity, sceneNodes[i]);
-        sceneRoot.addChild(childEntity);
-      }
+    sceneRoot = new Entity(engine, "GLTF_ROOT");
+    // @ts-ignore
+    sceneRoot._markAsTemplate(glTFResource);
+    for (let i = 0; i < sceneNodes.length; i++) {
+      sceneRoot.addChild(context.get<Entity>(GLTFParserType.Entity, sceneNodes[i]));
     }
 
     if (isDefaultScene) {

--- a/tests/src/core/Animator.test.ts
+++ b/tests/src/core/Animator.test.ts
@@ -307,7 +307,7 @@ describe("Animator test", function () {
     const additiveLayer = new AnimatorControllerLayer("additiveLayer");
     additiveLayer.stateMachine = animatorStateMachine;
     const mask = AnimatorLayerMask.createByEntity(animator.entity);
-    mask.setPathMaskActive("_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04", false, true);
+    mask.setPathMaskActive("root/_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04", false, true);
     additiveLayer.mask = mask;
     additiveLayer.blendingMode = AnimatorLayerBlendingMode.Additive;
     animatorController.addLayer(additiveLayer);
@@ -319,12 +319,12 @@ describe("Animator test", function () {
     animator.play("Walk", 0);
     animator.play("Run", 1);
 
-    const parentEntity = animator.entity.findByPath("_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/");
+    const parentEntity = animator.entity.findByPath("root/_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/");
     const targetEntity = animator.entity.findByPath(
-      "_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04"
+      "root/_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04"
     );
     const childEntity = animator.entity.findByPath(
-      "_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04/b_Head_05"
+      "root/_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04/b_Head_05"
     );
 
     let layerData = animator["_animatorLayersData"][1];
@@ -338,7 +338,7 @@ describe("Animator test", function () {
     expect(childLayerCurveOwner.isActive).to.eq(false);
 
     animator.animatorController.removeLayer(1);
-    mask.removePathMask("_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04/b_Head_05");
+    mask.removePathMask("root/_rootJoint/b_Root_00/b_Hip_01/b_Spine01_02/b_Spine02_03/b_Neck_04/b_Head_05");
     animator.animatorController.addLayer(additiveLayer);
     animator.play("Run", 1);
     layerData = animator["_animatorLayersData"][1];

--- a/tests/src/loader/GLTFLoader.test.ts
+++ b/tests/src/loader/GLTFLoader.test.ts
@@ -517,6 +517,21 @@ describe("glTF instance test", function () {
   });
 });
 
+describe("glTF scene root structure", function () {
+  it("Single root scene should have GLTF_ROOT container", async () => {
+    const glTFResource: GLTFResource = await engine.resourceManager.load({
+      type: AssetType.GLTF,
+      url: "mock/path/testRoot.gltf"
+    });
+    const { defaultSceneRoot } = glTFResource;
+
+    // Should always create GLTF_ROOT container, even for single-root scenes
+    expect(defaultSceneRoot.name).to.equal("GLTF_ROOT");
+    expect(defaultSceneRoot.children.length).to.equal(1);
+    expect(defaultSceneRoot.children[0].name).to.equal("entity1");
+  });
+});
+
 describe("glTF instance test", function () {
   it("GLTFResource destroy directly", async () => {
     const glTFResource: GLTFResource = await engine.resourceManager.load({


### PR DESCRIPTION
## Summary

Fixes #2942

- Remove single-root vs multi-root branching in `GLTFSceneParser`, always creating a `GLTF_ROOT` wrapper entity
- Ensures animation bone paths are consistent across different glTF files, fixing cross-file animation clip retargeting
- Matches the behavior of Three.js (wrapper Group), Babylon.js (\_\_root\_\_ node), and Cocos Creator

## Breaking Change

Single-root glTF files now have one extra nesting level (`GLTF_ROOT` → original root). Code that references entities by path or index from `instantiateSceneRoot()` may need adjustment.

## Test plan

- [x] Added test verifying single-root scene creates `GLTF_ROOT` container
- [x] Updated Animator layer mask test paths for new nesting level
- [x] Full test suite passes (1057 passed, 0 failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consistently create a standard GLTF_ROOT container as the scene root to unify hierarchy structure.

* **Tests**
  * Added a test validating single-root glTF scene structure.
  * Updated animator unit tests to match restructured entity paths.
  * Adjusted end-to-end cases to locate renderers differently and apply initial transforms to child nodes where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->