### PR TITLE
Fix some shaderlab bug

### DIFF
--- a/packages/shader-lab/src/parser/builtin/functions.ts
+++ b/packages/shader-lab/src/parser/builtin/functions.ts
@@ -29,23 +29,18 @@ function isGenericType(t: BuiltinType) {
 /**
  * Resolve a generic return type from the actual type of a generic parameter.
  *
- * Same-family generics (GenType→GenType, GenIntType→GenIntType) pass through directly.
- * Cross-family generics (GSampler→GVec4) require a mapping:
+ * For GVec4 return type, maps sampler variants to the correct vec4 type:
  *   sampler2D/sampler3D/samplerCube → vec4
  *   isampler2D/isampler3D/...       → ivec4
  *   usampler2D/usampler3D/...       → uvec4
+ *
+ * For all other generic return types (GenType etc.), passes through the actual param type directly.
  */
 function resolveGenericReturnType(
   genericReturnType: EGenType,
-  genericParamType: EGenType,
   actualParamType: NonGenericGalaceanType
 ): NonGenericGalaceanType {
-  // Cross-family: GSampler* → GVec4
-  if (
-    genericParamType >= EGenType.GSampler2D &&
-    genericParamType <= EGenType.GSampler2DArray &&
-    genericReturnType === EGenType.GVec4
-  ) {
+  if (genericReturnType === EGenType.GVec4) {
     switch (actualParamType) {
       case Keyword.I_SAMPLER2D:
       case Keyword.I_SAMPLER3D:
@@ -61,8 +56,6 @@ function resolveGenericReturnType(
         return Keyword.VEC4;
     }
   }
-
-  // Same-family: GenType→GenType etc. — pass through directly
   return actualParamType;
 }
 
@@ -124,11 +117,7 @@ export class BuiltinFunction {
           const curFnArg = fnArgs[i];
           if (isGenericType(curFnArg)) {
             if (resolvedReturnType === TypeAny) {
-              resolvedReturnType = resolveGenericReturnType(
-                fn._returnType as EGenType,
-                curFnArg as EGenType,
-                parameterTypes[i]
-              );
+              resolvedReturnType = resolveGenericReturnType(fn._returnType as EGenType, parameterTypes[i]);
             }
           } else {
             if (curFnArg !== parameterTypes[i] && parameterTypes[i] !== TypeAny) {
@@ -349,6 +338,7 @@ BuiltinFunction._create("textureLod", EGenType.GVec4, EGenType.GSampler3D, Keywo
 BuiltinFunction._create("textureLod", EGenType.GVec4, EGenType.GSamplerCube, Keyword.VEC3, Keyword.FLOAT);
 BuiltinFunction._create("textureLod", Keyword.FLOAT, Keyword.SAMPLER2D_SHADOW, Keyword.VEC3, Keyword.FLOAT);
 BuiltinFunction._create("textureLod", EGenType.GVec4, EGenType.GSampler2DArray, Keyword.VEC3, Keyword.FLOAT);
+BuiltinFunction._create("texture2DLod", Keyword.VEC4, Keyword.SAMPLER2D, Keyword.VEC2, Keyword.FLOAT);
 BuiltinFunction._create("texture2DLodEXT", EGenType.GVec4, EGenType.GSampler2D, Keyword.VEC2, Keyword.FLOAT);
 BuiltinFunction._create("texture2DLodEXT", EGenType.GVec4, EGenType.GSampler3D, Keyword.VEC3, Keyword.FLOAT);
 

--- a/packages/shader-lab/src/parser/builtin/functions.ts
+++ b/packages/shader-lab/src/parser/builtin/functions.ts
@@ -26,6 +26,46 @@ function isGenericType(t: BuiltinType) {
   return t >= EGenType.GenType && t <= EGenType.GSampler2DArray;
 }
 
+/**
+ * Resolve a generic return type from the actual type of a generic parameter.
+ *
+ * Same-family generics (GenType→GenType, GenIntType→GenIntType) pass through directly.
+ * Cross-family generics (GSampler→GVec4) require a mapping:
+ *   sampler2D/sampler3D/samplerCube → vec4
+ *   isampler2D/isampler3D/...       → ivec4
+ *   usampler2D/usampler3D/...       → uvec4
+ */
+function resolveGenericReturnType(
+  genericReturnType: EGenType,
+  genericParamType: EGenType,
+  actualParamType: NonGenericGalaceanType
+): NonGenericGalaceanType {
+  // Cross-family: GSampler* → GVec4
+  if (
+    genericParamType >= EGenType.GSampler2D &&
+    genericParamType <= EGenType.GSampler2DArray &&
+    genericReturnType === EGenType.GVec4
+  ) {
+    switch (actualParamType) {
+      case Keyword.I_SAMPLER2D:
+      case Keyword.I_SAMPLER3D:
+      case Keyword.I_SAMPLER_CUBE:
+      case Keyword.I_SAMPLER2D_ARRAY:
+        return Keyword.IVEC4;
+      case Keyword.U_SAMPLER2D:
+      case Keyword.U_SAMPLER3D:
+      case Keyword.U_SAMPLER_CUBE:
+      case Keyword.U_SAMPLER2D_ARRAY:
+        return Keyword.UVEC4;
+      default:
+        return Keyword.VEC4;
+    }
+  }
+
+  // Same-family: GenType→GenType etc. — pass through directly
+  return actualParamType;
+}
+
 const BuiltinFunctionTable: Map<string, BuiltinFunction[]> = new Map();
 
 export class BuiltinFunction {
@@ -78,12 +118,18 @@ export class BuiltinFunction {
         const argLength = fnArgs.length;
         if (argLength !== parameterTypes.length) continue;
         // Try to match generic parameter type.
-        let returnType = TypeAny;
+        let resolvedReturnType: NonGenericGalaceanType = TypeAny;
         let found = true;
         for (let i = 0; i < argLength; i++) {
           const curFnArg = fnArgs[i];
           if (isGenericType(curFnArg)) {
-            if (returnType === TypeAny) returnType = parameterTypes[i];
+            if (resolvedReturnType === TypeAny) {
+              resolvedReturnType = resolveGenericReturnType(
+                fn._returnType as EGenType,
+                curFnArg as EGenType,
+                parameterTypes[i]
+              );
+            }
           } else {
             if (curFnArg !== parameterTypes[i] && parameterTypes[i] !== TypeAny) {
               found = false;
@@ -92,7 +138,10 @@ export class BuiltinFunction {
           }
         }
         if (found) {
-          fn._realReturnType = returnType;
+          fn._realReturnType =
+            isGenericType(fn._returnType) && resolvedReturnType !== TypeAny
+              ? resolvedReturnType
+              : (fn._returnType as NonGenericGalaceanType);
           return fn;
         }
       }
@@ -303,10 +352,10 @@ BuiltinFunction._create("textureLod", EGenType.GVec4, EGenType.GSampler2DArray, 
 BuiltinFunction._create("texture2DLodEXT", EGenType.GVec4, EGenType.GSampler2D, Keyword.VEC2, Keyword.FLOAT);
 BuiltinFunction._create("texture2DLodEXT", EGenType.GVec4, EGenType.GSampler3D, Keyword.VEC3, Keyword.FLOAT);
 
-BuiltinFunction._create("textureCube", Keyword.SAMPLER_CUBE, Keyword.VEC3);
-BuiltinFunction._create("textureCube", Keyword.SAMPLER_CUBE, Keyword.VEC3, Keyword.FLOAT);
+BuiltinFunction._create("textureCube", Keyword.VEC4, Keyword.SAMPLER_CUBE, Keyword.VEC3);
+BuiltinFunction._create("textureCube", Keyword.VEC4, Keyword.SAMPLER_CUBE, Keyword.VEC3, Keyword.FLOAT);
 BuiltinFunction._create("textureCube", EGenType.GVec4, EGenType.GSamplerCube, Keyword.VEC3, Keyword.FLOAT);
-BuiltinFunction._create("textureCubeLod", Keyword.SAMPLER_CUBE, Keyword.VEC3, Keyword.FLOAT);
+BuiltinFunction._create("textureCubeLod", Keyword.VEC4, Keyword.SAMPLER_CUBE, Keyword.VEC3, Keyword.FLOAT);
 BuiltinFunction._create("textureCubeLodEXT", EGenType.GVec4, EGenType.GSamplerCube, Keyword.VEC3, Keyword.FLOAT);
 
 BuiltinFunction._create(

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -251,4 +251,9 @@ describe("ShaderLab", async () => {
     const shaderSource = await readFile("./shaders/mrt-struct.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);
   });
+
+  it("texture-generic (GVec4 → vec4 resolve)", async () => {
+    const shaderSource = await readFile("./shaders/texture-generic.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+  });
 });

--- a/tests/src/shader-lab/shaders/texture-generic.shader
+++ b/tests/src/shader-lab/shaders/texture-generic.shader
@@ -45,6 +45,16 @@ Shader "texture-generic-test" {
         return color;
       }
 
+      // Test: texture2DLod (ES 1.0 function, concrete types)
+      vec4 sampleLod2D(sampler2D tex, vec2 coord, float lod) {
+        return texture2DLod(tex, coord, lod);
+      }
+
+      // Test: texture2DLod result passed to user function
+      float decodeLod2D(sampler2D tex, vec2 coord) {
+        return decode32(texture2DLod(tex, coord, 0.0));
+      }
+
       // Test: texture() with samplerCube (GVec4 → vec4 resolve via GSamplerCube)
       samplerCube u_cubeMap;
       vec4 sampleCube(samplerCube tex, vec3 dir) {

--- a/tests/src/shader-lab/shaders/texture-generic.shader
+++ b/tests/src/shader-lab/shaders/texture-generic.shader
@@ -1,0 +1,84 @@
+Shader "texture-generic-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec2 uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Test: user-defined function taking vec4, called with texture() return value.
+      // texture(sampler2D, vec2) returns GVec4 which must resolve to vec4.
+      float decode32(vec4 rgba) {
+        rgba = rgba * 255.0;
+        float Sign = 1.0 - step(128.0, rgba[3] + 0.5) * 2.0;
+        float Exponent = 2.0 * mod(float(int(rgba[3] + 0.5)), 128.0) + step(128.0, rgba[2] + 0.5) - 127.0;
+        float Mantissa = mod(float(int(rgba[2] + 0.5)), 128.0) * 65536.0 + rgba[1] * 256.0 + rgba[0] + 8388608.0;
+        return Sign * exp2(Exponent - 23.0) * Mantissa;
+      }
+
+      sampler2D u_texture;
+
+      // Test: texture() result passed to user function (GVec4 → vec4 resolve)
+      mat4 getJointMatrix(float i) {
+        float x = 4.0 * i;
+        vec4 v1 = vec4(
+          decode32(texture(u_texture, vec2((x + 0.5) / 1024.0, 0.5))),
+          decode32(texture(u_texture, vec2((x + 1.5) / 1024.0, 0.5))),
+          decode32(texture(u_texture, vec2((x + 2.5) / 1024.0, 0.5))),
+          decode32(texture(u_texture, vec2((x + 3.5) / 1024.0, 0.5)))
+        );
+        return mat4(v1, v1, v1, vec4(0.0, 0.0, 0.0, 1.0));
+      }
+
+      // Test: texture() result used directly in arithmetic (GVec4 → vec4)
+      vec4 sampleAndScale(sampler2D tex, vec2 coord, float scale) {
+        vec4 color = texture(tex, coord);
+        return color * scale;
+      }
+
+      // Test: textureLod also returns GVec4
+      vec4 sampleLod(sampler2D tex, vec2 coord, float lod) {
+        vec4 color = textureLod(tex, coord, lod);
+        return color;
+      }
+
+      // Test: texture() with samplerCube (GVec4 → vec4 resolve via GSamplerCube)
+      samplerCube u_cubeMap;
+      vec4 sampleCube(samplerCube tex, vec3 dir) {
+        return texture(tex, dir);
+      }
+
+      // Test: textureLod with samplerCube (GVec4 → vec4 resolve via GSamplerCube)
+      vec4 sampleCubeLod(samplerCube tex, vec3 dir, float lod) {
+        return textureLod(tex, dir, lod);
+      }
+
+      // Test: texture(samplerCube) result passed to user function (vec4 param matching)
+      float decodeCube(vec4 rgba) {
+        return rgba.r + rgba.g;
+      }
+      float sampleAndDecode(samplerCube tex, vec3 dir) {
+        return decodeCube(texture(tex, dir));
+      }
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        gl_Position = renderer_MVPMat * attr.POSITION;
+        o.uv = attr.POSITION.xy;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        vec4 sampled = sampleAndScale(u_texture, v.uv, 1.0);
+        vec4 lodSampled = sampleLod(u_texture, v.uv, 0.0);
+        vec4 cubeSampled = sampleCube(u_cubeMap, vec3(v.uv, 1.0));
+        vec4 cubeLodSampled = sampleCubeLod(u_cubeMap, vec3(v.uv, 1.0), 0.0);
+        float decoded = sampleAndDecode(u_cubeMap, vec3(v.uv, 1.0));
+        gl_FragColor = sampled + lodSampled + cubeSampled + cubeLodSampled + vec4(decoded);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

  修复 ShaderLab
  内置纹理采样函数的泛型返回类型推导错误，以及若干函数签名缺失/错误。

  ### 问题

  `texture(sampler2D, vec2)` 等内置函数注册为泛型返回类型 `GVec4`，但
  `getFn()` 在解析泛型返回类型时，错误地将**泛型参数的实际类型**（如
  `sampler2D`）直接作为返回类型，导致：

  ```glsl
  // decode32 签名: float decode32(vec4 rgba)
  // texture() 返回类型被错误 resolve 为 sampler2D 而非 vec4
  decode32(texture(u_texture, uv))  // ❌ No overload function type found:
  decode32
  ```

  同时 `textureCube` / `textureCubeLod` 的返回类型注册为
  `SAMPLER_CUBE`（应为 `VEC4`），`texture2DLod` 缺失注册。

  ### 修复

  **泛型返回类型推导（`functions.ts`）：**
  - 新增 `resolveGenericReturnType()`：当返回类型为 `GVec4` 时，根据实际
  sampler 类型映射为 `vec4` / `ivec4` / `uvec4`
  - 其他泛型（`GenType` 等同族传递）保持原有逻辑

  **函数签名修正：**

  | 函数 | 修复前 | 修复后 |
  |------|--------|--------|
  | `textureCube(samplerCube, vec3)` | 返回 `SAMPLER_CUBE` ❌ | 返回 `VEC4`
  ✅ |
  | `textureCube(samplerCube, vec3, float)` | 返回 `SAMPLER_CUBE` ❌ | 返回
  `VEC4` ✅ |
  | `textureCubeLod(samplerCube, vec3, float)` | 返回 `SAMPLER_CUBE` ❌ |
  返回 `VEC4` ✅ |
  | `texture2DLod(sampler2D, vec2, float)` | 未注册 ❌ | 返回 `VEC4` ✅ |

  ### 测试

  新增 `tests/src/shader-lab/shaders/texture-generic.shader`，覆盖：
  - `decode32(texture(sampler2D, vec2))` — GVec4 → vec4 传递给用户函数
  - `texture(sampler2D)` 直接算术运算
  - `textureLod(sampler2D)` / `textureLod(samplerCube)` — GVec4 resolve
  - `texture(samplerCube)` — GSamplerCube → vec4
  - `texture2DLod(sampler2D)` — 新增注册验证
  - `texture2DLod` 结果传递给用户函数

  ## Test plan

  - [x] `tests/src/shader-lab/ShaderLab.test.ts` — 12 cases 全部通过
  - [x] `texture-generic.shader` — 纹理采样泛型 resolve + WebGL 编译验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader parser's generic return type resolution so texture sampling functions consistently yield correct vec4/ivec4/uvec4 results where appropriate, and updated texture function return behavior for cube/2D variants.
* **Tests**
  * Added a validation test to verify texture function compatibility with the updated generic return resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->