### PR TITLE
fix(core): fix crash when removeChild during deactivation callbacks

### DIFF
--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -693,7 +693,10 @@ export class Entity extends EngineObject {
   private _setActiveComponents(isActive: boolean, activeChangeFlag: ActiveChangeFlag): void {
     const activeChangedComponents = this._activeChangedComponents;
     for (let i = 0, length = activeChangedComponents.length; i < length; ++i) {
-      activeChangedComponents[i]._setActive(isActive, activeChangeFlag);
+      const component = activeChangedComponents[i];
+      // Skip components whose scene was already cleared by an earlier callback's removeChild
+      if (!isActive && !component._entity._scene) continue;
+      component._setActive(isActive, activeChangeFlag);
     }
     this._scene._componentsManager.putActiveChangedTempList(activeChangedComponents);
     this._activeChangedComponents = null;
@@ -715,17 +718,18 @@ export class Entity extends EngineObject {
   }
 
   private _setInActiveInHierarchy(activeChangedComponents: Component[], activeChangeFlag: ActiveChangeFlag): void {
+    // Children-first, reverse traversal for safe removeChild during callbacks
+    const children = this._children;
+    for (let i = children.length - 1; i >= 0; i--) {
+      const child = children[i];
+      child.isActive && child._setInActiveInHierarchy(activeChangedComponents, activeChangeFlag);
+    }
     activeChangeFlag & ActiveChangeFlag.Hierarchy && (this._isActiveInHierarchy = false);
     activeChangeFlag & ActiveChangeFlag.Scene && (this._isActiveInScene = false);
     const components = this._components;
     for (let i = 0, n = components.length; i < n; i++) {
       const component = components[i];
       component.enabled && activeChangedComponents.push(component);
-    }
-    const children = this._children;
-    for (let i = 0, n = children.length; i < n; i++) {
-      const child = children[i];
-      child.isActive && child._setInActiveInHierarchy(activeChangedComponents, activeChangeFlag);
     }
   }
 

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -681,4 +681,194 @@ describe("Entity", async () => {
       expect(script.onDestroy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("removeChild during onDisable", () => {
+    it("should not crash when removing children during parent's onDisable", () => {
+      // Issue #2947: Entity._scene is null in _onDisableInScene when child removed during parent's onDisable
+      //
+      // Entity tree: root → A → [B, C, D]
+      // A has a script that removes all children in onDisable
+      // B, C, D each have Script components
+      // When root.removeChild(A), the two-phase batched approach causes:
+      //   Phase 1: sets A/B/C/D._isActiveInScene = false, collects all components
+      //   Phase 2: fires callbacks — A's onDisable removes B/C/D, clearing their _scene,
+      //            then B/C/D's _onDisableInScene tries to access this.scene._componentsManager → crash
+
+      const root = scene.createRootEntity("root");
+
+      const A = new Entity(engine, "A");
+      root.addChild(A);
+
+      const B = new Entity(engine, "B");
+      const C = new Entity(engine, "C");
+      const D = new Entity(engine, "D");
+      A.addChild(B);
+      A.addChild(C);
+      A.addChild(D);
+
+      // A's script removes all children during onDisable
+      class ParentScript extends Script {
+        onDisable() {
+          const children = [...this.entity.children];
+          for (const child of children) {
+            this.entity.removeChild(child);
+          }
+        }
+      }
+      A.addComponent(ParentScript);
+
+      // B, C, D each have a Script component (triggers _onDisableInScene)
+      B.addComponent(Script);
+      C.addComponent(Script);
+      D.addComponent(Script);
+
+      // This should not throw "Cannot read properties of null (reading '_componentsManager')"
+      expect(() => {
+        root.removeChild(A);
+      }).not.toThrow();
+    });
+
+    it("should not crash when sibling removes another sibling during onDisable", () => {
+      // Entity tree: root → A → [B, C, D]
+      // D's onDisable removes sibling C
+      // With deferred callbacks, D fires first (children-first + reverse), then C's callback
+      // should be skipped since C's _scene was cleared by D's removeChild
+
+      const root = scene.createRootEntity("root");
+
+      const A = new Entity(engine, "A");
+      root.addChild(A);
+
+      const B = new Entity(engine, "B");
+      const C = new Entity(engine, "C");
+      const D = new Entity(engine, "D");
+      A.addChild(B);
+      A.addChild(C);
+      A.addChild(D);
+
+      class SiblingRemoverScript extends Script {
+        onDisable() {
+          // D removes sibling C
+          const parent = this.entity.parent;
+          const c = parent.findByName("C");
+          if (c && c.parent === parent) {
+            parent.removeChild(c);
+          }
+        }
+      }
+      D.addComponent(SiblingRemoverScript);
+
+      B.addComponent(Script);
+      C.addComponent(Script);
+
+      expect(() => {
+        root.removeChild(A);
+      }).not.toThrow();
+    });
+
+    it("should throw when child tries to removeChild its deactivating parent (reentrant)", () => {
+      // Entity tree: root → A → B
+      // B's onDisable tries to remove parent A — triggers reentrant _processInActive which should throw
+
+      const root = scene.createRootEntity("root");
+
+      const A = new Entity(engine, "A");
+      root.addChild(A);
+
+      const B = new Entity(engine, "B");
+      A.addChild(B);
+
+      class ReentrantScript extends Script {
+        onDisable() {
+          root.removeChild(this.entity.parent);
+        }
+      }
+      B.addComponent(ReentrantScript);
+
+      expect(() => {
+        A.isActive = false;
+      }).toThrow();
+    });
+
+    it("should not crash when setting sibling isActive=false during onDisable", () => {
+      // Entity tree: root → A → [B, C]
+      // B's onDisable sets C.isActive = false
+      // C's _isActiveInScene is already false from Phase 1, so _processInActive is skipped
+      // Phase 2 still triggers C's callback normally via _phasedActiveInScene
+
+      const root = scene.createRootEntity("root");
+
+      const A = new Entity(engine, "A");
+      root.addChild(A);
+
+      const B = new Entity(engine, "B");
+      const C = new Entity(engine, "C");
+      A.addChild(B);
+      A.addChild(C);
+
+      let cDisableCount = 0;
+
+      class DeactivateSiblingScript extends Script {
+        onDisable() {
+          C.isActive = false;
+        }
+      }
+      B.addComponent(DeactivateSiblingScript);
+
+      C.addComponent(
+        class extends Script {
+          onDisable() {
+            cDisableCount++;
+          }
+        }
+      );
+
+      root.removeChild(A);
+      // C's onDisable should fire exactly once
+      expect(cDisableCount).eq(1);
+    });
+
+    it("should fire deactivation callbacks in children-first order", () => {
+      // Entity tree: root → A → [B, C]
+      // Deactivation order should be: B, C (children) before A (parent)
+
+      const root = scene.createRootEntity("root");
+
+      const A = new Entity(engine, "A");
+      root.addChild(A);
+
+      const B = new Entity(engine, "B");
+      const C = new Entity(engine, "C");
+      A.addChild(B);
+      A.addChild(C);
+
+      const order: string[] = [];
+
+      A.addComponent(
+        class extends Script {
+          onDisable() {
+            order.push("A");
+          }
+        }
+      );
+      B.addComponent(
+        class extends Script {
+          onDisable() {
+            order.push("B");
+          }
+        }
+      );
+      C.addComponent(
+        class extends Script {
+          onDisable() {
+            order.push("C");
+          }
+        }
+      );
+
+      A.isActive = false;
+      // Children-first + reverse: C, B, then A
+      expect(order).toEqual(["C", "B", "A"]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2947
Follow-up: #2954

- **Children-first deactivation order**: `_setInActiveInHierarchy` now recurses children (reverse traversal) before processing the current node, aligning with Unity's deactivation order. This ensures child callbacks complete before parent callbacks fire
- **Scene guard**: `_setActiveComponents` skips components whose entity's `_scene` was cleared by an earlier callback's `removeChild`, preventing null access crashes in sibling removal scenarios

### Root cause

The two-phase deferred callback mechanism (Phase 1: collect components, Phase 2: fire callbacks) caused a timing issue:
- Phase 1 sets all nodes' `_isActiveInScene = false` upfront
- A callback in Phase 2 calls `removeChild(B)` → `_processInActive` is skipped (flag already false) → but `_traverseSetOwnerScene(B, null)` still runs, clearing `B._scene`
- Phase 2 continues to B's `_onDisableInScene` → `this.scene._componentsManager` → crash (scene is null)

### Known limitation / future improvement

The `_scene` null check and `_phasedActiveInScene` guard handle deferred callback safety at different layers:
- `_scene` check in `_setActiveComponents`: prevents crash from `removeChild` clearing scene
- `_phasedActiveInScene` in `Component._setActive`: prevents duplicate callback dispatch

A unified mechanism (e.g. `_deactivateCallbackPending` flag set during Phase 1, cleared after Phase 2) could replace both checks at the source, providing consistent protection for all cases (`removeChild`, `isActive = false`, etc.) in a single layer. This is deferred for a future PR.

## Test plan

- [x] `removeChild during parent's onDisable` — original crash scenario
- [x] `sibling removes another sibling during onDisable` — scene guard scenario  
- [x] `child tries to removeChild its deactivating parent` — reentrant protection
- [x] `setting sibling isActive=false during onDisable` — no duplicate dispatch
- [x] `deactivation callbacks in children-first order` — order verification (C, B, A)
- [x] Existing `InActiveAndActive` and `Script` lifecycle tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity deactivation safety when removing child entities during callback execution, preventing potential null reference errors in complex entity removal scenarios.

* **Tests**
  * Added comprehensive test coverage for entity removal during deactivation callbacks to ensure stability in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->