### PR TITLE
fix(camera): invViewProjMat should ignore scale like viewMatrix

### DIFF
--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -934,7 +934,15 @@ export class Camera extends Component {
   private _getInvViewProjMat(): Matrix {
     if (this._isInvViewProjDirty.flag) {
       this._isInvViewProjDirty.flag = false;
-      Matrix.multiply(this._entity.transform.worldMatrix, this._getInverseProjectionMatrix(), this._invViewProjMat);
+      const matrix = this._invViewProjMat;
+      if (this._isCustomViewMatrix) {
+        Matrix.invert(this.viewMatrix, matrix);
+      } else {
+        // Ignore scale, consistent with viewMatrix getter
+        const transform = this._entity.transform;
+        Matrix.rotationTranslation(transform.worldRotationQuaternion, transform.worldPosition, matrix);
+      }
+      matrix.multiply(this._getInverseProjectionMatrix());
     }
     return this._invViewProjMat;
   }

--- a/tests/src/core/Camera.test.ts
+++ b/tests/src/core/Camera.test.ts
@@ -245,10 +245,64 @@ describe("camera test", function () {
     expect(Math.abs(ray.direction.z)).not.eq(Infinity);
   });
 
+  it("screenPointToRay should ignore inherited scale from parent entity", () => {
+    // Simulate UICanvas scenario: camera is a child of a scaled parent entity
+    const scene = engine.sceneManager.scenes[0];
+    const parentEntity = scene.createRootEntity("scaledParent");
+    parentEntity.transform.setScale(1.5, 1.5, 1.5);
+    parentEntity.transform.setPosition(100, 200, 0);
+
+    const childEntity = parentEntity.createChild("cameraChild");
+    childEntity.transform.setPosition(0, 0, 500);
+    const scaledCamera = childEntity.addComponent(Camera);
+    scaledCamera.isOrthographic = true;
+    scaledCamera.orthographicSize = 5;
+    scaledCamera.nearClipPlane = 0.1;
+    scaledCamera.farClipPlane = 1000;
+
+    // A camera without inherited scale at the same world position/rotation for comparison
+    const refEntity = scene.createRootEntity("refCamera");
+    refEntity.transform.setWorldPosition(
+      childEntity.transform.worldPosition.x,
+      childEntity.transform.worldPosition.y,
+      childEntity.transform.worldPosition.z
+    );
+    const refCamera = refEntity.addComponent(Camera);
+    refCamera.isOrthographic = true;
+    refCamera.orthographicSize = 5;
+    refCamera.nearClipPlane = 0.1;
+    refCamera.farClipPlane = 1000;
+
+    // Both cameras should produce the same ray for the same screen point
+    const screenPoint = new Vector2(128, 128);
+    const rayScaled = scaledCamera.screenPointToRay(screenPoint, new Ray());
+    const rayRef = refCamera.screenPointToRay(screenPoint, new Ray());
+
+    expect(rayScaled.origin.x).to.be.closeTo(rayRef.origin.x, 0.001);
+    expect(rayScaled.origin.y).to.be.closeTo(rayRef.origin.y, 0.001);
+    expect(rayScaled.direction.x).to.be.closeTo(rayRef.direction.x, 0.001);
+    expect(rayScaled.direction.y).to.be.closeTo(rayRef.direction.y, 0.001);
+    expect(rayScaled.direction.z).to.be.closeTo(rayRef.direction.z, 0.001);
+
+    // Round-trip: worldToViewportPoint -> viewportToWorldPoint should be accurate
+    const worldPoint = new Vector3(105, 210, 0);
+    const viewportPoint = scaledCamera.worldToViewportPoint(worldPoint, new Vector3());
+    const recoveredPoint = scaledCamera.viewportToWorldPoint(viewportPoint, new Vector3());
+    expect(recoveredPoint.x).to.be.closeTo(worldPoint.x, 0.01);
+    expect(recoveredPoint.y).to.be.closeTo(worldPoint.y, 0.01);
+    expect(recoveredPoint.z).to.be.closeTo(worldPoint.z, 0.01);
+
+    // Clean up
+    scaledCamera.destroy();
+    refCamera.destroy();
+    parentEntity.destroy();
+    refEntity.destroy();
+  });
+
   /*
     Attention:
-    Below methods will change the default view of current Camera. 
-    If executed in advance, it will affect the expected results of other test cases, 
+    Below methods will change the default view of current Camera.
+    If executed in advance, it will affect the expected results of other test cases,
     so it should be placed at the end of the test case execution.
   */
   it("projection matrix", () => {


### PR DESCRIPTION
## Summary

- `viewMatrix` getter intentionally ignores the camera entity's world scale (`Matrix.rotationTranslation`), but `_getInvViewProjMat()` was using the full `entity.transform.worldMatrix` which includes inherited scale
- This inconsistency causes `screenPointToRay` to produce incorrect world-space rays when the camera has non-identity world scale (e.g. inherited from a parent UICanvas)
- Typical repro: UICanvas in `ScreenSpaceCamera` mode with camera as a child of the canvas entity — UI click positions are offset from rendered positions, proportional to distance from screen center

## Fix

- For normal (non-custom) viewMatrix: use `Matrix.rotationTranslation` (no scale), consistent with `viewMatrix` getter
- For custom viewMatrix: use `Matrix.invert(this.viewMatrix)` to correctly invert whatever the user provided

Closes #2748

## Test plan

- [ ] Verify UI raycast accuracy with camera as child of UICanvas in ScreenSpaceCamera mode at various screen aspect ratios
- [ ] Verify `screenPointToRay` / `screenToWorldPoint` produce correct results when camera entity has inherited scale
- [ ] Verify no regression for cameras without inherited scale (scale = 1)
- [ ] Verify custom viewMatrix path still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected camera matrix calculations so cameras produce consistent rays and viewport conversions whether using custom view transforms or inherited non-uniform scale—improves rendering accuracy and camera positioning.
* **Tests**
  * Added coverage verifying ray generation and viewport/world conversions remain consistent across scaled and unscaled camera setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->