### PR TITLE
refactor(loader): native v2 scene/prefab format parsing

### DIFF
--- a/packages/loader/src/PrefabLoader.ts
+++ b/packages/loader/src/PrefabLoader.ts
@@ -1,7 +1,7 @@
 import { AssetPromise, AssetType, Loader, LoadItem, resourceLoader, ResourceManager } from "@galacean/engine-core";
 import { PrefabParser } from "./prefab/PrefabParser";
 import { PrefabResource } from "./prefab/PrefabResource";
-import { IHierarchyFile } from "./resource-deserialize";
+import type { GalaceanPrefabFile } from "./scene-format/types";
 
 @resourceLoader(AssetType.Prefab, ["prefab"])
 export class PrefabLoader extends Loader<PrefabResource> {
@@ -11,7 +11,7 @@ export class PrefabLoader extends Loader<PrefabResource> {
     return new AssetPromise((resolve, reject) => {
       resourceManager
         // @ts-ignore
-        ._request<IHierarchyFile>(item.url, {
+        ._request<GalaceanPrefabFile>(item.url, {
           ...item,
           type: "json"
         })

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -11,7 +11,8 @@ import {
   ResourceManager,
   Scene
 } from "@galacean/engine-core";
-import { IScene, ParserContext, ParserType, SceneParser, SpecularMode } from "./resource-deserialize";
+import type { AssetRef } from "./scene-format/types";
+import { IScene, ParserContext, ParserType, ReflectionParser, SceneParser, SpecularMode } from "./resource-deserialize";
 
 @resourceLoader(AssetType.Scene, ["scene"], true)
 class SceneLoader extends Loader<Scene> {
@@ -29,7 +30,7 @@ class SceneLoader extends Loader<Scene> {
           context._setTaskCompleteProgress = setTaskCompleteProgress;
           parser.start();
           return parser.promise.then(() => {
-            const promises = [];
+            const promises: Promise<any>[] = [];
             // parse ambient light
             const ambient = data.scene.ambient;
             if (ambient) {
@@ -39,12 +40,20 @@ class SceneLoader extends Loader<Scene> {
               scene.ambientLight.diffuseIntensity = ambient.diffuseIntensity;
               scene.ambientLight.specularIntensity = ambient.specularIntensity;
               scene.ambientLight.diffuseMode = ambient.diffuseMode;
-              scene.ambientLight.diffuseSolidColor.copyFrom(ambient.diffuseSolidColor);
+              const solidColor = ambient.diffuseSolidColor;
+              if (solidColor) {
+                if (Array.isArray(solidColor)) {
+                  scene.ambientLight.diffuseSolidColor.set(solidColor[0], solidColor[1], solidColor[2], solidColor[3]);
+                } else {
+                  scene.ambientLight.diffuseSolidColor.copyFrom(solidColor);
+                }
+              }
+              scene.ambientLight.specularTextureDecodeRGBM = true;
 
               if (useCustomAmbient && ambient.customAmbientLight) {
                 promises.push(
                   // @ts-ignore
-                  resourceManager.getResourceByRef<any>(ambient.customAmbientLight).then((ambientLight) => {
+                  resourceManager.getResourceByRef<any>(assetRefToEngine(ambient.customAmbientLight)).then((ambientLight) => {
                     scene.ambientLight.specularTexture = ambientLight?.specularTexture;
                   })
                 );
@@ -53,7 +62,7 @@ class SceneLoader extends Loader<Scene> {
               if (ambient.ambientLight && (!useCustomAmbient || useSH)) {
                 promises.push(
                   // @ts-ignore
-                  resourceManager.getResourceByRef<any>(ambient.ambientLight).then((ambientLight) => {
+                  resourceManager.getResourceByRef<any>(assetRefToEngine(ambient.ambientLight)).then((ambientLight) => {
                     if (!useCustomAmbient) {
                       scene.ambientLight.specularTexture = ambientLight?.specularTexture;
                     }
@@ -71,18 +80,23 @@ class SceneLoader extends Loader<Scene> {
             scene.background.mode = background.mode;
 
             switch (scene.background.mode) {
-              case BackgroundMode.SolidColor:
-                scene.background.solidColor.copyFrom(background.color);
+              case BackgroundMode.SolidColor: {
+                const color = background.color;
+                if (Array.isArray(color)) {
+                  scene.background.solidColor.set(color[0], color[1], color[2], color[3]);
+                } else {
+                  scene.background.solidColor.copyFrom(color);
+                }
                 break;
+              }
               case BackgroundMode.Sky:
                 if (background.skyMesh && background.skyMaterial) {
                   // @ts-ignore
-                  const skyMeshPromise = resourceManager.getResourceByRef<Mesh>(background.skyMesh).then((mesh) => {
+                  const skyMeshPromise = resourceManager.getResourceByRef<Mesh>(assetRefToEngine(background.skyMesh)).then((mesh) => {
                     scene.background.sky.mesh = mesh;
                   });
                   // @ts-ignore
-                  // prettier-ignore
-                  const skyMaterialPromise = resourceManager.getResourceByRef<Material>(background.skyMaterial).then((material) => {
+                  const skyMaterialPromise = resourceManager.getResourceByRef(assetRefToEngine(background.skyMaterial)).then((material) => {
                     scene.background.sky.material = material;
                   });
                   promises.push(skyMeshPromise, skyMaterialPromise);
@@ -93,8 +107,7 @@ class SceneLoader extends Loader<Scene> {
               case BackgroundMode.Texture:
                 if (background.texture) {
                   // @ts-ignore
-                  // prettier-ignore
-                  const backgroundPromise = resourceManager.getResourceByRef<any>(background.texture).then((texture) => {
+                  const backgroundPromise = resourceManager.getResourceByRef<any>(assetRefToEngine(background.texture)).then((texture) => {
                     scene.background.texture = texture;
                   });
                   promises.push(backgroundPromise);
@@ -125,11 +138,17 @@ class SceneLoader extends Loader<Scene> {
               if (fog.fogStart != undefined) scene.fogStart = fog.fogStart;
               if (fog.fogEnd != undefined) scene.fogEnd = fog.fogEnd;
               if (fog.fogDensity != undefined) scene.fogDensity = fog.fogDensity;
-              if (fog.fogColor != undefined) scene.fogColor.copyFrom(fog.fogColor);
+              if (fog.fogColor != undefined) {
+                if (Array.isArray(fog.fogColor)) {
+                  scene.fogColor.set(fog.fogColor[0], fog.fogColor[1], fog.fogColor[2], fog.fogColor[3]);
+                } else {
+                  scene.fogColor.copyFrom(fog.fogColor);
+                }
+              }
             }
 
             // Post Process
-            const postProcessData = data.scene.postProcess;
+            const postProcessData = (data.scene as any).postProcess;
             if (postProcessData) {
               Logger.warn(
                 "Post Process is not supported in scene yet, please add PostProcess component in entity instead."
@@ -159,3 +178,17 @@ class SceneLoader extends Loader<Scene> {
     });
   }
 }
+
+/** Convert v2 AssetRef { $ref } → engine format { refId } for getResourceByRef. */
+function assetRefToEngine(ref: AssetRef): { refId: string; key?: string } {
+  return ref.key ? { refId: ref.$ref, key: ref.key } : { refId: ref.$ref };
+}
+
+ReflectionParser.registerCustomParseComponent("TextRenderer", async (instance: any, item: { props?: Record<string, unknown> }) => {
+  const { props } = item;
+  if (!props?.font) {
+    // @ts-ignore
+    instance.font = Font.createFromOS(instance.engine, (props?.fontFamily as string) || "Arial");
+  }
+  return instance;
+});

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -3,6 +3,7 @@ import {
   AssetType,
   BackgroundMode,
   DiffuseMode,
+  Font,
   Loader,
   LoadItem,
   Logger,
@@ -11,7 +12,7 @@ import {
   ResourceManager,
   Scene
 } from "@galacean/engine-core";
-import type { AssetRef } from "./scene-format/types";
+import { assetRefToEngine } from "./scene-format/types";
 import { IScene, ParserContext, ParserType, ReflectionParser, SceneParser, SpecularMode } from "./resource-deserialize";
 
 @resourceLoader(AssetType.Scene, ["scene"], true)
@@ -177,11 +178,6 @@ class SceneLoader extends Loader<Scene> {
         .catch(reject);
     });
   }
-}
-
-/** Convert v2 AssetRef { $ref } → engine format { refId } for getResourceByRef. */
-function assetRefToEngine(ref: AssetRef): { refId: string; key?: string } {
-  return ref.key ? { refId: ref.$ref, key: ref.key } : { refId: ref.$ref };
 }
 
 ReflectionParser.registerCustomParseComponent("TextRenderer", async (instance: any, item: { props?: Record<string, unknown> }) => {

--- a/packages/loader/src/prefab/PrefabParser.ts
+++ b/packages/loader/src/prefab/PrefabParser.ts
@@ -1,10 +1,11 @@
 import { Engine, Entity } from "@galacean/engine-core";
-import { IEntity, IHierarchyFile, ParserContext, ParserType } from "../resource-deserialize";
+import type { GalaceanEntitySchema, GalaceanPrefabFile, IHierarchyFile } from "../scene-format/types";
 import { HierarchyParser } from "../resource-deserialize/resources/parser/HierarchyParser";
+import { ParserContext, ParserType } from "../resource-deserialize/resources/parser/ParserContext";
 import { PrefabResource } from "./PrefabResource";
 
 export class PrefabParser extends HierarchyParser<PrefabResource, ParserContext<IHierarchyFile, Entity>> {
-  static parse(engine: Engine, url: string, data: IHierarchyFile): Promise<PrefabResource> {
+  static parse(engine: Engine, url: string, data: GalaceanPrefabFile): Promise<PrefabResource> {
     const prefabResource = new PrefabResource(engine, url);
     const context = new ParserContext<IHierarchyFile, Entity>(engine, ParserType.Prefab, prefabResource);
     const parser = new PrefabParser(data, context, prefabResource);
@@ -20,15 +21,19 @@ export class PrefabParser extends HierarchyParser<PrefabResource, ParserContext<
     super(data, context);
   }
 
-  protected override _applyEntityData(entity: Entity, entityConfig: IEntity = {}): Entity {
+  protected override _applyEntityData(entity: Entity, entityConfig: GalaceanEntitySchema): Entity {
     super._applyEntityData(entity, entityConfig);
     // @ts-ignore
     entity._markAsTemplate(this.context.resource);
     return entity;
   }
 
-  protected override _handleRootEntity(id: string): void {
-    this.prefabResource._root = this.context.entityMap.get(id);
+  protected override _getRootIndices(): number[] {
+    return [(this.data as GalaceanPrefabFile).root];
+  }
+
+  protected override _handleRootEntity(index: number): void {
+    this.prefabResource._root = this.context.entityMap.get(index);
   }
 
   protected override _clearAndResolve(): PrefabResource {

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -1,11 +1,12 @@
 import { Component, Engine, Entity, Loader, Scene } from "@galacean/engine-core";
 import { GLTFResource } from "../../../gltf";
 import { PrefabResource } from "../../../prefab/PrefabResource";
-import type {
-  GalaceanEntityOverrideProps,
-  GalaceanEntitySchema,
-  GalaceanInlineEntitySchema,
-  IHierarchyFile
+import {
+  assetRefToEngine,
+  type GalaceanEntityOverrideProps,
+  type GalaceanEntitySchema,
+  type GalaceanInlineEntitySchema,
+  type IHierarchyFile
 } from "../../../scene-format/types";
 import { ParserContext, type PrefabInstanceContext } from "./ParserContext";
 import { ReflectionParser } from "./ReflectionParser";
@@ -20,14 +21,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   protected _reflectionParser: ReflectionParser;
 
   private _prefabContextMap = new WeakMap<Entity, PrefabInstanceContext>();
-
-  private _prefabPromiseMap = new Map<
-    number,
-    {
-      resolve: (context: PrefabInstanceContext) => void;
-      reject: (reason: any) => void;
-    }[]
-  >();
 
   constructor(
     public readonly data: IHierarchyFile,
@@ -89,7 +82,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
       if (entityConfig.instance) {
         promises.push(
-          this._loadPrefabInstance(i, entityConfig, engine).then((entity) => {
+          this._loadPrefabInstance(entityConfig, engine).then((entity) => {
             entityMap.set(i, entity);
           })
         );
@@ -279,18 +272,13 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // Prefab instance loading
   // ---------------------------------------------------------------------------
 
-  private _loadPrefabInstance(
-    entityIndex: number,
-    entityConfig: GalaceanEntitySchema,
-    engine: Engine
-  ): Promise<Entity> {
+  private _loadPrefabInstance(entityConfig: GalaceanEntitySchema, engine: Engine): Promise<Entity> {
     const instance = entityConfig.instance;
-    const $ref = instance.asset.$ref;
 
     return (
       engine.resourceManager
         // @ts-ignore
-        .getResourceByRef<Entity>({ refId: $ref })
+        .getResourceByRef<Entity>(assetRefToEngine(instance.asset))
         .then((prefabResource: PrefabResource | GLTFResource) => {
           const entity =
             prefabResource instanceof PrefabResource
@@ -301,15 +289,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
           const instanceContext = HierarchyParser._buildInstanceContext(entity);
           this._prefabContextMap.set(entity, instanceContext);
-
-          // Notify any pending override resolution
-          const cbArray = this._prefabPromiseMap.get(entityIndex);
-          if (cbArray) {
-            for (let j = 0, m = cbArray.length; j < m; j++) {
-              cbArray[j].resolve(instanceContext);
-            }
-            this._prefabPromiseMap.delete(entityIndex);
-          }
 
           return entity;
         })

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -1,15 +1,17 @@
-import { Component, Engine, Entity, Loader, Scene, Transform } from "@galacean/engine-core";
+import { Component, Engine, Entity, Loader, Scene } from "@galacean/engine-core";
 import { GLTFResource } from "../../../gltf";
 import { PrefabResource } from "../../../prefab/PrefabResource";
-import type { IEntity, IHierarchyFile, IRefEntity, IStrippedEntity } from "../schema";
-import { ParserContext, ParserType } from "./ParserContext";
+import type {
+  GalaceanEntityOverrideProps,
+  GalaceanEntitySchema,
+  GalaceanInlineEntitySchema,
+  IHierarchyFile
+} from "../../../scene-format/types";
+import { ParserContext, type PrefabInstanceContext } from "./ParserContext";
 import { ReflectionParser } from "./ReflectionParser";
 
 /** @Internal */
 export abstract class HierarchyParser<T extends Scene | PrefabResource, V extends ParserContext<IHierarchyFile, T>> {
-  /**
-   * The promise of parsed object.
-   */
   readonly promise: Promise<T>;
 
   protected _resolve: (item: T) => void;
@@ -17,12 +19,12 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   protected _engine: Engine;
   protected _reflectionParser: ReflectionParser;
 
-  private _prefabContextMap = new WeakMap<Entity, ParserContext<IHierarchyFile, Entity>>();
+  private _prefabContextMap = new WeakMap<Entity, PrefabInstanceContext>();
 
   private _prefabPromiseMap = new Map<
-    string,
+    number,
     {
-      resolve: (context: ParserContext<IHierarchyFile, Entity>) => void;
+      resolve: (context: PrefabInstanceContext) => void;
       reject: (reason: any) => void;
     }[]
   >();
@@ -34,11 +36,8 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     this._engine = this.context.engine;
     this._organizeEntities = this._organizeEntities.bind(this);
     this._parseComponents = this._parseComponents.bind(this);
-    this._parsePrefabModification = this._parsePrefabModification.bind(this);
-    this._parseAddedComponents = this._parseAddedComponents.bind(this);
-    this._parseComponentsPropsAndMethods = this._parseComponentsPropsAndMethods.bind(this);
-    this._parsePrefabRemovedEntities = this._parsePrefabRemovedEntities.bind(this);
-    this._parsePrefabRemovedComponents = this._parsePrefabRemovedComponents.bind(this);
+    this._parseComponentsProps = this._parseComponentsProps.bind(this);
+    this._parsePrefabOverrides = this._parsePrefabOverrides.bind(this);
     this._clearAndResolve = this._clearAndResolve.bind(this);
     this.promise = new Promise<T>((resolve, reject) => {
       this._reject = reject;
@@ -47,320 +46,355 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     this._reflectionParser = new ReflectionParser(context);
   }
 
-  /** start parse the scene or prefab or others */
   public start() {
     this._parseEntities()
       .then(this._organizeEntities)
       .then(this._parseComponents)
-      .then(this._parseAddedComponents)
-      .then(this._parseComponentsPropsAndMethods)
-      .then(this._parsePrefabModification)
-      .then(this._parsePrefabRemovedEntities)
-      .then(this._parsePrefabRemovedComponents)
+      .then(this._parseComponentsProps)
+      .then(this._parsePrefabOverrides)
       .then(this._clearAndResolve)
       .then(this._resolve)
       .catch(this._reject);
   }
 
-  protected _applyEntityData(entity: Entity, entityConfig: IEntity = {}): Entity {
+  /** Root entity indices for this hierarchy (scene.entities or [prefab.root]). */
+  protected abstract _getRootIndices(): number[];
+  protected abstract _handleRootEntity(index: number): void;
+  protected abstract _clearAndResolve(): Scene | PrefabResource;
+
+  protected _applyEntityData(entity: Entity, entityConfig: GalaceanEntitySchema): Entity {
     entity.isActive = entityConfig.isActive ?? entity.isActive;
     entity.name = entityConfig.name ?? entity.name;
     const transform = entity.transform;
-    const transformConfig = entityConfig.transform;
-    if (transformConfig) {
-      this._reflectionParser.parsePropsAndMethods(transform, transformConfig);
-    } else {
-      const { position, rotation, scale } = entityConfig;
-      if (position) transform.position.copyFrom(position);
-      if (rotation) transform.rotation.copyFrom(rotation);
-      if (scale) transform.scale.copyFrom(scale);
-    }
-    if (entityConfig.layer) entity.layer = entityConfig.layer;
+    const { position, rotation, scale } = entityConfig;
+    if (position) transform.position.set(position[0], position[1], position[2]);
+    if (rotation) transform.rotation.set(rotation[0], rotation[1], rotation[2]);
+    if (scale) transform.scale.set(scale[0], scale[1], scale[2]);
+    if (entityConfig.layer != null) entity.layer = entityConfig.layer;
     return entity;
   }
 
-  protected abstract _handleRootEntity(id: string): void;
-  protected abstract _clearAndResolve(): Scene | PrefabResource;
+  // ---------------------------------------------------------------------------
+  // Stage 1: Create entity instances
+  // ---------------------------------------------------------------------------
 
-  private _parseEntities(): Promise<Entity[]> {
-    const entitiesConfig = this.data.entities;
-    const entityConfigMap = this.context.entityConfigMap;
+  private _parseEntities(): Promise<void> {
+    const entities = this.data.entities;
     const entityMap = this.context.entityMap;
     const engine = this._engine;
-    const promises = entitiesConfig.map((entityConfig) => {
-      const id = (entityConfig as IStrippedEntity).strippedId ?? entityConfig.id;
-      entityConfig.id = id;
-      entityConfigMap.set(id, entityConfig);
-      return this._getEntityByConfig(entityConfig, engine);
-    });
-    return Promise.all(promises).then((entities) => {
-      for (let i = 0, l = entities.length; i < l; i++) {
-        entityMap.set(entitiesConfig[i].id, entities[i]);
-      }
-      // Build rootIds in serialization order (not async completion order)
-      const rootIds = this.context.rootIds;
-      for (let i = 0, l = entitiesConfig.length; i < l; i++) {
-        if (!entitiesConfig[i].parent && !(entitiesConfig[i] as IStrippedEntity).strippedId) {
-          rootIds.push(entitiesConfig[i].id);
-        }
-      }
-      return entities;
-    });
-  }
+    const promises: Promise<void>[] = [];
 
-  private _parseComponents(): void {
-    const entitiesConfig = this.data.entities;
-    const entityMap = this.context.entityMap;
+    for (let i = 0, n = entities.length; i < n; i++) {
+      const entityConfig = entities[i];
 
-    for (let i = 0, l = entitiesConfig.length; i < l; i++) {
-      const entityConfig = entitiesConfig[i];
-      if ((entityConfig as IStrippedEntity).strippedId) {
-        continue;
-      }
-      const entity = entityMap.get(entityConfig.id);
-      this._addComponents(entity, entityConfig.components);
-    }
-  }
-
-  private _parsePrefabModification() {
-    const entitiesConfig = this.data.entities;
-    const entityMap = this.context.entityMap;
-
-    const promises = [];
-    for (let i = 0, l = entitiesConfig.length; i < l; i++) {
-      const entityConfig = entitiesConfig[i];
-      const { id, modifications } = entityConfig as IRefEntity;
-
-      if (modifications?.length) {
-        const rootEntity = entityMap.get(id);
+      if (entityConfig.instance) {
         promises.push(
-          ...modifications.map((modification) => {
-            const { target, props, methods } = modification;
-            const { entityId, componentId } = target;
-            const context = this._prefabContextMap.get(rootEntity);
-            const targetEntity = context.entityMap.get(entityId);
-            const targetComponent = context.components.get(componentId);
-            if (targetComponent) {
-              return this._reflectionParser.parsePropsAndMethods(targetComponent, {
-                props,
-                methods
-              });
-            } else if (targetEntity) {
-              return Promise.resolve(this._applyEntityData(targetEntity, props));
-            }
+          this._loadPrefabInstance(i, entityConfig, engine).then((entity) => {
+            entityMap.set(i, entity);
           })
         );
+      } else {
+        const entity = new Entity(engine, entityConfig.name);
+        this._applyEntityData(entity, entityConfig);
+        entityMap.set(i, entity);
       }
     }
 
-    return Promise.all(promises);
+    return Promise.all(promises).then(() => {});
   }
 
-  private _parseAddedComponents(): void {
-    const entityMap = this.context.entityMap;
-    const entityConfigMap = this.context.entityConfigMap;
-    const strippedIds = this.context.strippedIds;
-
-    for (let i = 0, n = strippedIds.length; i < n; i++) {
-      const entityConfig = entityConfigMap.get(strippedIds[i]) as IStrippedEntity;
-      const prefabContext = this._prefabContextMap.get(entityMap.get(entityConfig.prefabInstanceId));
-      const entity = prefabContext.entityMap.get(entityConfig.prefabSource.entityId);
-      this._addComponents(entity, entityConfig.components);
-    }
-  }
-
-  private _parsePrefabRemovedEntities() {
-    const entitiesConfig = this.data.entities;
-    const entityMap = this.context.entityMap;
-
-    for (let i = 0, l = entitiesConfig.length; i < l; i++) {
-      const entityConfig = entitiesConfig[i];
-      const { id, removedEntities } = entityConfig as IRefEntity;
-
-      if (removedEntities?.length) {
-        const rootEntity = entityMap.get(id);
-        for (let j = 0, m = removedEntities.length; j < m; j++) {
-          const target = removedEntities[j];
-          const { entityId } = target;
-          const context = this._prefabContextMap.get(rootEntity);
-          const targetEntity = context.entityMap.get(entityId);
-          if (targetEntity) {
-            targetEntity.destroy();
-          }
-        }
-      }
-    }
-  }
-
-  private _parsePrefabRemovedComponents() {
-    const entitiesConfig = this.data.entities;
-    const entityMap = this.context.entityMap;
-    const prefabContextMap = this._prefabContextMap;
-
-    for (let i = 0, l = entitiesConfig.length; i < l; i++) {
-      const entityConfig = entitiesConfig[i];
-      const { id, removedComponents } = entityConfig as IRefEntity;
-
-      if (removedComponents?.length) {
-        const rootEntity = entityMap.get(id);
-        for (let j = 0, m = removedComponents.length; j < m; j++) {
-          const target = removedComponents[j];
-          const { componentId } = target;
-          const context = prefabContextMap.get(rootEntity);
-          const targetComponent = context.components.get(componentId);
-          if (targetComponent) {
-            targetComponent.destroy();
-          }
-        }
-      }
-    }
-  }
+  // ---------------------------------------------------------------------------
+  // Stage 2: Build parent-child hierarchy
+  // ---------------------------------------------------------------------------
 
   private _organizeEntities(): void {
-    const { rootIds, strippedIds } = this.context;
-    const parentIds = rootIds.concat(strippedIds);
-    for (let i = 0, l = parentIds.length; i < l; i++) {
-      this._parseChildren(parentIds[i]);
+    const entities = this.data.entities;
+    const entityMap = this.context.entityMap;
+
+    for (let i = 0, n = entities.length; i < n; i++) {
+      const children = entities[i].children;
+      if (!children) continue;
+      // Prefab instance entities manage their own children
+      if (entities[i].instance) continue;
+
+      const parent = entityMap.get(i);
+      for (let j = 0, m = children.length; j < m; j++) {
+        parent.addChild(entityMap.get(children[j]));
+      }
     }
-    for (let i = 0; i < rootIds.length; i++) {
-      this._handleRootEntity(rootIds[i]);
+
+    const rootIndices = this._getRootIndices();
+    for (let i = 0, n = rootIndices.length; i < n; i++) {
+      this._handleRootEntity(rootIndices[i]);
     }
   }
 
-  private _getEntityByConfig(entityConfig: IEntity, engine: Engine): Promise<Entity> {
-    let entityPromise: Promise<Entity>;
-    if ((<IRefEntity>entityConfig).assetUrl) {
-      entityPromise = this._parsePrefab(<IRefEntity>entityConfig, engine);
-    } else if ((<IStrippedEntity>entityConfig).strippedId) {
-      entityPromise = this._parseStrippedEntity(<IStrippedEntity>entityConfig);
-    } else {
-      entityPromise = this._parseEntity(entityConfig, engine);
+  // ---------------------------------------------------------------------------
+  // Stage 3: Add components to entities
+  // ---------------------------------------------------------------------------
+
+  private _parseComponents(): void {
+    const entities = this.data.entities;
+    const allComponents = this.data.components;
+    const entityMap = this.context.entityMap;
+    const componentPairs = this.context.componentPairs;
+
+    for (let i = 0, n = entities.length; i < n; i++) {
+      const entityConfig = entities[i];
+      if (entityConfig.instance) continue;
+
+      const entity = entityMap.get(i);
+      const componentIndices = entityConfig.components;
+      if (!componentIndices) continue;
+
+      for (let j = 0, m = componentIndices.length; j < m; j++) {
+        const config = allComponents[componentIndices[j]];
+        const key = config.script ? config.script.$ref : config.type;
+        const component = entity.addComponent(Loader.getClass(key));
+        componentPairs.push({ component, config });
+      }
     }
-    return entityPromise.then((entity) => {
-      return this._applyEntityData(entity, entityConfig);
-    });
   }
 
-  private _parseEntity(entityConfig: IEntity, engine: Engine): Promise<Entity> {
-    const transform = entityConfig.transform;
-    const entity = new Entity(engine, entityConfig.name, transform ? Loader.getClass(transform.class) : Transform);
-    this._addEntityPlugin(entityConfig.id, entity);
-    return Promise.resolve(entity);
+  // ---------------------------------------------------------------------------
+  // Stage 4: Apply props to components
+  // ---------------------------------------------------------------------------
+
+  private _parseComponentsProps(): Promise<void> {
+    const { componentPairs } = this.context;
+    const reflectionParser = this._reflectionParser;
+    const promises: Promise<any>[] = [];
+
+    for (let i = 0, n = componentPairs.length; i < n; i++) {
+      const { component, config } = componentPairs[i];
+      if (config.props) {
+        promises.push(reflectionParser.parseProps(component, config.props));
+      }
+    }
+
+    return Promise.all(promises).then(() => {});
   }
 
-  private _parsePrefab(entityConfig: IRefEntity, engine: Engine): Promise<Entity> {
-    const assetUrl: string = entityConfig.assetUrl;
+  // ---------------------------------------------------------------------------
+  // Stage 5: Apply prefab instance overrides
+  // ---------------------------------------------------------------------------
+
+  private _parsePrefabOverrides(): Promise<void> {
+    const entities = this.data.entities;
+    const entityMap = this.context.entityMap;
+    const promises: Promise<any>[] = [];
+
+    for (let i = 0, n = entities.length; i < n; i++) {
+      const instance = entities[i].instance;
+      if (!instance?.overrides) continue;
+
+      const rootEntity = entityMap.get(i);
+      const ctx = this._prefabContextMap.get(rootEntity);
+      if (!ctx) continue;
+
+      const overrides = instance.overrides;
+
+      // entityProps — entity-level property overrides
+      if (overrides.entityProps) {
+        for (const key in overrides.entityProps) {
+          const path = HierarchyParser._overrideKeyToPath(key);
+          const target = ctx.entityMap.get(path);
+          if (target) {
+            HierarchyParser._applyEntityOverrides(target, overrides.entityProps[key]);
+          }
+        }
+      }
+
+      // componentProps — component-level property overrides
+      if (overrides.componentProps) {
+        for (const key in overrides.componentProps) {
+          const path = HierarchyParser._overrideKeyToPath(key);
+          const componentMap = overrides.componentProps[key];
+          for (const selector in componentMap) {
+            const componentKey = path ? `${path}:${selector}` : `:${selector}`;
+            const target = ctx.components.get(componentKey);
+            if (target) {
+              promises.push(this._reflectionParser.parseProps(target, componentMap[selector]));
+            }
+          }
+        }
+      }
+
+      // addedComponents — new components on existing prefab entities
+      if (overrides.addedComponents) {
+        for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
+          const added = overrides.addedComponents[j];
+          const path = added.target.join("/");
+          const target = ctx.entityMap.get(path);
+          if (target) {
+            const compConfig = added.component;
+            const compKey = compConfig.script ? compConfig.script.$ref : compConfig.type;
+            const component = target.addComponent(Loader.getClass(compKey));
+            if (compConfig.props) {
+              promises.push(this._reflectionParser.parseProps(component, compConfig.props));
+            }
+          }
+        }
+      }
+
+      // addedEntities — new child entities in prefab tree
+      if (overrides.addedEntities) {
+        for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
+          const added = overrides.addedEntities[j];
+          const path = added.parent.join("/");
+          const parent = ctx.entityMap.get(path);
+          if (parent) {
+            this._createInlineEntity(added.entity, parent, promises);
+          }
+        }
+      }
+
+      // removedEntities — destroy entities from prefab tree
+      if (overrides.removedEntities) {
+        for (let j = 0, m = overrides.removedEntities.length; j < m; j++) {
+          const path = overrides.removedEntities[j].join("/");
+          const target = ctx.entityMap.get(path);
+          if (target) target.destroy();
+        }
+      }
+
+      // removedComponents — destroy components from prefab entities
+      if (overrides.removedComponents) {
+        for (const key in overrides.removedComponents) {
+          const path = HierarchyParser._overrideKeyToPath(key);
+          const selectors = overrides.removedComponents[key];
+          for (let j = 0, m = selectors.length; j < m; j++) {
+            const componentKey = path ? `${path}:${selectors[j]}` : `:${selectors[j]}`;
+            const target = ctx.components.get(componentKey);
+            if (target) target.destroy();
+          }
+        }
+      }
+    }
+
+    return Promise.all(promises).then(() => {});
+  }
+
+  // ---------------------------------------------------------------------------
+  // Prefab instance loading
+  // ---------------------------------------------------------------------------
+
+  private _loadPrefabInstance(
+    entityIndex: number,
+    entityConfig: GalaceanEntitySchema,
+    engine: Engine
+  ): Promise<Entity> {
+    const instance = entityConfig.instance;
+    const $ref = instance.asset.$ref;
 
     return (
       engine.resourceManager
         // @ts-ignore
-        .getResourceByRef<Entity>({
-          url: assetUrl
-        })
+        .getResourceByRef<Entity>({ refId: $ref })
         .then((prefabResource: PrefabResource | GLTFResource) => {
           const entity =
             prefabResource instanceof PrefabResource
               ? prefabResource.instantiate()
               : prefabResource.instantiateSceneRoot();
-          const instanceContext = new ParserContext<IHierarchyFile, Entity>(engine, ParserType.Prefab, null);
-          this._generateInstanceContext(entity, instanceContext, "");
 
+          this._applyEntityData(entity, entityConfig);
+
+          const instanceContext = HierarchyParser._buildInstanceContext(entity);
           this._prefabContextMap.set(entity, instanceContext);
-          const cbArray = this._prefabPromiseMap.get(entityConfig.id);
+
+          // Notify any pending override resolution
+          const cbArray = this._prefabPromiseMap.get(entityIndex);
           if (cbArray) {
-            for (let i = 0, n = cbArray.length; i < n; i++) {
-              cbArray[i].resolve(instanceContext);
+            for (let j = 0, m = cbArray.length; j < m; j++) {
+              cbArray[j].resolve(instanceContext);
             }
+            this._prefabPromiseMap.delete(entityIndex);
           }
+
           return entity;
         })
     );
   }
 
-  private _parseStrippedEntity(entityConfig: IStrippedEntity): Promise<Entity> {
-    this.context.strippedIds.push(entityConfig.id);
-
-    return new Promise<ParserContext<IHierarchyFile, Entity>>((resolve, reject) => {
-      const cbArray = this._prefabPromiseMap.get((<IStrippedEntity>entityConfig).prefabInstanceId) ?? [];
-      cbArray.push({ resolve, reject });
-      this._prefabPromiseMap.set((<IStrippedEntity>entityConfig).prefabInstanceId, cbArray);
-    }).then((context) => {
-      const { entityId } = entityConfig.prefabSource;
-
-      return context.entityMap.get(entityId);
-    });
+  private static _buildInstanceContext(entity: Entity): PrefabInstanceContext {
+    const ctx: PrefabInstanceContext = {
+      entityMap: new Map(),
+      components: new Map()
+    };
+    HierarchyParser._walkPrefabTree(entity, ctx, "");
+    return ctx;
   }
 
-  private _parseChildren(parentId: string) {
-    const { entityConfigMap, entityMap } = this.context;
-    const children = entityConfigMap.get(parentId).children;
-    if (children && children.length > 0) {
-      const parent = entityMap.get(parentId);
-      for (let i = 0; i < children.length; i++) {
-        const childId = children[i];
-        const entity = entityMap.get(childId);
-        parent.addChild(entity);
-        this._parseChildren(childId);
-      }
-    }
-  }
+  private static _walkPrefabTree(entity: Entity, ctx: PrefabInstanceContext, path: string): void {
+    ctx.entityMap.set(path, entity);
+    const componentIndexMap: Record<string, number> = {};
 
-  private _addComponents(entity: Entity, components: IEntity["components"]): void {
-    const context = this.context;
-    const componentMap = context.components;
-    const componentConfigMap = context.componentConfigMap;
-
-    for (let i = 0, n = components.length; i < n; i++) {
-      const componentConfig = components[i];
-      const key = !componentConfig.url ? componentConfig.class : componentConfig.url;
-      const componentId = componentConfig.id;
-      const component = entity.addComponent(Loader.getClass(key));
-      componentMap.set(componentId, component);
-      componentConfigMap.set(componentId, componentConfig);
-      this._addComponentPlugin(componentId, component);
-    }
-  }
-
-  private _generateInstanceContext(entity: Entity, context: ParserContext<IHierarchyFile, Entity>, path: string) {
-    const { entityMap, components } = context;
-    const componentsMap = {};
-    const componentIndexMap = {};
-
-    entityMap.set(path, entity);
     // @ts-ignore
-    entity._components.forEach((component) => {
+    entity._components.forEach((component: Component) => {
       // @ts-ignore
       const name = Loader.getClassName(component.constructor);
-      if (!componentsMap[name]) {
-        componentsMap[name] = entity.getComponents(component.constructor, []);
-        componentIndexMap[name] = 0;
-      }
-      components.set(`${path}:${name}/${componentIndexMap[name]++}`, component);
+      if (!(name in componentIndexMap)) componentIndexMap[name] = 0;
+      ctx.components.set(`${path}:${name}/${componentIndexMap[name]++}`, component);
     });
+
     for (let i = 0, n = entity.children.length; i < n; i++) {
-      const child = entity.children[i];
       const childPath = path ? `${path}/${i}` : `${i}`;
-      this._generateInstanceContext(child, context, childPath);
+      HierarchyParser._walkPrefabTree(entity.children[i], ctx, childPath);
     }
   }
 
-  private _parseComponentsPropsAndMethods(): Promise<any[]> {
-    const context = this.context;
-    const componentConfigMap = context.componentConfigMap;
-    const reflectionParser = this._reflectionParser;
-    const promises = [];
+  // ---------------------------------------------------------------------------
+  // Inline entity creation (for addedEntities overrides)
+  // ---------------------------------------------------------------------------
 
-    for (const [componentId, component] of context.components) {
-      const componentConfig = componentConfigMap.get(componentId);
-      if (componentConfig) {
-        promises.push(reflectionParser.parsePropsAndMethods(component, componentConfig));
+  private _createInlineEntity(
+    config: GalaceanInlineEntitySchema,
+    parent: Entity,
+    promises: Promise<any>[]
+  ): void {
+    const entity = new Entity(this._engine, config.name);
+    entity.isActive = config.isActive ?? true;
+    if (config.layer != null) entity.layer = config.layer;
+    if (config.position) entity.transform.position.set(config.position[0], config.position[1], config.position[2]);
+    if (config.rotation) entity.transform.rotation.set(config.rotation[0], config.rotation[1], config.rotation[2]);
+    if (config.scale) entity.transform.scale.set(config.scale[0], config.scale[1], config.scale[2]);
+    parent.addChild(entity);
+
+    if (config.components) {
+      for (let i = 0, n = config.components.length; i < n; i++) {
+        const compConfig = config.components[i];
+        const key = compConfig.script ? compConfig.script.$ref : compConfig.type;
+        const component = entity.addComponent(Loader.getClass(key));
+        if (compConfig.props) {
+          promises.push(this._reflectionParser.parseProps(component, compConfig.props));
+        }
       }
     }
 
-    return Promise.all(promises);
+    if (config.children) {
+      for (let i = 0, n = config.children.length; i < n; i++) {
+        this._createInlineEntity(config.children[i], entity, promises);
+      }
+    }
   }
 
-  private _addComponentPlugin(componentId: string, component: Component): void {}
+  // ---------------------------------------------------------------------------
+  // Utilities
+  // ---------------------------------------------------------------------------
 
-  private _addEntityPlugin(entityId: string, entity: Entity): void {}
+  /** Convert override key "[0,1]" → path string "0/1" */
+  private static _overrideKeyToPath(key: string): string {
+    const arr: number[] = JSON.parse(key);
+    return arr.join("/");
+  }
+
+  /** Apply entity-level override props to an entity. */
+  private static _applyEntityOverrides(entity: Entity, props: GalaceanEntityOverrideProps): void {
+    if (props.name !== undefined) entity.name = props.name;
+    if (props.isActive !== undefined) entity.isActive = props.isActive;
+    if (props.layer !== undefined) entity.layer = props.layer;
+    if (props.position) entity.transform.position.set(props.position[0], props.position[1], props.position[2]);
+    if (props.rotation) entity.transform.rotation.set(props.rotation[0], props.rotation[1], props.rotation[2]);
+    if (props.scale) entity.transform.scale.set(props.scale[0], props.scale[1], props.scale[2]);
+  }
 }

--- a/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
@@ -8,22 +8,29 @@ import {
   ResourceManager,
   Scene
 } from "@galacean/engine-core";
-import type { IEntity, IHierarchyFile } from "../schema";
+import type { GalaceanComponentSchema, IHierarchyFile } from "../../../scene-format/types";
 
 export enum ParserType {
   Prefab,
   Scene
 }
+
+/** Prefab instance context for override resolution. */
+export interface PrefabInstanceContext {
+  /** Path string → Entity (e.g., "" → root, "0" → first child, "0/1" → ...) */
+  entityMap: Map<string, Entity>;
+  /** Component key → Component (e.g., "0:MeshRenderer/0") */
+  components: Map<string, Component>;
+}
+
 /**
  * @internal
  */
 export class ParserContext<T extends IHierarchyFile, I extends EngineObject> {
-  entityMap: Map<string, Entity> = new Map();
-  entityConfigMap: Map<string, IEntity> = new Map();
-  components: Map<string, Component> = new Map();
-  componentConfigMap: Map<string, any> = new Map();
-  rootIds: string[] = [];
-  strippedIds: string[] = [];
+  /** Flat entity index → Entity instance */
+  entityMap: Map<number, Entity> = new Map();
+  /** Component instance → config pairs for props application */
+  componentPairs: Array<{ component: Component; config: GalaceanComponentSchema }> = [];
 
   readonly resourceManager: ResourceManager;
 
@@ -41,11 +48,7 @@ export class ParserContext<T extends IHierarchyFile, I extends EngineObject> {
 
   clear() {
     this.entityMap.clear();
-    this.components.clear();
-    this.componentConfigMap.clear();
-    this.entityConfigMap.clear();
-    this.rootIds.length = 0;
-    this.strippedIds.length = 0;
+    this.componentPairs.length = 0;
   }
 
   /** @internal */

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -1,227 +1,160 @@
-import { EngineObject, Entity, Loader, Signal, Transform } from "@galacean/engine-core";
-import type {
-  IAssetRef,
-  IBasicType,
-  IClass,
-  IClassType,
-  IComponentRef,
-  IEntity,
-  IEntityRef,
-  IHierarchyFile,
-  IMethod,
-  IMethodParams,
-  IRefEntity,
-  ISignalRef
-} from "../schema";
+import { Loader } from "@galacean/engine-core";
+import type { IHierarchyFile } from "../../../scene-format/types";
 import { ParserContext, ParserType } from "./ParserContext";
 
 export class ReflectionParser {
-  constructor(private readonly _context: ParserContext<IHierarchyFile, EngineObject>) {}
+  static customParseComponentHandles = new Map<string, Function>();
 
-  parseEntity(entityConfig: IEntity): Promise<Entity> {
-    return this._getEntityByConfig(entityConfig).then((entity) => {
-      entity.isActive = entityConfig.isActive ?? true;
-      const transform = entity.transform;
-      const transformConfig = entityConfig.transform;
-      if (transformConfig) {
-        this.parsePropsAndMethods(transform, transformConfig);
-      } else {
-        const { position, rotation, scale } = entityConfig;
-        if (position) transform.position.copyFrom(position);
-        if (rotation) transform.rotation.copyFrom(rotation);
-        if (scale) transform.scale.copyFrom(scale);
-      }
-      entity.layer = entityConfig.layer ?? entity.layer;
+  static registerCustomParseComponent(componentType: string, handle: Function) {
+    this.customParseComponentHandles[componentType] = handle;
+  }
+
+  constructor(private readonly _context: ParserContext<IHierarchyFile, any>) {}
+
+  /**
+   * Apply v2 props to a component/object instance.
+   * Each prop value is resolved recursively (handling $ref, $type, $entity, $component, $signal).
+   */
+  parseProps(instance: any, props: Record<string, unknown>): Promise<any> {
+    const promises: Promise<any>[] = [];
+    for (const key in props) {
+      const promise = this._resolveValue(props[key], instance[key]).then((v) => {
+        instance[key] = v;
+      });
+      promises.push(promise);
+    }
+    return Promise.all(promises).then(() => {
+      const handle = ReflectionParser.customParseComponentHandles[instance.constructor.name];
+      if (handle) return handle(instance, { props });
+      return instance;
+    });
+  }
+
+  /**
+   * Resolve a v2 value with $ prefix detection.
+   *
+   * Priority:
+   * 1. null/undefined/primitive → passthrough
+   * 2. Array → recurse each element
+   * 3. { $ref }       → asset reference
+   * 4. { $type }      → polymorphic type construct
+   * 5. { $entity }    → entity reference (flat index)
+   * 6. { $component } → component reference
+   * 7. { $signal }    → signal binding
+   * 8. plain object   → recurse values (modify originValue in place if exists)
+   */
+  private _resolveValue(value: unknown, originValue?: any): Promise<any> {
+    if (value == null || typeof value !== "object") return Promise.resolve(value);
+    if (Array.isArray(value)) return Promise.all(value.map((v) => this._resolveValue(v)));
+
+    const obj = value as Record<string, unknown>;
+
+    // $ref — asset reference
+    if ("$ref" in obj) {
+      const { _context: context } = this;
+      const ref = obj as { $ref: string; key?: string };
       // @ts-ignore
-      this._context.type === ParserType.Prefab && entity._markAsTemplate(this._context.resource);
-      return entity;
-    });
-  }
-
-  parseClassObject(item: IClass) {
-    const Class = Loader.getClass(item.class);
-    const params = item.constructParams ?? [];
-    return Promise.all(params.map((param) => this.parseBasicType(param)))
-      .then((resultParams) => new Class(...resultParams))
-      .then((instance) => this.parsePropsAndMethods(instance, item));
-  }
-
-  parsePropsAndMethods(instance: any, item: Omit<IClass, "class">) {
-    const promises = [];
-    if (item.methods) {
-      for (let methodName in item.methods) {
-        const methodParams = item.methods[methodName];
-        for (let i = 0, count = methodParams.length; i < count; i++) {
-          promises.push(this.parseMethod(instance, methodName, methodParams[i]));
-        }
-      }
-    }
-
-    if (item.props) {
-      for (let key in item.props) {
-        const value = item.props[key];
-        const promise = this.parseBasicType(value, instance[key]).then((v) => {
-          return (instance[key] = v);
-        });
-        promises.push(promise);
-      }
-    }
-
-    return Promise.all(promises).then(() => instance);
-  }
-
-  parseMethod(instance: any, methodName: string, methodParams: IMethodParams) {
-    const isMethodObject = ReflectionParser._isMethodObject(methodParams);
-    const params = isMethodObject ? methodParams.params : methodParams;
-
-    return Promise.all(params.map((param) => this.parseBasicType(param))).then((result) => {
-      const methodResult = instance[methodName](...result);
-      if (isMethodObject && methodParams.result) {
-        return this.parsePropsAndMethods(methodResult, methodParams.result);
-      } else {
-        return methodResult;
-      }
-    });
-  }
-
-  parseSignal(signalRef: ISignalRef): Promise<Signal> {
-    const signal = new Signal();
-    return Promise.all(
-      signalRef.listeners.map((listener) =>
-        Promise.all([
-          this.parseBasicType(listener.target),
-          listener.arguments ? Promise.all(listener.arguments.map((a) => this.parseBasicType(a))) : Promise.resolve([])
-        ]).then(([target, resolvedArgs]) => {
-          if (target) {
-            signal.on(target, listener.methodName, ...resolvedArgs);
-          }
-        })
-      )
-    ).then(() => signal);
-  }
-
-  parseBasicType(value: IBasicType, originValue?: any): Promise<any> {
-    if (Array.isArray(value)) {
-      return Promise.all(value.map((item) => this.parseBasicType(item)));
-    } else if (typeof value === "object" && value != null) {
-      if (ReflectionParser._isClassType(value)) {
-        return Promise.resolve(Loader.getClass(value["classType"]));
-      } else if (ReflectionParser._isClass(value)) {
-        // class object
-        return this.parseClassObject(value);
-      } else if (ReflectionParser._isAssetRef(value)) {
-        const { _context: context } = this;
-        // reference object
-        // @ts-ignore
-        return context.resourceManager.getResourceByRef(value).then((resource) => {
-          if (resource && context.type === ParserType.Prefab) {
-            // @ts-ignore
-            context.resource._addDependenceAsset(resource);
-          }
-          return resource;
-        });
-      } else if (ReflectionParser._isComponentRef(value)) {
-        const entity = this._resolveEntityByPath(value.entityPath);
-        if (!entity) return Promise.resolve(null);
-        const type = Loader.getClass(value.componentType);
-        if (!type) return Promise.resolve(null);
-        return Promise.resolve(entity.getComponents(type, [])[value.componentIndex] ?? null);
-      } else if (ReflectionParser._isEntityRef(value)) {
-        return Promise.resolve(this._resolveEntityByPath(value.entityPath));
-      } else if (ReflectionParser._isSignalRef(value)) {
-        return this.parseSignal(value);
-      } else if (originValue) {
-        const promises: Promise<any>[] = [];
-        for (let key in value as any) {
-          if (key === "methods") {
-            const methods: any = value[key];
-            for (let methodName in methods) {
-              const methodParams = methods[methodName];
-              for (let i = 0, count = methodParams.length; i < count; i++) {
-                const params = methodParams[i];
-                const promise = this.parseMethod(originValue, methodName, params);
-                promises.push(promise);
-              }
-            }
-          } else {
-            promises.push(this.parseBasicType(value[key], originValue[key]).then((v) => (originValue[key] = v)));
-          }
-        }
-        return Promise.all(promises).then(() => originValue);
-      }
-    }
-    // primitive type
-    return Promise.resolve(value);
-  }
-
-  private _getEntityByConfig(entityConfig: IEntity) {
-    // @ts-ignore
-    const assetUrl: string = entityConfig.assetUrl;
-    const engine = this._context.engine;
-
-    if (assetUrl) {
-      return (
-        engine.resourceManager
+      return context.resourceManager.getResourceByRef({ refId: ref.$ref, key: ref.key }).then((resource) => {
+        if (context.type === ParserType.Prefab) {
           // @ts-ignore
-          .getResourceByRef({
-            url: assetUrl,
-            key: (entityConfig as IRefEntity).key,
-            isClone: (entityConfig as IRefEntity).isClone
-          })
-          .then((entity) => {
-            // @ts-ignore
-            const resource = engine.resourceManager._objectPool[assetUrl];
-            if (resource && this._context.type === ParserType.Prefab) {
-              // @ts-ignore
-              this._context.resource._addDependenceAsset(resource);
-            }
-            entity.name = entityConfig.name;
-            return entity;
-          })
-      );
-    } else {
-      const transform = entityConfig.transform;
-      const entity = new Entity(engine, entityConfig.name, transform ? Loader.getClass(transform.class) : Transform);
+          context.resource._addDependenceAsset(resource);
+        }
+        return resource;
+      });
+    }
+
+    // $type — polymorphic type: construct instance and apply remaining props
+    if ("$type" in obj) {
+      const { $type, ...rest } = obj;
+      const Class = Loader.getClass($type as string);
+      const instance = new Class();
+      if (Object.keys(rest).length > 0) {
+        return this.parseProps(instance, rest);
+      }
+      return Promise.resolve(instance);
+    }
+
+    // $entity — entity reference by flat index
+    if ("$entity" in obj) {
+      const entity = this._context.entityMap.get(obj.$entity as number);
       return Promise.resolve(entity);
     }
-  }
 
-  private _resolveEntityByPath(entityPath: number[]): Entity | null {
-    const { rootIds, entityMap } = this._context;
-    if (!entityPath.length || entityPath[0] >= rootIds.length) return null;
-    let entity = entityMap.get(rootIds[entityPath[0]]);
-    for (let i = 1; i < entityPath.length; i++) {
-      if (!entity || entityPath[i] >= entity.children.length) return null;
-      entity = entity.children[entityPath[i]];
+    // $component — component reference: { entity, type, index }
+    if ("$component" in obj) {
+      const comp = obj.$component as { entity: number; type: string; index: number };
+      const entity = this._context.entityMap.get(comp.entity);
+      if (entity) {
+        const components = entity.getComponents(Loader.getClass(comp.type), []);
+        return Promise.resolve(components[comp.index] ?? null);
+      }
+      return Promise.resolve(null);
     }
-    return entity;
+
+    // $signal — signal binding
+    if ("$signal" in obj) {
+      return this._resolveSignal(
+        obj.$signal as Array<{
+          target: { $component: { entity: number; type: string; index: number } };
+          methodName: string;
+          arguments?: unknown[];
+        }>
+      );
+    }
+
+    // Plain object — recurse each value, modifying originValue in place if it exists
+    if (originValue && typeof originValue === "object" && !Array.isArray(originValue)) {
+      const promises: Promise<any>[] = [];
+      for (const key in obj) {
+        promises.push(this._resolveValue(obj[key], originValue[key]).then((v) => (originValue[key] = v)));
+      }
+      return Promise.all(promises).then(() => originValue);
+    }
+
+    // No originValue — build a new object
+    const result: Record<string, unknown> = {};
+    const promises: Promise<any>[] = [];
+    for (const key in obj) {
+      promises.push(this._resolveValue(obj[key]).then((v) => (result[key] = v)));
+    }
+    return Promise.all(promises).then(() => result);
   }
 
-  private static _isClass(value: any): value is IClass {
-    return value["class"] !== undefined;
+  private _resolveSignal(
+    listeners: Array<{
+      target: { $component: { entity: number; type: string; index: number } };
+      methodName: string;
+      arguments?: unknown[];
+    }>
+  ): Promise<any> {
+    const promises = listeners.map((listener) => {
+      const comp = listener.target.$component;
+      const entity = this._context.entityMap.get(comp.entity);
+      let targetComponent = null;
+      if (entity) {
+        const components = entity.getComponents(Loader.getClass(comp.type), []);
+        targetComponent = components[comp.index] ?? null;
+      }
+
+      const argPromise = listener.arguments
+        ? Promise.all(listener.arguments.map((a) => this._resolveValue(a)))
+        : Promise.resolve(undefined);
+
+      return argPromise.then((resolvedArgs) => ({
+        target: targetComponent,
+        methodName: listener.methodName,
+        ...(resolvedArgs ? { arguments: resolvedArgs } : {})
+      }));
+    });
+    return Promise.all(promises).then((resolved) => ({ listeners: resolved }));
   }
 
-  private static _isClassType(value: any): value is IClassType {
-    return value["classType"] !== undefined;
-  }
-
-  private static _isAssetRef(value: any): value is IAssetRef {
-    return value["url"] !== undefined;
-  }
-
-  private static _isEntityRef(value: any): value is IEntityRef {
-    return Array.isArray(value["entityPath"]) && value["componentType"] === undefined;
-  }
-
-  private static _isComponentRef(value: any): value is IComponentRef {
-    return Array.isArray(value["entityPath"]) && value["componentType"] !== undefined;
-  }
-
-  private static _isSignalRef(value: any): value is ISignalRef {
-    return value["listeners"] !== undefined;
-  }
-
-  private static _isMethodObject(value: any): value is IMethod {
-    return Array.isArray(value?.params);
+  /**
+   * Check if a value is a v2 asset reference ($ref).
+   * Used by SceneParser for dependency collection.
+   * @internal
+   */
+  static _isAssetRef(value: any): boolean {
+    return value != null && typeof value === "object" && "$ref" in value;
   }
 }

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -1,9 +1,9 @@
 import { Loader } from "@galacean/engine-core";
-import type { IHierarchyFile } from "../../../scene-format/types";
+import { assetRefToEngine, type IHierarchyFile } from "../../../scene-format/types";
 import { ParserContext, ParserType } from "./ParserContext";
 
 export class ReflectionParser {
-  static customParseComponentHandles = new Map<string, Function>();
+  static customParseComponentHandles: Record<string, Function> = {};
 
   static registerCustomParseComponent(componentType: string, handle: Function) {
     this.customParseComponentHandles[componentType] = handle;
@@ -54,7 +54,7 @@ export class ReflectionParser {
       const { _context: context } = this;
       const ref = obj as { $ref: string; key?: string };
       // @ts-ignore
-      return context.resourceManager.getResourceByRef({ refId: ref.$ref, key: ref.key }).then((resource) => {
+      return context.resourceManager.getResourceByRef(assetRefToEngine(ref)).then((resource) => {
         if (context.type === ParserType.Prefab) {
           // @ts-ignore
           context.resource._addDependenceAsset(resource);
@@ -91,9 +91,10 @@ export class ReflectionParser {
       return Promise.resolve(null);
     }
 
-    // $signal — signal binding
+    // $signal — signal binding: register listeners on the existing Signal instance
     if ("$signal" in obj) {
       return this._resolveSignal(
+        originValue,
         obj.$signal as Array<{
           target: { $component: { entity: number; type: string; index: number } };
           methodName: string;
@@ -121,6 +122,7 @@ export class ReflectionParser {
   }
 
   private _resolveSignal(
+    signal: any,
     listeners: Array<{
       target: { $component: { entity: number; type: string; index: number } };
       methodName: string;
@@ -136,17 +138,21 @@ export class ReflectionParser {
         targetComponent = components[comp.index] ?? null;
       }
 
+      if (!targetComponent) return Promise.resolve();
+
       const argPromise = listener.arguments
         ? Promise.all(listener.arguments.map((a) => this._resolveValue(a)))
         : Promise.resolve(undefined);
 
-      return argPromise.then((resolvedArgs) => ({
-        target: targetComponent,
-        methodName: listener.methodName,
-        ...(resolvedArgs ? { arguments: resolvedArgs } : {})
-      }));
+      return argPromise.then((resolvedArgs) => {
+        if (resolvedArgs) {
+          signal.on(targetComponent, listener.methodName, ...resolvedArgs);
+        } else {
+          signal.on(targetComponent, listener.methodName);
+        }
+      });
     });
-    return Promise.all(promises).then((resolved) => ({ listeners: resolved }));
+    return Promise.all(promises).then(() => signal);
   }
 
   /**

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -1,8 +1,9 @@
 import { BackgroundMode, DiffuseMode, Scene } from "@galacean/engine-core";
+import type { IHierarchyFile } from "../../../scene-format/types";
 import { HierarchyParser } from "../parser/HierarchyParser";
 import { ParserContext } from "../parser/ParserContext";
 import { ReflectionParser } from "../parser/ReflectionParser";
-import { IHierarchyFile, IRefEntity, IStrippedEntity, SpecularMode, type IScene } from "../schema";
+import { SpecularMode, type IScene } from "../schema";
 
 /** @Internal */
 export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Scene>> {
@@ -29,11 +30,11 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
       const { customAmbientLight, ambientLight } = ambient;
       if (useCustomAmbient && customAmbientLight) {
         // @ts-ignore
-        context._addDependentAsset(customAmbientLight.url, resourceManager.getResourceByRef(customAmbientLight));
+        context._addDependentAsset(customAmbientLight.$ref, resourceManager.getResourceByRef({ refId: customAmbientLight.$ref, key: customAmbientLight.key }));
       }
       if (ambientLight && (!useCustomAmbient || useSH)) {
         // @ts-ignore
-        context._addDependentAsset(ambientLight.url, resourceManager.getResourceByRef(ambientLight));
+        context._addDependentAsset(ambientLight.$ref, resourceManager.getResourceByRef({ refId: ambientLight.$ref, key: ambientLight.key }));
       }
     }
 
@@ -41,22 +42,27 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
     const backgroundMode = background.mode;
     if (backgroundMode === BackgroundMode.Texture) {
       const texture = background.texture;
-      // @ts-ignore
-      texture && context._addDependentAsset(texture.url, resourceManager.getResourceByRef(texture));
+      if (texture) {
+        // @ts-ignore
+        context._addDependentAsset(texture.$ref, resourceManager.getResourceByRef({ refId: texture.$ref, key: texture.key }));
+      }
     } else if (backgroundMode === BackgroundMode.Sky) {
       const { skyMesh, skyMaterial } = background;
       if (skyMesh && skyMaterial) {
         // @ts-ignore
-        context._addDependentAsset(skyMesh.url, resourceManager.getResourceByRef(skyMesh));
+        context._addDependentAsset(skyMesh.$ref, resourceManager.getResourceByRef({ refId: skyMesh.$ref, key: skyMesh.key }));
         // @ts-ignore
-        context._addDependentAsset(skyMaterial.url, resourceManager.getResourceByRef(skyMaterial));
+        context._addDependentAsset(skyMaterial.$ref, resourceManager.getResourceByRef({ refId: skyMaterial.$ref, key: skyMaterial.key }));
       }
     }
   }
 
-  protected override _handleRootEntity(id: string): void {
-    const { entityMap } = this.context;
-    this.scene.addRootEntity(entityMap.get(id));
+  protected override _getRootIndices(): number[] {
+    return (this.data as IScene).scene.entities;
+  }
+
+  protected override _handleRootEntity(index: number): void {
+    this.scene.addRootEntity(this.context.entityMap.get(index));
   }
 
   protected override _clearAndResolve() {
@@ -66,21 +72,27 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
 
   private _parseDependentAssets(file: IHierarchyFile): void {
     const entities = file.entities;
+    const components = file.components;
+    const context = this.context;
+
     for (let i = 0, n = entities.length; i < n; i++) {
       const entity = entities[i];
-      if (!!(<IRefEntity>entity).assetUrl) {
-        const context = this.context;
-        const { assetUrl: url, key } = <IRefEntity>entity;
+      if (entity.instance) {
+        const $ref = entity.instance.asset.$ref;
         // @ts-ignore
-        context._addDependentAsset(url, context.resourceManager.getResourceByRef({ url, key }));
-      } else if ((<IStrippedEntity>entity).strippedId) {
-        continue;
+        context._addDependentAsset($ref, context.resourceManager.getResourceByRef({ refId: $ref }));
       } else {
-        const components = entity.components;
-        for (let j = 0, m = components.length; j < m; j++) {
-          const component = components[j];
-          this._searchDependentAssets(component.methods);
-          this._searchDependentAssets(component.props);
+        const componentIndices = entity.components;
+        if (!componentIndices) continue;
+        for (let j = 0, m = componentIndices.length; j < m; j++) {
+          const comp = components[componentIndices[j]];
+          if (comp.script) {
+            // @ts-ignore
+            context._addDependentAsset(comp.script.$ref, context.resourceManager.getResourceByRef({ refId: comp.script.$ref, key: comp.script.key }));
+          }
+          if (comp.props) {
+            this._searchDependentAssets(comp.props);
+          }
         }
       }
     }
@@ -91,14 +103,14 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
       for (let i = 0, n = value.length; i < n; i++) {
         this._searchDependentAssets(value[i]);
       }
-    } else if (!!value && typeof value === "object") {
+    } else if (value != null && typeof value === "object") {
       // @ts-ignore
       if (ReflectionParser._isAssetRef(value)) {
         const context = this.context;
         // @ts-ignore
-        context._addDependentAsset(value.url, context.resourceManager.getResourceByRef(value));
+        context._addDependentAsset(value.$ref, context.resourceManager.getResourceByRef({ refId: value.$ref, key: value.key }));
       } else {
-        for (let key in value) {
+        for (const key in value) {
           this._searchDependentAssets(value[key]);
         }
       }

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -1,5 +1,5 @@
 import { BackgroundMode, DiffuseMode, Scene } from "@galacean/engine-core";
-import type { IHierarchyFile } from "../../../scene-format/types";
+import { assetRefToEngine, type IHierarchyFile } from "../../../scene-format/types";
 import { HierarchyParser } from "../parser/HierarchyParser";
 import { ParserContext } from "../parser/ParserContext";
 import { ReflectionParser } from "../parser/ReflectionParser";
@@ -30,11 +30,11 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
       const { customAmbientLight, ambientLight } = ambient;
       if (useCustomAmbient && customAmbientLight) {
         // @ts-ignore
-        context._addDependentAsset(customAmbientLight.$ref, resourceManager.getResourceByRef({ refId: customAmbientLight.$ref, key: customAmbientLight.key }));
+        context._addDependentAsset(customAmbientLight.$ref, resourceManager.getResourceByRef(assetRefToEngine(customAmbientLight)));
       }
       if (ambientLight && (!useCustomAmbient || useSH)) {
         // @ts-ignore
-        context._addDependentAsset(ambientLight.$ref, resourceManager.getResourceByRef({ refId: ambientLight.$ref, key: ambientLight.key }));
+        context._addDependentAsset(ambientLight.$ref, resourceManager.getResourceByRef(assetRefToEngine(ambientLight)));
       }
     }
 
@@ -44,15 +44,15 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
       const texture = background.texture;
       if (texture) {
         // @ts-ignore
-        context._addDependentAsset(texture.$ref, resourceManager.getResourceByRef({ refId: texture.$ref, key: texture.key }));
+        context._addDependentAsset(texture.$ref, resourceManager.getResourceByRef(assetRefToEngine(texture)));
       }
     } else if (backgroundMode === BackgroundMode.Sky) {
       const { skyMesh, skyMaterial } = background;
       if (skyMesh && skyMaterial) {
         // @ts-ignore
-        context._addDependentAsset(skyMesh.$ref, resourceManager.getResourceByRef({ refId: skyMesh.$ref, key: skyMesh.key }));
+        context._addDependentAsset(skyMesh.$ref, resourceManager.getResourceByRef(assetRefToEngine(skyMesh)));
         // @ts-ignore
-        context._addDependentAsset(skyMaterial.$ref, resourceManager.getResourceByRef({ refId: skyMaterial.$ref, key: skyMaterial.key }));
+        context._addDependentAsset(skyMaterial.$ref, resourceManager.getResourceByRef(assetRefToEngine(skyMaterial)));
       }
     }
   }
@@ -78,9 +78,9 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
     for (let i = 0, n = entities.length; i < n; i++) {
       const entity = entities[i];
       if (entity.instance) {
-        const $ref = entity.instance.asset.$ref;
+        const asset = entity.instance.asset;
         // @ts-ignore
-        context._addDependentAsset($ref, context.resourceManager.getResourceByRef({ refId: $ref }));
+        context._addDependentAsset(asset.$ref, context.resourceManager.getResourceByRef(assetRefToEngine(asset)));
       } else {
         const componentIndices = entity.components;
         if (!componentIndices) continue;
@@ -88,7 +88,7 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
           const comp = components[componentIndices[j]];
           if (comp.script) {
             // @ts-ignore
-            context._addDependentAsset(comp.script.$ref, context.resourceManager.getResourceByRef({ refId: comp.script.$ref, key: comp.script.key }));
+            context._addDependentAsset(comp.script.$ref, context.resourceManager.getResourceByRef(assetRefToEngine(comp.script)));
           }
           if (comp.props) {
             this._searchDependentAssets(comp.props);
@@ -108,7 +108,7 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext<IScene, Sc
       if (ReflectionParser._isAssetRef(value)) {
         const context = this.context;
         // @ts-ignore
-        context._addDependentAsset(value.$ref, context.resourceManager.getResourceByRef({ refId: value.$ref, key: value.key }));
+        context._addDependentAsset(value.$ref, context.resourceManager.getResourceByRef(assetRefToEngine(value)));
       } else {
         for (const key in value) {
           this._searchDependentAssets(value[key]);

--- a/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/BasicSchema.ts
@@ -1,5 +1,3 @@
-import { Layer } from "@galacean/engine-core";
-
 export interface IVector3 {
   x: number;
   y: number;
@@ -24,99 +22,8 @@ export interface IColor {
   a: number;
 }
 
-export interface IHierarchyFile {
-  entities: Array<IEntity>;
-}
-
-export type IMethod = {
-  params: Array<IBasicType>;
-  result?: IInstance;
-};
-
-export type IMethodParams = Array<IBasicType> | IMethod;
-
-export interface IBasicEntity {
-  name?: string;
-  id?: string;
-  transform?: IComponent;
-  components?: Array<IComponent>;
-  isActive?: boolean;
-  position?: IVector3;
-  rotation?: IVector3;
-  scale?: IVector3;
-  children?: Array<string>;
-  parent?: string;
-  layer?: Layer;
-}
-
-export type IEntity = IBasicEntity | IRefEntity | IStrippedEntity;
-
-export interface IRefEntity extends IBasicEntity {
-  assetUrl: string;
-  key?: string;
-  isClone?: boolean;
-  modifications: (IInstance & {
-    target: IPrefabModifyTarget;
-  })[];
-  removedEntities: IPrefabModifyTarget[];
-  removedComponents: IPrefabModifyTarget[];
-}
-
-export interface IPrefabModifyTarget {
-  entityId?: string;
-  componentId?: string;
-}
-
-export interface IStrippedEntity extends IBasicEntity {
-  strippedId: string;
-  prefabInstanceId: string;
-  prefabSource: { assetId: string; entityId: string };
-}
-
-export type IComponent = { id: string; url?: string } & IClass;
-
-export type IClass = {
-  class: string;
-  constructParams?: Array<IBasicType>;
-} & IInstance;
-
-export interface IInstance {
-  methods?: { [methodName: string]: Array<IMethodParams> };
-  props?: { [key: string]: IBasicType | IMethodParams };
-}
-
-export type IClassType = {
-  classType: string;
-};
-
-export type IBasicType =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | IAssetRef
-  | IClass
-  | IClassType
-  | IMethodParams
-  | IEntityRef
-  | IComponentRef
-  | ISignalRef;
-
-export type IAssetRef = { key?: string; url: string };
-
-export type IEntityRef = { entityPath: number[] };
-
-export type IComponentRef = {
-  entityPath: number[];
-  componentType: string;
-  componentIndex: number;
-};
-
-export type ISignalRef = {
-  listeners: Array<{
-    target: IComponentRef;
-    methodName: string;
-    arguments?: Array<IBasicType>;
-  }>;
-};
+/**
+ * Legacy asset reference format used by material/animation loaders.
+ * Scene/prefab v2 format uses AssetRef { $ref } from scene-format/types instead.
+ */
+export type IAssetRef = { key?: string; refId: string };

--- a/packages/loader/src/resource-deserialize/resources/schema/SceneSchema.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/SceneSchema.ts
@@ -1,14 +1,13 @@
 import {
   BackgroundMode,
   BackgroundTextureFillMode,
-  BloomDownScaleMode,
   DiffuseMode,
   FogMode,
   ShadowCascadesMode,
-  ShadowResolution,
-  TonemappingMode
+  ShadowResolution
 } from "@galacean/engine-core";
-import type { IAssetRef, IColor, IHierarchyFile, IVector3 } from "./BasicSchema";
+import type { AssetRef, IHierarchyFile, Vec4Tuple } from "../../../scene-format/types";
+import type { IColor, IVector3 } from "./BasicSchema";
 
 export enum SpecularMode {
   Sky = "Sky",
@@ -18,20 +17,21 @@ export enum SpecularMode {
 export interface IScene extends IHierarchyFile {
   name?: string;
   scene: {
+    entities: number[];
     background: {
       mode: BackgroundMode;
-      color: IColor;
-      texture?: IAssetRef;
+      color: Vec4Tuple | IColor;
+      texture?: AssetRef;
       textureFillMode?: BackgroundTextureFillMode;
-      skyMesh?: IAssetRef;
-      skyMaterial?: IAssetRef;
+      skyMesh?: AssetRef;
+      skyMaterial?: AssetRef;
     };
     ambient: {
       diffuseMode: DiffuseMode;
-      ambientLight: IAssetRef;
-      customAmbientLight: IAssetRef;
-      customSpecularTexture: IAssetRef;
-      diffuseSolidColor: IColor;
+      ambientLight?: AssetRef;
+      customAmbientLight?: AssetRef;
+      customSpecularTexture?: AssetRef;
+      diffuseSolidColor?: Vec4Tuple | IColor;
       diffuseIntensity: number;
       specularIntensity: number;
       specularMode: SpecularMode;
@@ -52,24 +52,7 @@ export interface IScene extends IHierarchyFile {
       fogStart: number;
       fogEnd: number;
       fogDensity: number;
-      fogColor: IColor;
-    };
-    postProcess?: {
-      isActive: boolean;
-      bloom: {
-        enabled: boolean;
-        downScale: BloomDownScaleMode;
-        threshold: number;
-        scatter: number;
-        intensity: number;
-        tint: IColor;
-        dirtTexture: IAssetRef;
-        dirtIntensity: number;
-      };
-      tonemapping: {
-        enabled: boolean;
-        mode: TonemappingMode;
-      };
+      fogColor: Vec4Tuple | IColor;
     };
     ambientOcclusion?: {
       bias: number;
@@ -82,5 +65,4 @@ export interface IScene extends IHierarchyFile {
       minHorizonAngle: number;
     };
   };
-  files: Array<{ id: string; type: string; virtualPath: string; path: string }>;
 }

--- a/packages/loader/src/resource-deserialize/resources/schema/index.ts
+++ b/packages/loader/src/resource-deserialize/resources/schema/index.ts
@@ -2,3 +2,13 @@ export * from "./BasicSchema";
 export * from "./MaterialSchema";
 export * from "./ProjectSchema";
 export * from "./SceneSchema";
+export type {
+  AssetRef,
+  GalaceanComponentSchema,
+  GalaceanEntitySchema,
+  GalaceanEntityOverrideProps,
+  GalaceanInlineEntitySchema,
+  GalaceanPrefabFile,
+  GalaceanSceneFile,
+  IHierarchyFile
+} from "../../../scene-format/types";

--- a/packages/loader/src/scene-format/types.ts
+++ b/packages/loader/src/scene-format/types.ts
@@ -1,0 +1,110 @@
+/**
+ * Galacean Scene/Prefab v2 file format types.
+ * glTF-inspired flat-array structure with integer index references.
+ */
+
+export type Vec3Tuple = [number, number, number];
+export type Vec4Tuple = [number, number, number, number];
+
+export interface AssetRef {
+  $ref: string;
+  key?: string;
+}
+
+export interface GalaceanAssetInfo {
+  version: string;
+  generator?: string;
+}
+
+export interface GalaceanComponentSchema {
+  type: string;
+  script?: AssetRef;
+  props?: Record<string, unknown>;
+}
+
+export interface GalaceanEntityOverrideProps {
+  name?: string;
+  isActive?: boolean;
+  layer?: number;
+  isLocked?: boolean;
+  position?: Vec3Tuple;
+  rotation?: Vec3Tuple;
+  scale?: Vec3Tuple;
+}
+
+export interface GalaceanInlineEntitySchema {
+  name?: string;
+  position?: Vec3Tuple;
+  rotation?: Vec3Tuple;
+  scale?: Vec3Tuple;
+  children?: GalaceanInlineEntitySchema[];
+  components?: GalaceanComponentSchema[];
+  isActive?: boolean;
+  layer?: number;
+  isLocked?: boolean;
+}
+
+export interface GalaceanAddedEntityOverride {
+  parent: number[];
+  entity: GalaceanInlineEntitySchema;
+}
+
+export interface GalaceanAddedComponentOverride {
+  target: number[];
+  component: GalaceanComponentSchema;
+}
+
+export interface GalaceanInstanceOverrides {
+  entityProps?: Record<string, GalaceanEntityOverrideProps>;
+  componentProps?: Record<string, Record<string, Record<string, unknown>>>;
+  removedEntities?: number[][];
+  removedComponents?: Record<string, string[]>;
+  addedEntities?: GalaceanAddedEntityOverride[];
+  addedComponents?: GalaceanAddedComponentOverride[];
+}
+
+export interface GalaceanInstanceSchema {
+  asset: AssetRef;
+  overrides?: GalaceanInstanceOverrides;
+}
+
+export interface GalaceanEntitySchema {
+  name?: string;
+  children?: number[];
+  position?: Vec3Tuple;
+  rotation?: Vec3Tuple;
+  scale?: Vec3Tuple;
+  components?: number[];
+  isActive?: boolean;
+  layer?: number;
+  isLocked?: boolean;
+  instance?: GalaceanInstanceSchema;
+}
+
+export interface GalaceanSceneSchema {
+  name?: string;
+  entities: number[];
+  background?: Record<string, unknown>;
+  ambient?: Record<string, unknown>;
+  shadow?: Record<string, unknown>;
+  fog?: Record<string, unknown>;
+  ambientOcclusion?: Record<string, unknown>;
+}
+
+/** Common base for v2 scene and prefab files. */
+export interface IHierarchyFile {
+  entities: GalaceanEntitySchema[];
+  components: GalaceanComponentSchema[];
+  _entityIds?: string[];
+  _componentIds?: string[];
+}
+
+export interface GalaceanSceneFile extends IHierarchyFile {
+  asset: GalaceanAssetInfo;
+  scene: GalaceanSceneSchema;
+}
+
+export interface GalaceanPrefabFile extends IHierarchyFile {
+  asset: GalaceanAssetInfo;
+  root: number;
+}

--- a/packages/loader/src/scene-format/types.ts
+++ b/packages/loader/src/scene-format/types.ts
@@ -11,6 +11,11 @@ export interface AssetRef {
   key?: string;
 }
 
+/** Convert v2 AssetRef { $ref } → engine format { url } for getResourceByRef. */
+export function assetRefToEngine(ref: AssetRef): { url: string; key?: string } {
+  return ref.key ? { url: ref.$ref, key: ref.key } : { url: ref.$ref };
+}
+
 export interface GalaceanAssetInfo {
   version: string;
   generator?: string;

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -1,0 +1,297 @@
+import "@galacean/engine-loader";
+import { Entity, Loader, Scene, Transform } from "@galacean/engine-core";
+import {
+  ParserContext,
+  ParserType,
+  ReflectionParser,
+  SceneParser,
+  type IScene
+} from "@galacean/engine-loader";
+import { WebGLEngine } from "@galacean/engine-rhi-webgl";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+Loader.registerClass("Transform", Transform);
+
+let engine: WebGLEngine;
+
+beforeAll(async function () {
+  const canvasDOM = document.createElement("canvas");
+  canvasDOM.width = 100;
+  canvasDOM.height = 100;
+  engine = await WebGLEngine.create({ canvas: canvasDOM });
+});
+
+afterAll(() => {
+  engine?.destroy();
+});
+
+// ---------------------------------------------------------------------------
+// ReflectionParser — $ prefix props resolution
+// ---------------------------------------------------------------------------
+
+describe("ReflectionParser v2 props resolution", () => {
+  it("should resolve primitive values directly", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context);
+    const target: any = {};
+    await parser.parseProps(target, {
+      name: "test",
+      value: 42,
+      flag: true
+    });
+    expect(target.name).to.equal("test");
+    expect(target.value).to.equal(42);
+    expect(target.flag).to.equal(true);
+  });
+
+  it("should resolve nested plain objects recursively", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context);
+    const target: any = {};
+    await parser.parseProps(target, {
+      nested: { a: 1, b: { c: 2 } }
+    });
+    expect(target.nested).to.deep.equal({ a: 1, b: { c: 2 } });
+  });
+
+  it("should modify existing object properties in place", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context);
+    const original = { x: 0, y: 0, z: 0 };
+    const target: any = { position: original };
+    await parser.parseProps(target, {
+      position: { x: 1, y: 2, z: 3 }
+    });
+    // Should modify in place, not replace
+    expect(target.position).to.equal(original);
+    expect(target.position.x).to.equal(1);
+    expect(target.position.y).to.equal(2);
+    expect(target.position.z).to.equal(3);
+  });
+
+  it("should resolve arrays recursively", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context);
+    const target: any = {};
+    await parser.parseProps(target, {
+      items: [1, "two", { key: 3 }]
+    });
+    expect(target.items).to.deep.equal([1, "two", { key: 3 }]);
+  });
+
+  it("should resolve $entity by flat index", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const entity0 = new Entity(engine, "entity0");
+    const entity1 = new Entity(engine, "entity1");
+    context.entityMap.set(0, entity0);
+    context.entityMap.set(1, entity1);
+
+    const parser = new ReflectionParser(context);
+    const target: any = {};
+    await parser.parseProps(target, {
+      target: { $entity: 1 }
+    });
+    expect(target.target).to.equal(entity1);
+  });
+
+  it("should resolve $component by entity index + type + index", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const entity = new Entity(engine, "test");
+    context.entityMap.set(0, entity);
+
+    const parser = new ReflectionParser(context);
+    const target: any = {};
+    await parser.parseProps(target, {
+      comp: { $component: { entity: 0, type: "Transform", index: 0 } }
+    });
+    expect(target.comp).to.equal(entity.transform);
+  });
+
+  it("should detect $ref values via _isAssetRef", () => {
+    expect(ReflectionParser._isAssetRef({ $ref: "some-uuid" })).to.be.true;
+    expect(ReflectionParser._isAssetRef({ $ref: "uuid", key: "k" })).to.be.true;
+    expect(ReflectionParser._isAssetRef({ refId: "old-format" })).to.be.false;
+    expect(ReflectionParser._isAssetRef(null)).to.be.false;
+    expect(ReflectionParser._isAssetRef(42)).to.be.false;
+    expect(ReflectionParser._isAssetRef("string")).to.be.false;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SceneParser — v2 entity tree construction
+// ---------------------------------------------------------------------------
+
+describe("SceneParser v2 entity tree", () => {
+  function createSceneData(
+    entities: IScene["entities"],
+    components: IScene["components"],
+    rootEntities: number[]
+  ): IScene {
+    return {
+      entities,
+      components,
+      scene: {
+        entities: rootEntities,
+        background: {
+          mode: 0,
+          color: [0.25, 0.25, 0.25, 1]
+        },
+        ambient: {
+          diffuseMode: 0,
+          diffuseIntensity: 1,
+          specularIntensity: 1,
+          specularMode: "Sky" as any,
+          bakerResolution: 0
+        }
+      }
+    };
+  }
+
+  it("should build single-root entity tree from flat array", async () => {
+    const data = createSceneData(
+      [
+        { name: "Root", children: [1, 2] },
+        { name: "Camera" },
+        { name: "Light" }
+      ],
+      [],
+      [0]
+    );
+
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    expect(scene.rootEntitiesCount).to.equal(1);
+    const root = scene.rootEntities[0];
+    expect(root.name).to.equal("Root");
+    expect(root.childCount).to.equal(2);
+    expect(root.children[0].name).to.equal("Camera");
+    expect(root.children[1].name).to.equal("Light");
+  });
+
+  it("should build multi-root entity tree", async () => {
+    const data = createSceneData(
+      [
+        { name: "Root1", children: [2] },
+        { name: "Root2" },
+        { name: "Child" }
+      ],
+      [],
+      [0, 1]
+    );
+
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    expect(scene.rootEntitiesCount).to.equal(2);
+    expect(scene.rootEntities[0].name).to.equal("Root1");
+    expect(scene.rootEntities[1].name).to.equal("Root2");
+    expect(scene.rootEntities[0].childCount).to.equal(1);
+    expect(scene.rootEntities[0].children[0].name).to.equal("Child");
+  });
+
+  it("should apply entity transforms from Vec3Tuple", async () => {
+    const data = createSceneData(
+      [
+        {
+          name: "Entity",
+          position: [1, 2, 3],
+          rotation: [45, 90, 0],
+          scale: [2, 2, 2]
+        }
+      ],
+      [],
+      [0]
+    );
+
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    const entity = scene.rootEntities[0];
+    expect(entity.transform.position.x).to.equal(1);
+    expect(entity.transform.position.y).to.equal(2);
+    expect(entity.transform.position.z).to.equal(3);
+    expect(entity.transform.rotation.x).to.equal(45);
+    expect(entity.transform.rotation.y).to.equal(90);
+    expect(entity.transform.rotation.z).to.equal(0);
+    expect(entity.transform.scale.x).to.equal(2);
+    expect(entity.transform.scale.y).to.equal(2);
+    expect(entity.transform.scale.z).to.equal(2);
+  });
+
+  it("should set entity isActive and layer", async () => {
+    const data = createSceneData(
+      [{ name: "Inactive", isActive: false, layer: 3 }],
+      [],
+      [0]
+    );
+
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    const entity = scene.rootEntities[0];
+    expect(entity.isActive).to.equal(false);
+    expect(entity.layer).to.equal(3);
+  });
+
+  it("should handle deep entity nesting", async () => {
+    const data = createSceneData(
+      [
+        { name: "A", children: [1] },
+        { name: "B", children: [2] },
+        { name: "C", children: [3] },
+        { name: "D" }
+      ],
+      [],
+      [0]
+    );
+
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    const a = scene.rootEntities[0];
+    expect(a.name).to.equal("A");
+    expect(a.children[0].name).to.equal("B");
+    expect(a.children[0].children[0].name).to.equal("C");
+    expect(a.children[0].children[0].children[0].name).to.equal("D");
+  });
+
+  it("should default missing transform to identity", async () => {
+    const data = createSceneData([{ name: "Default" }], [], [0]);
+
+    const scene = new Scene(engine);
+    const context = new ParserContext<IScene, Scene>(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    const entity = scene.rootEntities[0];
+    expect(entity.transform.position.x).to.equal(0);
+    expect(entity.transform.position.y).to.equal(0);
+    expect(entity.transform.position.z).to.equal(0);
+    expect(entity.transform.scale.x).to.equal(1);
+    expect(entity.transform.scale.y).to.equal(1);
+    expect(entity.transform.scale.z).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary

- 重写 loader parser 层，直接消费 v2 scene/prefab 格式的 `$` 前缀值类型（`$ref`/`$type`/`$entity`/`$component`/`$signal`），消除 v2→v1 转换层
- `ReflectionParser` 完全重写：递归解析 props 树，按优先级匹配 `$` 前缀
- `HierarchyParser` 完全重写：5 阶段管线（parseEntities → organizeEntities → parseComponents → parseComponentsProps → parsePrefabOverrides），支持扁平实体数组 + 整数索引引用
- `ParserContext.entityMap` 改为 `Map<number, Entity>`（扁平索引），新增 `PrefabInstanceContext` 处理 prefab override
- `BasicSchema` 精简：移除所有 v1 类型（IEntity/IComponent/IClass 等），保留 `IAssetRef` 供材质/动画 loader 使用
- 新增 `scene-format/types.ts`：v2 文件格式的 canonical 类型定义

## Related

- RFC: galacean/editor#3668

## Test plan

- [x] ReflectionParser: 原始值、嵌套对象、就地修改、数组、`$entity`、`$component`、`_isAssetRef` (7 tests)
- [x] SceneParser: 单根/多根实体树、Vec3Tuple 变换、isActive/layer、深层嵌套、默认值 (6 tests)
- [x] TypeScript 编译无新增错误
- [ ] 集成测试：v2 格式 scene JSON 端到端加载
- [ ] Prefab instance + override 场景验证