### PR TITLE
fix(audio): guard suspend/resume against uninitialized AudioContext

### DIFF
--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -15,10 +15,7 @@ export class AudioManager {
    * @returns A promise that resolves when the audio context is suspended
    */
   static suspend(): Promise<void> {
-    if (!AudioManager._context) {
-      return Promise.resolve();
-    }
-    return AudioManager._context.suspend();
+    return AudioManager.getContext().suspend();
   }
 
   /**
@@ -27,10 +24,7 @@ export class AudioManager {
    * @returns A promise that resolves when the audio context is resumed
    */
   static resume(): Promise<void> {
-    if (!AudioManager._context) {
-      return Promise.resolve();
-    }
-    return (AudioManager._resumePromise ??= AudioManager._context
+    return (AudioManager._resumePromise ??= AudioManager.getContext()
       .resume()
       .then(() => {
         AudioManager._needsUserGestureResume = false;

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -15,6 +15,9 @@ export class AudioManager {
    * @returns A promise that resolves when the audio context is suspended
    */
   static suspend(): Promise<void> {
+    if (!AudioManager._context) {
+      return Promise.resolve();
+    }
     return AudioManager._context.suspend();
   }
 
@@ -24,6 +27,9 @@ export class AudioManager {
    * @returns A promise that resolves when the audio context is resumed
    */
   static resume(): Promise<void> {
+    if (!AudioManager._context) {
+      return Promise.resolve();
+    }
     return (AudioManager._resumePromise ??= AudioManager._context
       .resume()
       .then(() => {


### PR DESCRIPTION
## Summary
- `AudioManager._context` is lazily created on first audio play, but `suspend()`/`resume()` as public API can be called before that
- Added null check to both methods — return `Promise.resolve()` when `_context` doesn't exist yet
- No AudioContext means nothing to suspend/resume, user completely unaffected

## Test plan
- [ ] Call `AudioManager.suspend()` before any audio plays — should not throw
- [ ] Call `AudioManager.resume()` before any audio plays — should not throw
- [ ] Normal audio playback + suspend/resume flow still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio reliability when pausing/resuming: suspend and resume now safely handle cases where the audio system hasn't been initialized yet, preventing potential crashes and ensuring more consistent audio behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->