### PR TITLE
fix(physics): unify scene query filtering to use collisionLayer

### DIFF
--- a/packages/core/src/physics/PhysicsScene.ts
+++ b/packages/core/src/physics/PhysicsScene.ts
@@ -835,7 +835,7 @@ export class PhysicsScene {
       if (!shape) {
         return false;
       }
-      return shape.collider.entity.layer & mask && shape.isSceneQuery;
+      return shape.collider.collisionLayer & mask && shape.isSceneQuery;
     };
   }
 

--- a/tests/src/core/physics/PhysicsScene.test.ts
+++ b/tests/src/core/physics/PhysicsScene.test.ts
@@ -504,10 +504,10 @@ describe("Physics Test", () => {
       expect(physicsScene.raycast(ray, Number.MAX_VALUE, Layer.Everything, outHitResult)).to.eq(false);
 
       const rootEntityCharacter = root.createChild("root_character");
-      rootEntityCharacter.layer = Layer.Layer3;
       rootEntityCharacter.transform.position = new Vector3(0, 0, 0);
 
       const characterController = rootEntityCharacter.addComponent(CharacterController);
+      characterController.collisionLayer = Layer.Layer3;
       const boxShape2 = new BoxColliderShape();
       boxShape2.size.set(1, 1, 1);
       boxShape2.position = new Vector3(0, 0, 0);


### PR DESCRIPTION
## 背景

之前物理系统存在两套 layer 过滤机制：
- **场景查询**（raycast / sweep / overlap）使用 `entity.layer` 过滤
- **碰撞检测**（contact / trigger）使用 `collider.collisionLayer` 过滤

这对用户来说很不直观——同样是物理相关的操作，需要分别设置两个不同的 layer 才能得到预期结果。

## 从用户角度看问题

射线检测本质上也是一种物理查询，用户的直觉是：我在 collider 上设了 `collisionLayer`，那所有物理相关的过滤（碰撞、射线、扫描、重叠检测）都应该走这个 layer。不应该还要额外去设 `entity.layer` 才能让射线检测生效。

统一后的心智模型很简单：
- `collisionLayer` → 管所有物理相关的事
- `entity.layer` → 管渲染剔除等非物理的事

职责清晰，互不干扰。这也和 Unity 的设计思路一致——用一套 layer 统一管理所有物理过滤。

## 改动

- `PhysicsScene._createPreFilter` 中将 `shape.collider.entity.layer & mask` 改为 `shape.collider.collisionLayer & mask`
- 更新 CharacterController 射线检测测试，使用 `collisionLayer` 替代 `entity.layer`

## 测试计划
- [ ] 验证 raycast 过滤使用 `collisionLayer` 正常工作
- [ ] 验证 sweep（boxCast / sphereCast / capsuleCast）过滤正常
- [ ] 验证 overlap 查询正常
- [ ] 运行已有物理单元测试