### PR TITLE
fix(shader-lab): transform struct member access in #define values

### DIFF
--- a/packages/shader-lab/src/Preprocessor.ts
+++ b/packages/shader-lab/src/Preprocessor.ts
@@ -5,6 +5,7 @@ import { ShaderLib } from "@galacean/engine";
 export enum MacroValueType {
   Number, // 1, 1.1
   Symbol, // variable name
+  MemberAccess, // member access, e.g. input.v_uv, v.rgb
   FunctionCall, // function call, e.g. clamp(a, 0.0, 1.0)
   Other // shaderLab does not check this
 }
@@ -27,6 +28,7 @@ export class Preprocessor {
   private static readonly _macroRegex =
     /^\s*#define\s+(\w+)[ ]*(\(([^)]*)\))?[ ]+(\(?\w+\)?.*?)(?:\/\/.*|\/\*.*?\*\/)?\s*$/gm;
   private static readonly _symbolReg = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+  private static readonly _memberAccessReg = /^([a-zA-Z_][a-zA-Z0-9_]*)(\.[a-zA-Z_][a-zA-Z0-9_]*)+$/;
   private static readonly _funcCallReg = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\((.*)\)$/;
   private static readonly _macroDefineIncludeMap = new Map<string, MacroDefineList>();
 
@@ -61,6 +63,10 @@ export class Preprocessor {
         const referencedName = valueType === MacroValueType.FunctionCall ? info.functionCallName : info.value;
         if (info.params.indexOf(referencedName) !== -1) continue;
         if (out.indexOf(referencedName) === -1) out.push(referencedName);
+      } else if (valueType === MacroValueType.MemberAccess) {
+        // Extract root symbol: "input.v_uv" → "input"
+        const rootName = info.value.substring(0, info.value.indexOf("."));
+        if (out.indexOf(rootName) === -1) out.push(rootName);
       } else if (valueType === MacroValueType.Other) {
         // #if _VERBOSE
         Logger.warn(
@@ -110,6 +116,8 @@ export class Preprocessor {
         valueType = MacroValueType.Number;
       } else if (this._symbolReg.test(value)) {
         valueType = MacroValueType.Symbol;
+      } else if (this._memberAccessReg.test(value)) {
+        valueType = MacroValueType.MemberAccess;
       } else {
         const callMatch = this._funcCallReg.exec(value);
         if (callMatch) {

--- a/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
+++ b/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
@@ -244,7 +244,19 @@ export abstract class CodeGenVisitor {
     const children = node.children;
     const fullType = children[0];
     if (fullType instanceof ASTNode.FullySpecifiedType && fullType.typeSpecifier.isCustom) {
-      VisitorContext.context.referenceGlobal(<string>fullType.type, ESymbolType.STRUCT);
+      const context = VisitorContext.context;
+      const typeLexeme = fullType.typeSpecifier.lexeme;
+      const role = context.getStructRole(typeLexeme);
+      if (role) {
+        // Global variable of a varying/attribute/mrt struct type (e.g. "Varyings o;").
+        // Don't output as uniform; register the variable in struct var maps instead.
+        const ident = children[1];
+        if (ident instanceof BaseToken) {
+          context.registerStructVar(ident.lexeme, role);
+        }
+        return "";
+      }
+      context.referenceGlobal(<string>fullType.type, ESymbolType.STRUCT);
     }
     return `uniform ${this.defaultCodeGen(children)}`;
   }

--- a/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
+++ b/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
@@ -31,19 +31,48 @@ export abstract class CodeGenVisitor {
 
   protected static _tmpArrayPool = new ReturnableObjectPool(TempArray<string>, 10);
 
+  private static readonly _memberAccessReg = /\b(\w+)\.(\w+)\b/g;
+
   defaultCodeGen(children: NodeChild[]) {
     const pool = CodeGenVisitor._tmpArrayPool;
     let ret = pool.get();
     ret.dispose();
     for (const child of children) {
       if (child instanceof BaseToken) {
-        ret.array.push(child.lexeme);
+        if (child.type === Keyword.MACRO_DEFINE_EXPRESSION) {
+          ret.array.push(this._transformMacroDefineValue(child.lexeme));
+        } else {
+          ret.array.push(child.lexeme);
+        }
       } else {
         ret.array.push(child.codeGen(this));
       }
     }
     pool.return(ret);
     return ret.array.join(" ");
+  }
+
+  protected _transformMacroDefineValue(lexeme: string): string {
+    const context = VisitorContext.context;
+    const structVarMap = context._structVarMap;
+    if (!structVarMap) return lexeme;
+
+    const spaceIdx = lexeme.indexOf(" ");
+    if (spaceIdx === -1) return lexeme;
+
+    const macroName = lexeme.substring(0, spaceIdx);
+    let value = lexeme.substring(spaceIdx);
+
+    const reg = CodeGenVisitor._memberAccessReg;
+    reg.lastIndex = 0;
+    value = value.replace(reg, (match, varName, propName) => {
+      const role = structVarMap[varName];
+      if (!role) return match;
+      context.referenceStructPropByName(role, propName);
+      return propName;
+    });
+
+    return macroName + value;
   }
 
   visitPostfixExpression(node: ASTNode.PostfixExpression): string {
@@ -351,11 +380,81 @@ export abstract class CodeGenVisitor {
     const fnName = fnNode.protoType.ident.lexeme;
     const context = VisitorContext.context;
 
+    this._collectStructVars(fnNode, context);
+
     if (fnName == context.stageEntry) {
       const statements = fnNode.statements.codeGen(this);
       return `void main() ${statements}`;
     } else {
       return this.defaultCodeGen(fnNode.children);
+    }
+  }
+
+  private _collectStructVars(fnNode: ASTNode.FunctionDefinition, context: VisitorContext): void {
+    const map = context._structVarMap;
+    // Clear previous function's mappings
+    for (const key in map) delete map[key];
+
+    // Collect from function parameters
+    const paramList = fnNode.protoType.parameterList;
+    if (paramList) {
+      for (const param of paramList) {
+        if (param.ident && param.typeInfo && typeof param.typeInfo.type === "string") {
+          const role = context.getStructRole(param.typeInfo.typeLexeme);
+          if (role) map[param.ident.lexeme] = role;
+        }
+      }
+    }
+
+    // Collect from local variable declarations in function body
+    this._collectStructVarsFromNode(fnNode.statements, context, map);
+  }
+
+  private _collectStructVarsFromNode(
+    node: TreeNode,
+    context: VisitorContext,
+    map: Record<string, "varying" | "attribute" | "mrt">
+  ): void {
+    const children = node.children;
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child instanceof ASTNode.InitDeclaratorList) {
+        const typeLexeme = child.typeInfo?.typeLexeme;
+        if (typeLexeme) {
+          const role = context.getStructRole(typeLexeme);
+          if (role) {
+            // Extract variable name from SingleDeclaration or comma-separated identifiers
+            this._extractVarNamesFromInitDeclaratorList(child, map, role);
+          }
+        }
+      } else if (child instanceof TreeNode) {
+        this._collectStructVarsFromNode(child, context, map);
+      }
+    }
+  }
+
+  private _extractVarNamesFromInitDeclaratorList(
+    node: ASTNode.InitDeclaratorList,
+    map: Record<string, "varying" | "attribute" | "mrt">,
+    role: "varying" | "attribute" | "mrt"
+  ): void {
+    const children = node.children;
+    if (children.length === 1) {
+      // SingleDeclaration: type ident
+      const singleDecl = children[0] as ASTNode.SingleDeclaration;
+      const identChildren = singleDecl.children;
+      if (identChildren.length >= 2 && identChildren[1] instanceof BaseToken) {
+        map[identChildren[1].lexeme] = role;
+      }
+    } else if (children.length >= 3) {
+      // InitDeclaratorList , ident ...
+      const initDeclList = children[0];
+      if (initDeclList instanceof ASTNode.InitDeclaratorList) {
+        this._extractVarNamesFromInitDeclaratorList(initDeclList, map, role);
+      }
+      if (children[2] instanceof BaseToken) {
+        map[children[2].lexeme] = role;
+      }
     }
   }
 

--- a/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
+++ b/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
@@ -31,7 +31,7 @@ export abstract class CodeGenVisitor {
 
   protected static _tmpArrayPool = new ReturnableObjectPool(TempArray<string>, 10);
 
-  private static readonly _memberAccessReg = /\b(\w+)\.(\w+)\b/g;
+  protected static readonly _memberAccessReg = /\b(\w+)\.(\w+)\b/g;
 
   defaultCodeGen(children: NodeChild[]) {
     const pool = CodeGenVisitor._tmpArrayPool;
@@ -52,9 +52,12 @@ export abstract class CodeGenVisitor {
     return ret.array.join(" ");
   }
 
-  protected _transformMacroDefineValue(lexeme: string): string {
+  protected _transformMacroDefineValue(
+    lexeme: string,
+    overrideMap?: Record<string, "varying" | "attribute" | "mrt">
+  ): string {
     const context = VisitorContext.context;
-    const structVarMap = context._structVarMap;
+    const structVarMap = overrideMap ?? context._structVarMap;
     if (!structVarMap) return lexeme;
 
     const spaceIdx = lexeme.indexOf(" ");
@@ -433,7 +436,7 @@ export abstract class CodeGenVisitor {
     }
   }
 
-  private _extractVarNamesFromInitDeclaratorList(
+  protected _extractVarNamesFromInitDeclaratorList(
     node: ASTNode.InitDeclaratorList,
     map: Record<string, "varying" | "attribute" | "mrt">,
     role: "varying" | "attribute" | "mrt"

--- a/packages/shader-lab/src/codeGen/GLESVisitor.ts
+++ b/packages/shader-lab/src/codeGen/GLESVisitor.ts
@@ -5,6 +5,7 @@ import { Keyword } from "../common/enums/Keyword";
 import { ASTNode, TreeNode } from "../parser/AST";
 import { ShaderData } from "../parser/ShaderInfo";
 import { ESymbolType, FnSymbol, StructSymbol, SymbolInfo } from "../parser/symbolTable";
+import { NodeChild } from "../parser/types";
 import { CodeGenVisitor } from "./CodeGenVisitor";
 import { ICodeSegment } from "./types";
 import { VisitorContext } from "./VisitorContext";
@@ -37,9 +38,14 @@ export abstract class GLESVisitor extends CodeGenVisitor {
     this.reset();
 
     const shaderData = node.shaderData;
-    VisitorContext.context._passSymbolTable = shaderData.symbolTable;
+    const context = VisitorContext.context;
+    context._passSymbolTable = shaderData.symbolTable;
 
     const outerGlobalMacroDeclarations = shaderData.getOuterGlobalMacroDeclarations();
+
+    // Build combined _globalStructVarMap from both entry functions before per-stage processing.
+    // This must happen here because vertex runs first and doesn't yet know fragment's variables.
+    this._buildGlobalStructVarMap(vertexEntry, fragmentEntry, shaderData, context);
 
     return {
       vertex: this._vertexMain(vertexEntry, shaderData, outerGlobalMacroDeclarations),
@@ -109,6 +115,9 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       }
     });
 
+    // Pre-register global #define member access references for this stage
+    this._registerGlobalMacroReferences(outerGlobalMacroDeclarations, context);
+
     const globalCodeArray = this._globalCodeArray;
     VisitorContext.context.referenceGlobal(entry, ESymbolType.FN);
 
@@ -173,6 +182,9 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       }
     });
 
+    // Pre-register global #define member access references for this stage
+    this._registerGlobalMacroReferences(outerGlobalMacroStatements, context);
+
     const globalCodeArray = this._globalCodeArray;
     VisitorContext.context.referenceGlobal(entry, ESymbolType.FN);
 
@@ -191,6 +203,127 @@ export abstract class GLESVisitor extends CodeGenVisitor {
     this.reset();
 
     return globalCode;
+  }
+
+  /**
+   * Build _globalStructVarMap from both entry functions before per-stage processing.
+   * Classifies struct types by their position in function signatures:
+   * - vertex param[0] → attribute, vertex return type → varying
+   * - fragment param[0] → varying, fragment return type → mrt
+   */
+  private _buildGlobalStructVarMap(
+    vertexEntry: string,
+    fragmentEntry: string,
+    data: ShaderData,
+    context: VisitorContext
+  ): void {
+    const map = context._globalStructVarMap;
+    const lookupSymbol = GLESVisitor._lookupSymbol;
+    const { symbolTable } = data;
+
+    // Map struct type names to roles based on function signature positions
+    const structTypeRoles: Record<string, "varying" | "attribute" | "mrt"> = Object.create(null);
+
+    // Vertex entry: param[0] type → attribute, return type → varying
+    lookupSymbol.set(vertexEntry, ESymbolType.FN);
+    const vertexFns = <FnSymbol[]>symbolTable.getSymbols(lookupSymbol, true, []);
+    for (const fn of vertexFns) {
+      const proto = fn.astNode.protoType;
+      const param0 = proto.parameterList?.[0];
+      if (param0 && typeof param0.typeInfo.type === "string") {
+        structTypeRoles[param0.typeInfo.typeLexeme] = "attribute";
+      }
+      if (typeof proto.returnType.type === "string") {
+        structTypeRoles[<string>proto.returnType.type] = "varying";
+      }
+    }
+
+    // Fragment entry: param[0] type → varying, return type → mrt
+    lookupSymbol.set(fragmentEntry, ESymbolType.FN);
+    const fragmentFns = <FnSymbol[]>symbolTable.getSymbols(lookupSymbol, true, []);
+    for (const fn of fragmentFns) {
+      const proto = fn.astNode.protoType;
+      const param0 = proto.parameterList?.[0];
+      if (param0 && typeof param0.typeInfo.type === "string") {
+        structTypeRoles[param0.typeInfo.typeLexeme] = "varying";
+      }
+      if (typeof proto.returnType.type === "string") {
+        structTypeRoles[<string>proto.returnType.type] = "mrt";
+      }
+    }
+
+    // Scan all entry functions' params and local vars, classify by structTypeRoles
+    for (const fn of [...vertexFns, ...fragmentFns]) {
+      const fnNode = fn.astNode;
+      const paramList = fnNode.protoType.parameterList;
+      if (paramList) {
+        for (const param of paramList) {
+          if (param.ident && param.typeInfo && typeof param.typeInfo.type === "string") {
+            const role = structTypeRoles[param.typeInfo.typeLexeme];
+            if (role) map[param.ident.lexeme] = role;
+          }
+        }
+      }
+      this._collectStructVarsFromBody(fnNode.statements, structTypeRoles, map);
+    }
+  }
+
+  private _collectStructVarsFromBody(
+    node: TreeNode,
+    structTypeRoles: Record<string, "varying" | "attribute" | "mrt">,
+    map: Record<string, "varying" | "attribute" | "mrt">
+  ): void {
+    const children = node.children;
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child instanceof ASTNode.InitDeclaratorList) {
+        const typeLexeme = child.typeInfo?.typeLexeme;
+        if (typeLexeme) {
+          const role = structTypeRoles[typeLexeme];
+          if (role) {
+            this._extractVarNamesFromInitDeclaratorList(child, map, role);
+          }
+        }
+      } else if (child instanceof TreeNode) {
+        this._collectStructVarsFromBody(child, structTypeRoles, map);
+      }
+    }
+  }
+
+  /**
+   * Pre-register attribute/varying/mrt references from global #define member access patterns,
+   * so that declarations are emitted by _getCustomStruct for the current stage.
+   */
+  private _registerGlobalMacroReferences(globalMacros: ASTNode.GlobalDeclaration[], context: VisitorContext): void {
+    const map = context._globalStructVarMap;
+    if (!Object.keys(map).length) return;
+    const reg = CodeGenVisitor._memberAccessReg;
+    for (const macro of globalMacros) {
+      this._scanMacroMemberAccess(macro.children, reg, map, context);
+    }
+  }
+
+  private _scanMacroMemberAccess(
+    children: NodeChild[],
+    reg: RegExp,
+    map: Record<string, "varying" | "attribute" | "mrt">,
+    context: VisitorContext
+  ): void {
+    for (const child of children) {
+      if (child instanceof BaseToken && child.type === Keyword.MACRO_DEFINE_EXPRESSION) {
+        const spaceIdx = child.lexeme.indexOf(" ");
+        if (spaceIdx === -1) continue;
+        const value = child.lexeme.substring(spaceIdx);
+        reg.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = reg.exec(value)) !== null) {
+          const role = map[match[1]];
+          if (role) context.referenceStructPropByName(role, match[2]);
+        }
+      } else if (child instanceof TreeNode) {
+        this._scanMacroMemberAccess(child.children, reg, map, context);
+      }
+    }
   }
 
   private _getGlobalSymbol(out: ICodeSegment[]): void {
@@ -233,6 +366,7 @@ export abstract class GLESVisitor extends CodeGenVisitor {
 
   private _getGlobalMacroDeclarations(macros: ASTNode.GlobalDeclaration[], out: ICodeSegment[]): void {
     const context = VisitorContext.context;
+    const globalMap = context._globalStructVarMap;
     const referencedGlobals = context._referencedGlobals;
     const referencedGlobalMacroASTs = context._referencedGlobalMacroASTs;
     referencedGlobalMacroASTs.length = 0;
@@ -256,7 +390,7 @@ export abstract class GLESVisitor extends CodeGenVisitor {
             text:
               item instanceof BaseToken
                 ? item.type === Keyword.MACRO_DEFINE_EXPRESSION
-                  ? this._transformMacroDefineValue(item.lexeme)
+                  ? this._transformMacroDefineValue(item.lexeme, globalMap)
                   : item.lexeme
                 : item.codeGen(this),
             index: item.location.start.index
@@ -269,6 +403,8 @@ export abstract class GLESVisitor extends CodeGenVisitor {
           .sort((a, b) => a.index - b.index)
           .map((item) => item.text)
           .join("\n");
+      } else if (child instanceof BaseToken && child.type === Keyword.MACRO_DEFINE_EXPRESSION) {
+        text = this._transformMacroDefineValue(child.lexeme, globalMap);
       } else {
         text = macro.codeGen(this);
       }

--- a/packages/shader-lab/src/codeGen/GLESVisitor.ts
+++ b/packages/shader-lab/src/codeGen/GLESVisitor.ts
@@ -45,7 +45,7 @@ export abstract class GLESVisitor extends CodeGenVisitor {
 
     // Build combined _globalStructVarMap from both entry functions before per-stage processing.
     // This must happen here because vertex runs first and doesn't yet know fragment's variables.
-    this._buildGlobalStructVarMap(vertexEntry, fragmentEntry, shaderData, context);
+    this._buildGlobalStructVarMap(vertexEntry, fragmentEntry, shaderData, outerGlobalMacroDeclarations, context);
 
     return {
       vertex: this._vertexMain(vertexEntry, shaderData, outerGlobalMacroDeclarations),
@@ -215,6 +215,7 @@ export abstract class GLESVisitor extends CodeGenVisitor {
     vertexEntry: string,
     fragmentEntry: string,
     data: ShaderData,
+    globalMacros: ASTNode.GlobalDeclaration[],
     context: VisitorContext
   ): void {
     const map = context._globalStructVarMap;
@@ -266,6 +267,33 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       }
       this._collectStructVarsFromBody(fnNode.statements, structTypeRoles, map);
     }
+
+    // Also scan global macros for root variable names that might be global struct variables.
+    // e.g. #define VSOutput_worldPos o.v_worldPos → root "o" → look up in symbol table
+    let hasRoles = false;
+    for (const _ in structTypeRoles) {
+      hasRoles = true;
+      break;
+    }
+    if (hasRoles) {
+      const checked = new Set<string>();
+      const symOut: SymbolInfo[] = [];
+      this._forEachMacroMemberAccess(globalMacros, (rootName) => {
+        if (map[rootName] || checked.has(rootName)) return;
+        checked.add(rootName);
+        lookupSymbol.set(rootName, ESymbolType.VAR);
+        symbolTable.getSymbols(lookupSymbol, true, symOut);
+        for (const sym of symOut) {
+          if (sym.dataType) {
+            const role = structTypeRoles[sym.dataType.typeLexeme];
+            if (role) {
+              map[rootName] = role;
+              break;
+            }
+          }
+        }
+      });
+    }
   }
 
   private _collectStructVarsFromBody(
@@ -296,18 +324,36 @@ export abstract class GLESVisitor extends CodeGenVisitor {
    */
   private _registerGlobalMacroReferences(globalMacros: ASTNode.GlobalDeclaration[], context: VisitorContext): void {
     const map = context._globalStructVarMap;
-    if (!Object.keys(map).length) return;
+    let hasEntries = false;
+    for (const _ in map) {
+      hasEntries = true;
+      break;
+    }
+    if (!hasEntries) return;
+    this._forEachMacroMemberAccess(globalMacros, (rootName, propName) => {
+      const role = map[rootName];
+      if (role) context.referenceStructPropByName(role, propName);
+    });
+  }
+
+  /**
+   * Traverse global macro declarations, extracting member access patterns (e.g. "o.v_uv")
+   * and invoking the callback with (rootName, propName) for each match.
+   */
+  private _forEachMacroMemberAccess(
+    macros: ASTNode.GlobalDeclaration[],
+    callback: (rootName: string, propName: string) => void
+  ): void {
     const reg = CodeGenVisitor._memberAccessReg;
-    for (const macro of globalMacros) {
-      this._scanMacroMemberAccess(macro.children, reg, map, context);
+    for (const macro of macros) {
+      this._walkMacroChildren(macro.children, reg, callback);
     }
   }
 
-  private _scanMacroMemberAccess(
+  private _walkMacroChildren(
     children: NodeChild[],
     reg: RegExp,
-    map: Record<string, "varying" | "attribute" | "mrt">,
-    context: VisitorContext
+    callback: (rootName: string, propName: string) => void
   ): void {
     for (const child of children) {
       if (child instanceof BaseToken && child.type === Keyword.MACRO_DEFINE_EXPRESSION) {
@@ -317,19 +363,20 @@ export abstract class GLESVisitor extends CodeGenVisitor {
         reg.lastIndex = 0;
         let match: RegExpExecArray | null;
         while ((match = reg.exec(value)) !== null) {
-          const role = map[match[1]];
-          if (role) context.referenceStructPropByName(role, match[2]);
+          callback(match[1], match[2]);
         }
       } else if (child instanceof TreeNode) {
-        this._scanMacroMemberAccess(child.children, reg, map, context);
+        this._walkMacroChildren(child.children, reg, callback);
       }
     }
   }
 
   private _getGlobalSymbol(out: ICodeSegment[]): void {
-    const { _referencedGlobals } = VisitorContext.context;
+    const context = VisitorContext.context;
+    const { _referencedGlobals } = context;
 
-    const lastLength = Object.keys(_referencedGlobals).length;
+    let lastLength = 0;
+    for (const _ in _referencedGlobals) lastLength++;
     if (lastLength === 0) return;
 
     for (const ident in _referencedGlobals) {
@@ -339,7 +386,9 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       const symbols = _referencedGlobals[ident];
       for (let i = 0; i < symbols.length; i++) {
         const sm = symbols[i];
-        const text = sm.astNode.codeGen(this) + (sm.type === ESymbolType.VAR ? ";" : "");
+        const codeGenResult = sm.astNode.codeGen(this);
+        if (!codeGenResult) continue;
+        const text = codeGenResult + (sm.type === ESymbolType.VAR ? ";" : "");
         if (!sm.isInMacroBranch) {
           out.push({
             text,
@@ -349,7 +398,9 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       }
     }
 
-    if (Object.keys(_referencedGlobals).length !== lastLength) {
+    let newLength = 0;
+    for (const _ in _referencedGlobals) newLength++;
+    if (newLength !== lastLength) {
       this._getGlobalSymbol(out);
     }
   }

--- a/packages/shader-lab/src/codeGen/GLESVisitor.ts
+++ b/packages/shader-lab/src/codeGen/GLESVisitor.ts
@@ -253,7 +253,12 @@ export abstract class GLESVisitor extends CodeGenVisitor {
         let result: ICodeSegment[] = [];
         result.push(
           ...macro.macroExpressions.map((item) => ({
-            text: item instanceof BaseToken ? item.lexeme : item.codeGen(this),
+            text:
+              item instanceof BaseToken
+                ? item.type === Keyword.MACRO_DEFINE_EXPRESSION
+                  ? this._transformMacroDefineValue(item.lexeme)
+                  : item.lexeme
+                : item.codeGen(this),
             index: item.location.start.index
           }))
         );

--- a/packages/shader-lab/src/codeGen/VisitorContext.ts
+++ b/packages/shader-lab/src/codeGen/VisitorContext.ts
@@ -38,6 +38,8 @@ export class VisitorContext {
   _referencedMRTList: Record<string, StructProp[]>;
   _referencedGlobals: Record<string, SymbolInfo[]>;
   _referencedGlobalMacroASTs: TreeNode[] = [];
+  /** Maps variable names to their struct role for #define value transformation. */
+  _structVarMap: Record<string, "varying" | "attribute" | "mrt">;
 
   _passSymbolTable: SymbolTable<SymbolInfo>;
 
@@ -56,6 +58,28 @@ export class VisitorContext {
     this._referencedMRTList = Object.create(null);
     this._referencedGlobals = Object.create(null);
     this._referencedGlobalMacroASTs.length = 0;
+    this._structVarMap = Object.create(null);
+  }
+
+  getStructRole(typeLexeme: string): "varying" | "attribute" | "mrt" | undefined {
+    if (this.isAttributeStruct(typeLexeme)) return "attribute";
+    if (this.isVaryingStruct(typeLexeme)) return "varying";
+    if (this.isMRTStruct(typeLexeme)) return "mrt";
+  }
+
+  referenceStructPropByName(role: "varying" | "attribute" | "mrt", propName: string): void {
+    const list = role === "varying" ? this.varyingList : role === "attribute" ? this.attributeList : this.mrtList;
+    const refList =
+      role === "varying"
+        ? this._referencedVaryingList
+        : role === "attribute"
+          ? this._referencedAttributeList
+          : this._referencedMRTList;
+    if (refList[propName]) return;
+    const props = list.filter((item) => item.ident.lexeme === propName);
+    if (props.length) {
+      refList[propName] = props;
+    }
   }
 
   isAttributeStruct(type: string) {

--- a/packages/shader-lab/src/codeGen/VisitorContext.ts
+++ b/packages/shader-lab/src/codeGen/VisitorContext.ts
@@ -72,6 +72,11 @@ export class VisitorContext {
     if (this.isMRTStruct(typeLexeme)) return "mrt";
   }
 
+  registerStructVar(varName: string, role: "varying" | "attribute" | "mrt"): void {
+    this._structVarMap[varName] = role;
+    this._globalStructVarMap[varName] = role;
+  }
+
   referenceStructPropByName(role: "varying" | "attribute" | "mrt", propName: string): void {
     const list = role === "varying" ? this.varyingList : role === "attribute" ? this.attributeList : this.mrtList;
     const refList =

--- a/packages/shader-lab/src/codeGen/VisitorContext.ts
+++ b/packages/shader-lab/src/codeGen/VisitorContext.ts
@@ -38,8 +38,10 @@ export class VisitorContext {
   _referencedMRTList: Record<string, StructProp[]>;
   _referencedGlobals: Record<string, SymbolInfo[]>;
   _referencedGlobalMacroASTs: TreeNode[] = [];
-  /** Maps variable names to their struct role for #define value transformation. */
+  /** Maps variable names to their struct role for function-body #define value transformation. */
   _structVarMap: Record<string, "varying" | "attribute" | "mrt">;
+  /** Combined mapping from all entry functions for global #define transformation. */
+  _globalStructVarMap: Record<string, "varying" | "attribute" | "mrt">;
 
   _passSymbolTable: SymbolTable<SymbolInfo>;
 
@@ -59,6 +61,9 @@ export class VisitorContext {
     this._referencedGlobals = Object.create(null);
     this._referencedGlobalMacroASTs.length = 0;
     this._structVarMap = Object.create(null);
+    if (resetAll) {
+      this._globalStructVarMap = Object.create(null);
+    }
   }
 
   getStructRole(typeLexeme: string): "varying" | "attribute" | "mrt" | undefined {

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -4,7 +4,7 @@ import { ETokenType, GalaceanDataType, ShaderRange, TokenType, TypeAny } from ".
 import { BaseToken } from "../common/BaseToken";
 import { Keyword } from "../common/enums/Keyword";
 import { ParserUtils } from "../ParserUtils";
-import { Preprocessor } from "../Preprocessor";
+import { MacroValueType, Preprocessor } from "../Preprocessor";
 import { ShaderLabUtils } from "../ShaderLabUtils";
 import { BuiltinFunction, BuiltinVariable, NonGenericGalaceanType } from "./builtin";
 import { NoneTerminal } from "./GrammarSymbol";
@@ -1424,7 +1424,12 @@ export namespace ASTNode {
           sa.reportWarning(this.location, `Please sure the identifier "${name}" will be declared before used.`);
           // #endif
         } else {
-          this.typeInfo = symbols[0].dataType?.type;
+          // For member access macros (e.g. #define FRAG_UV v.v_uv), the referenceSymbolNames
+          // contains the root variable ("v") whose type is the struct ("Varyings"), not the
+          // member type ("vec2"). Skip type inference in this case — keep TypeAny.
+          if (child instanceof BaseToken || !this._isMemberAccessMacro(sa, child)) {
+            this.typeInfo = symbols[0].dataType?.type;
+          }
           const currentScopeSymbol = <VarSymbol | FnSymbol>sa.symbolTableStack.scope.getSymbol(lookupSymbol, true);
           if (currentScopeSymbol) {
             if (
@@ -1441,6 +1446,12 @@ export namespace ASTNode {
           }
         }
       }
+    }
+
+    private _isMemberAccessMacro(sa: SemanticAnalyzer, child: MacroCallSymbol | MacroCallFunction): boolean {
+      const macroName = child.macroName;
+      const infos = sa.macroDefineList[macroName];
+      return infos?.some((info) => info.valueType === MacroValueType.MemberAccess) ?? false;
     }
 
     override codeGen(visitor: CodeGenVisitor): string {

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -291,4 +291,62 @@ describe("ShaderLab", async () => {
     expect(vertex).to.equal(expectedVert);
     expect(fragment).to.equal(expectedFrag);
   });
+
+  it("macro-member-access-builtin-arg (Cocos FSInput pattern: member access macro as builtin fn arg)", async () => {
+    const shaderSource = await readFile("./shaders/macro-member-access-builtin-arg.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+
+    // Also verify verbose mode (semantic analysis) succeeds — this was the original bug:
+    // member access macros like #define FSInput_worldNormal v.v_normal.xyz resolved to
+    // struct type "Varyings" instead of TypeAny, causing builtin overload matching to fail.
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+
+    expect(vertex).to.be.a("string").and.not.empty;
+    expect(fragment).to.be.a("string").and.not.empty;
+
+    // Verify key builtins are present in output (macros expanded correctly)
+    expect(fragment).to.contain("normalize");
+    expect(fragment).to.contain("dot");
+    expect(fragment).to.contain("texture2D");
+  });
+
+  it("global-varying-var (Cocos VSOutput pattern: global Varyings var with #define macros)", async () => {
+    const shaderSource = await readFile("./shaders/global-varying-var.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+
+    // Verify verbose mode: global "Varyings o;" should not produce "uniform Varyings o;"
+    // and should not duplicate varying declarations.
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+
+    expect(vertex).to.be.a("string").and.not.empty;
+    expect(fragment).to.be.a("string").and.not.empty;
+
+    // No "uniform Varyings o;" in output
+    expect(vertex).to.not.contain("uniform Varyings");
+    expect(fragment).to.not.contain("uniform Varyings");
+
+    // Macros should be transformed: "o.v_worldPos" → "v_worldPos"
+    expect(vertex).to.contain("#define VSOutput_worldPos v_worldPos");
+    expect(vertex).to.contain("#define VSOutput_worldNormal v_normal.xyz");
+
+    // No duplicate varying declarations
+    const varyingMatches = vertex.match(/varying vec3 v_worldPos/g);
+    expect(varyingMatches).to.have.lengthOf(1);
+  });
 });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -252,61 +252,43 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabRelease);
   });
 
-  it("define-struct-access (#define value with struct member access)", async () => {
-    const shaderSource = await readFile("./shaders/define-struct-access.shader");
-
-    // Validate GLSL compilation
+  it("define-struct-access-global (global #define with struct member access)", async () => {
+    const shaderSource = await readFile("./shaders/define-struct-access-global.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);
 
-    // Verify CodeGen transformation results
     const shader = shaderLabVerbose._parseShaderSource(shaderSource);
     const passSource = shader.subShaders[0].passes[0];
-    const shaderProgram = shaderLabVerbose._parseShaderPass(
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
       passSource.contents,
       passSource.vertexEntry,
       passSource.fragmentEntry,
-      0, // GLSLES100
+      0,
       ""
-    );
+    )!;
 
-    const { vertex, fragment } = shaderProgram!;
+    const expectedVert = await readFile("./expected/define-struct-access-global.vert.glsl");
+    const expectedFrag = await readFile("./expected/define-struct-access-global.frag.glsl");
+    expect(vertex).to.equal(expectedVert);
+    expect(fragment).to.equal(expectedFrag);
+  });
 
-    // ---- #define transformation ----
-    // Vertex: struct member access should be stripped to property name
-    expect(vertex).to.include("#define ATTR_POS POSITION");
-    expect(vertex).not.to.include("#define ATTR_POS attr.POSITION");
-    expect(vertex).to.include("#define VARYING_UV v_uv");
-    expect(vertex).not.to.include("#define VARYING_UV o.v_uv");
-    expect(vertex).to.include("#define VARYING_NORMAL v_normal");
-    expect(vertex).not.to.include("#define VARYING_NORMAL o.v_normal");
+  it("define-struct-access (function-body #define with struct member access)", async () => {
+    const shaderSource = await readFile("./shaders/define-struct-access.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
 
-    // Fragment: same transformation
-    expect(fragment).to.include("#define FRAG_UV v_uv");
-    expect(fragment).not.to.include("#define FRAG_UV v.v_uv");
-    expect(fragment).to.include("#define FRAG_NORMAL v_normal");
-    expect(fragment).not.to.include("#define FRAG_NORMAL v.v_normal");
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
 
-    // ---- Declarations emitted from #define references ----
-    expect(vertex).to.match(/attribute\s+vec4\s+POSITION/);
-    expect(vertex).to.match(/attribute\s+vec2\s+TEXCOORD_0/);
-    expect(vertex).to.match(/varying\s+vec2\s+v_uv/);
-    expect(vertex).to.match(/varying\s+vec3\s+v_normal/);
-    expect(fragment).to.match(/varying\s+vec2\s+v_uv/);
-    expect(fragment).to.match(/varying\s+vec3\s+v_normal/);
-
-    // ---- Macro usage in expressions ----
-    // CodeGen outputs spaces between tokens, so use regex for flexible matching.
-
-    // Vertex: ATTR_POS used in multiplication expression
-    expect(vertex).to.match(/renderer_MVPMat\s*\*\s*ATTR_POS/);
-    // Vertex: VARYING_UV used as assignment target (LHS)
-    expect(vertex).to.match(/VARYING_UV\s*=\s*TEXCOORD_0/);
-    // Vertex: VARYING_NORMAL used as assignment target
-    expect(vertex).to.match(/VARYING_NORMAL\s*=\s*vec3/);
-
-    // Fragment: FRAG_NORMAL used as argument in dot() call
-    expect(fragment).to.match(/dot\s*\(\s*FRAG_NORMAL/);
-    // Fragment: FRAG_UV used as argument in texture2D() call
-    expect(fragment).to.match(/texture2D\s*\(\s*u_texture\s*,\s*FRAG_UV\s*\)/);
+    const expectedVert = await readFile("./expected/define-struct-access.vert.glsl");
+    const expectedFrag = await readFile("./expected/define-struct-access.frag.glsl");
+    expect(vertex).to.equal(expectedVert);
+    expect(fragment).to.equal(expectedFrag);
   });
 });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -271,24 +271,42 @@ describe("ShaderLab", async () => {
 
     const { vertex, fragment } = shaderProgram!;
 
-    // Vertex: `#define ATTR_POS attr.POSITION` → `#define ATTR_POS POSITION`
+    // ---- #define transformation ----
+    // Vertex: struct member access should be stripped to property name
     expect(vertex).to.include("#define ATTR_POS POSITION");
     expect(vertex).not.to.include("#define ATTR_POS attr.POSITION");
-
-    // Vertex: `#define VARYING_UV o.v_uv` → `#define VARYING_UV v_uv`
     expect(vertex).to.include("#define VARYING_UV v_uv");
     expect(vertex).not.to.include("#define VARYING_UV o.v_uv");
+    expect(vertex).to.include("#define VARYING_NORMAL v_normal");
+    expect(vertex).not.to.include("#define VARYING_NORMAL o.v_normal");
 
-    // Vertex: varying declaration should be emitted for referenced v_uv
-    expect(vertex).to.match(/varying\s+vec2\s+v_uv/);
-    // Vertex: attribute declaration should be emitted for referenced POSITION
-    expect(vertex).to.match(/attribute\s+vec4\s+POSITION/);
-
-    // Fragment: `#define FRAG_UV v.v_uv` → `#define FRAG_UV v_uv`
+    // Fragment: same transformation
     expect(fragment).to.include("#define FRAG_UV v_uv");
     expect(fragment).not.to.include("#define FRAG_UV v.v_uv");
+    expect(fragment).to.include("#define FRAG_NORMAL v_normal");
+    expect(fragment).not.to.include("#define FRAG_NORMAL v.v_normal");
 
-    // Fragment: varying declaration should be emitted for referenced v_uv
+    // ---- Declarations emitted from #define references ----
+    expect(vertex).to.match(/attribute\s+vec4\s+POSITION/);
+    expect(vertex).to.match(/attribute\s+vec2\s+TEXCOORD_0/);
+    expect(vertex).to.match(/varying\s+vec2\s+v_uv/);
+    expect(vertex).to.match(/varying\s+vec3\s+v_normal/);
     expect(fragment).to.match(/varying\s+vec2\s+v_uv/);
+    expect(fragment).to.match(/varying\s+vec3\s+v_normal/);
+
+    // ---- Macro usage in expressions ----
+    // CodeGen outputs spaces between tokens, so use regex for flexible matching.
+
+    // Vertex: ATTR_POS used in multiplication expression
+    expect(vertex).to.match(/renderer_MVPMat\s*\*\s*ATTR_POS/);
+    // Vertex: VARYING_UV used as assignment target (LHS)
+    expect(vertex).to.match(/VARYING_UV\s*=\s*TEXCOORD_0/);
+    // Vertex: VARYING_NORMAL used as assignment target
+    expect(vertex).to.match(/VARYING_NORMAL\s*=\s*vec3/);
+
+    // Fragment: FRAG_NORMAL used as argument in dot() call
+    expect(fragment).to.match(/dot\s*\(\s*FRAG_NORMAL/);
+    // Fragment: FRAG_UV used as argument in texture2D() call
+    expect(fragment).to.match(/texture2D\s*\(\s*u_texture\s*,\s*FRAG_UV\s*\)/);
   });
 });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -251,4 +251,9 @@ describe("ShaderLab", async () => {
     const shaderSource = await readFile("./shaders/mrt-struct.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);
   });
+
+  it("define-struct-access (#define value with struct member access)", async () => {
+    const shaderSource = await readFile("./shaders/define-struct-access.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+  });
 });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -254,6 +254,41 @@ describe("ShaderLab", async () => {
 
   it("define-struct-access (#define value with struct member access)", async () => {
     const shaderSource = await readFile("./shaders/define-struct-access.shader");
+
+    // Validate GLSL compilation
     glslValidate(engine, shaderSource, shaderLabRelease);
+
+    // Verify CodeGen transformation results
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const shaderProgram = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0, // GLSLES100
+      ""
+    );
+
+    const { vertex, fragment } = shaderProgram!;
+
+    // Vertex: `#define ATTR_POS attr.POSITION` → `#define ATTR_POS POSITION`
+    expect(vertex).to.include("#define ATTR_POS POSITION");
+    expect(vertex).not.to.include("#define ATTR_POS attr.POSITION");
+
+    // Vertex: `#define VARYING_UV o.v_uv` → `#define VARYING_UV v_uv`
+    expect(vertex).to.include("#define VARYING_UV v_uv");
+    expect(vertex).not.to.include("#define VARYING_UV o.v_uv");
+
+    // Vertex: varying declaration should be emitted for referenced v_uv
+    expect(vertex).to.match(/varying\s+vec2\s+v_uv/);
+    // Vertex: attribute declaration should be emitted for referenced POSITION
+    expect(vertex).to.match(/attribute\s+vec4\s+POSITION/);
+
+    // Fragment: `#define FRAG_UV v.v_uv` → `#define FRAG_UV v_uv`
+    expect(fragment).to.include("#define FRAG_UV v_uv");
+    expect(fragment).not.to.include("#define FRAG_UV v.v_uv");
+
+    // Fragment: varying declaration should be emitted for referenced v_uv
+    expect(fragment).to.match(/varying\s+vec2\s+v_uv/);
   });
 });

--- a/tests/src/shader-lab/expected/define-struct-access-global.frag.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access-global.frag.glsl
@@ -1,0 +1,10 @@
+varying vec2 v_uv;
+
+uniform sampler2D u_texture;
+#define ATTR_POS POSITION
+
+#define VARYING_UV v_uv
+
+#define FRAG_UV v_uv
+
+void main() { gl_FragColor = texture2D ( u_texture , FRAG_UV ) ; }

--- a/tests/src/shader-lab/expected/define-struct-access-global.vert.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access-global.vert.glsl
@@ -1,0 +1,16 @@
+uniform mat4 renderer_MVPMat;
+attribute vec4 POSITION;
+attribute vec2 TEXCOORD_0;
+
+varying vec2 v_uv;
+
+#define ATTR_POS POSITION
+
+#define VARYING_UV v_uv
+
+#define FRAG_UV v_uv
+
+void main() { 
+gl_Position = renderer_MVPMat * ATTR_POS ;
+VARYING_UV = TEXCOORD_0 ;
+ }

--- a/tests/src/shader-lab/expected/define-struct-access.frag.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access.frag.glsl
@@ -1,0 +1,11 @@
+varying vec2 v_uv;
+varying vec3 v_normal;
+
+uniform sampler2D u_texture;
+uniform vec3 u_lightDir;
+void main() { #define FRAG_UV v_uv
+
+#define FRAG_NORMAL v_normal
+
+float NdotL = dot ( FRAG_NORMAL , u_lightDir ) ;
+gl_FragColor = texture2D ( u_texture , FRAG_UV ) * NdotL ; }

--- a/tests/src/shader-lab/expected/define-struct-access.vert.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access.vert.glsl
@@ -1,0 +1,18 @@
+uniform mat4 renderer_MVPMat;
+attribute vec4 POSITION;
+attribute vec2 TEXCOORD_0;
+
+varying vec2 v_uv;
+varying vec3 v_normal;
+
+void main() { 
+#define ATTR_POS POSITION
+
+#define VARYING_UV v_uv
+
+#define VARYING_NORMAL v_normal
+
+gl_Position = renderer_MVPMat * ATTR_POS ;
+VARYING_UV = TEXCOORD_0 ;
+VARYING_NORMAL = vec3 ( 0.0 , 1.0 , 0.0 ) ;
+ }

--- a/tests/src/shader-lab/shaders/define-struct-access-global.shader
+++ b/tests/src/shader-lab/shaders/define-struct-access-global.shader
@@ -1,0 +1,31 @@
+Shader "define-struct-access-global-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+
+      // Global #define referencing entry function parameter names
+      #define ATTR_POS attr.POSITION
+      #define VARYING_UV o.v_uv
+      #define FRAG_UV v.v_uv
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        gl_Position = renderer_MVPMat * ATTR_POS;
+        VARYING_UV = attr.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = texture2D(u_texture, FRAG_UV);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-struct-access.shader
+++ b/tests/src/shader-lab/shaders/define-struct-access.shader
@@ -1,0 +1,29 @@
+Shader "define-struct-access-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        #define ATTR_POS attr.POSITION
+        #define VARYING_UV o.v_uv
+        gl_Position = renderer_MVPMat * ATTR_POS;
+        VARYING_UV = attr.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        #define FRAG_UV v.v_uv
+        gl_FragColor = texture(u_texture, FRAG_UV);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-struct-access.shader
+++ b/tests/src/shader-lab/shaders/define-struct-access.shader
@@ -4,25 +4,30 @@ Shader "define-struct-access-test" {
       mat4 renderer_MVPMat;
 
       struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
-      struct Varyings { vec2 v_uv; };
+      struct Varyings { vec2 v_uv; vec3 v_normal; };
 
       VertexShader = vert;
       FragmentShader = frag;
 
       sampler2D u_texture;
+      vec3 u_lightDir;
 
       Varyings vert(Attributes attr) {
         Varyings o;
         #define ATTR_POS attr.POSITION
         #define VARYING_UV o.v_uv
+        #define VARYING_NORMAL o.v_normal
         gl_Position = renderer_MVPMat * ATTR_POS;
         VARYING_UV = attr.TEXCOORD_0;
+        VARYING_NORMAL = vec3(0.0, 1.0, 0.0);
         return o;
       }
 
       void frag(Varyings v) {
         #define FRAG_UV v.v_uv
-        gl_FragColor = texture(u_texture, FRAG_UV);
+        #define FRAG_NORMAL v.v_normal
+        float NdotL = dot(FRAG_NORMAL, u_lightDir);
+        gl_FragColor = texture2D(u_texture, FRAG_UV) * NdotL;
       }
     }
   }

--- a/tests/src/shader-lab/shaders/global-varying-var.shader
+++ b/tests/src/shader-lab/shaders/global-varying-var.shader
@@ -1,0 +1,42 @@
+Shader "global-varying-var-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec3 POSITION; vec3 NORMAL; vec2 TEXCOORD_0; };
+      struct Varyings { vec3 v_worldPos; vec4 v_normal; vec2 v_uv; vec4 v_shadowBiasAndProbeId; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+      vec3 u_lightDir;
+
+      #define VSOutput_worldPos o.v_worldPos
+      #define VSOutput_worldNormal o.v_normal.xyz
+      #define VSOutput_faceSideSign o.v_normal.w
+      #define VSOutput_texcoord o.v_uv
+      #define VSOutput_shadowBias o.v_shadowBiasAndProbeId.xy
+
+      Varyings o;
+
+      Varyings vert(Attributes input) {
+        mat4 matWorld = renderer_MVPMat;
+        vec4 pos = matWorld * vec4(input.POSITION, 1.0);
+        VSOutput_worldPos = pos.xyz;
+        VSOutput_worldNormal = input.NORMAL;
+        VSOutput_faceSideSign = 1.0;
+        VSOutput_texcoord = input.TEXCOORD_0;
+        VSOutput_shadowBias = vec2(0.0, 0.0);
+        gl_Position = pos;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        vec3 N = normalize(v.v_normal.xyz);
+        float NdotL = dot(N, u_lightDir);
+        gl_FragColor = texture2D(u_texture, v.v_uv) * NdotL;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/macro-member-access-builtin-arg.shader
+++ b/tests/src/shader-lab/shaders/macro-member-access-builtin-arg.shader
@@ -1,0 +1,49 @@
+Shader "macro-member-access-builtin-arg-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; vec3 NORMAL; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; vec4 v_normal; vec3 v_worldPos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+      vec3 u_lightDir;
+      vec3 u_cameraPos;
+
+      // Cocos-style FSInput macros: member access used as builtin function args
+      #define FSInput_worldNormal v.v_normal.xyz
+      #define FSInput_faceSideSign v.v_normal.w
+      #define FSInput_worldPos v.v_worldPos
+      #define FSInput_texcoord v.v_uv
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        gl_Position = renderer_MVPMat * attr.POSITION;
+        o.v_uv = attr.TEXCOORD_0;
+        o.v_normal = vec4(attr.NORMAL, 1.0);
+        o.v_worldPos = attr.POSITION.xyz;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        // normalize() with member access macro as arg
+        vec3 N = normalize(FSInput_worldNormal);
+
+        // dot() with member access macro as arg
+        float NdotL = dot(N, u_lightDir);
+
+        // texture2D() with member access macro as arg
+        vec4 albedo = texture2D(u_texture, FSInput_texcoord);
+
+        // mix() with member access macro and scalar macro
+        vec3 viewDir = normalize(u_cameraPos - FSInput_worldPos);
+        float rim = 1.0 - dot(N, viewDir);
+
+        gl_FragColor = albedo * NdotL + vec4(vec3(rim), 0.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Support `#define VAR o.v_uv` style macros: CodeGen now strips struct variable prefix during transformation
- Handle global `#define` with cross-stage struct variable transformation
- Skip type inference for member access macros in semantic analysis (prevents wrong type resolution)
- Handle global struct-typed variable declarations (suppress incorrect `uniform` output)
- Add `MacroValueType.MemberAccess` classification in Preprocessor

## Test plan
- [x] Added `define-struct-access.shader` with expected GLSL output snapshot comparison
- [x] Added `define-struct-access-global.shader` for global define cross-stage test
- [x] Added `macro-member-access-builtin-arg.shader` for Cocos FSInput pattern
- [x] Added `global-varying-var.shader` for Cocos VSOutput pattern
- [x] Verified no duplicate varying declarations and no `uniform Varyings` in output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for shader macro definitions with member-access patterns (e.g., `input.v_uv`, `v.rgb`).

* **Bug Fixes**
  * Improved type inference accuracy for member-access expressions in macro expansions.

* **Tests**
  * Added test cases validating struct member-access patterns in shader definitions and macro expansions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->