### PR TITLE
fix(shader-lab): add missing semicolon in GLES100 fragment return conversion

### DIFF
--- a/packages/shader-lab/src/codeGen/GLES100.ts
+++ b/packages/shader-lab/src/codeGen/GLES100.ts
@@ -47,7 +47,7 @@ export class GLES100Visitor extends GLESVisitor {
         return "";
       }
       const expression = node.children[1] as ASTNode.Expression;
-      return `gl_FragColor = ${expression.codeGen(this)}`;
+      return `gl_FragColor = ${expression.codeGen(this)};`;
     }
     return super.visitJumpStatement(node);
   }

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -251,4 +251,10 @@ describe("ShaderLab", async () => {
     const shaderSource = await readFile("./shaders/mrt-struct.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);
   });
+
+  it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
+    const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
 });

--- a/tests/src/shader-lab/shaders/frag-return-vec4.shader
+++ b/tests/src/shader-lab/shaders/frag-return-vec4.shader
@@ -1,0 +1,41 @@
+Shader "frag-return-vec4-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec3 POSITION; vec3 NORMAL; vec2 TEXCOORD_0; };
+      struct Varyings { vec3 v_worldPos; vec4 v_normal; vec2 v_uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+      vec3 u_lightDir;
+
+      vec3 SRGBToLinear(vec3 gamma) { return gamma * gamma; }
+      vec3 LinearToSRGB(vec3 linear) { return sqrt(linear); }
+
+      vec4 SurfacesFragmentModifyBaseColorAndTransparency(Varyings input) {
+        vec4 color = texture2D(u_texture, input.v_uv);
+        color.rgb = SRGBToLinear(color.rgb);
+        return color;
+      }
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        vec4 pos = renderer_MVPMat * vec4(attr.POSITION, 1.0);
+        o.v_worldPos = pos.xyz;
+        o.v_normal = vec4(attr.NORMAL, 1.0);
+        o.v_uv = attr.TEXCOORD_0;
+        gl_Position = pos;
+        return o;
+      }
+
+      vec4 frag(Varyings input) {
+        vec4 color = SurfacesFragmentModifyBaseColorAndTransparency(input);
+        color.rgb = LinearToSRGB(color.rgb);
+        return color;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fix GLES100 `visitJumpStatement` converting `return expr;` to `gl_FragColor = expr` without trailing semicolon
- Only affects Cocos pattern where fragment entry returns `vec4` instead of `void`

## Test plan
- [x] Added `frag-return-vec4.shader` test case
- [x] Validated in both verbose and release ShaderLab modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fragment shader code generation to ensure proper syntax formatting for return statements.

* **Tests**
  * Added validation test for fragment shaders returning vec4 values, ensuring compatibility with specific shader patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->