### PR TITLE
fix(shader): add missing camera_VPMat declaration in Transform.glsl

### DIFF
--- a/packages/shader/src/shaders/Transform.glsl
+++ b/packages/shader/src/shaders/Transform.glsl
@@ -5,6 +5,7 @@ mat4 renderer_LocalMat;
 mat4 renderer_ModelMat;
 mat4 camera_ViewMat;
 mat4 camera_ProjMat;
+mat4 camera_VPMat;
 mat4 renderer_MVMat;
 mat4 renderer_MVPMat;
 mat4 renderer_NormalMat;


### PR DESCRIPTION
## Summary
- Add `mat4 camera_VPMat;` declaration to `Transform.glsl` shader include

## Test plan
- [x] Declaration-only change, no logic affected