### PR TITLE
feat(particle): add cycles and repeatInterval to Burst

### DIFF
--- a/e2e/case/particleRenderer-burst-cycles.ts
+++ b/e2e/case/particleRenderer-burst-cycles.ts
@@ -1,0 +1,110 @@
+/**
+ * @title Particle Burst Cycles
+ * @category Particle
+ */
+import {
+  AssetType,
+  BlendMode,
+  Burst,
+  Camera,
+  Color,
+  Engine,
+  Entity,
+  ParticleCompositeCurve,
+  ParticleCurveMode,
+  ParticleGradientMode,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleSimulationSpace,
+  SphereShape,
+  Texture2D,
+  WebGLEngine
+} from "@galacean/engine";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+WebGLEngine.create({
+  canvas: "canvas"
+}).then((engine) => {
+  engine.canvas.resizeByClientSize();
+
+  const scene = engine.sceneManager.activeScene;
+  const rootEntity = scene.createRootEntity();
+  scene.background.solidColor = new Color(0, 0, 0, 1);
+
+  const cameraEntity = rootEntity.createChild("camera");
+  cameraEntity.transform.setPosition(0, 2, 18);
+  const camera = cameraEntity.addComponent(Camera);
+  camera.fieldOfView = 60;
+
+  engine.resourceManager
+    .load({
+      url: "https://mdn.alipayobjects.com/huamei_b4l2if/afts/img/A*JPsCSK5LtYkAAAAAAAAAAAAADil6AQ/original",
+      type: AssetType.Texture
+    })
+    .then((texture) => {
+      createBurstCyclesParticle(engine, rootEntity, <Texture2D>texture);
+      updateForE2E(engine, 50);
+      initScreenshot(engine, camera);
+    });
+});
+
+function createBurstCyclesParticle(engine: Engine, rootEntity: Entity, texture: Texture2D): void {
+  const particleEntity = new Entity(engine, "BurstCycles");
+  particleEntity.transform.setPosition(0, 0, 0);
+
+  const particleRenderer = particleEntity.addComponent(ParticleRenderer);
+  const generator = particleRenderer.generator;
+  generator.useAutoRandomSeed = false;
+
+  const material = new ParticleMaterial(engine);
+  material.baseColor = new Color(0.4, 0.8, 1.0, 1.0);
+  material.blendMode = BlendMode.Additive;
+  material.baseTexture = texture;
+  particleRenderer.setMaterial(material);
+
+  const { main, emission, colorOverLifetime, sizeOverLifetime } = generator;
+
+  // Main
+  main.duration = 3;
+  main.isLoop = true;
+  main.startLifetime.constantMin = 1;
+  main.startLifetime.constantMax = 2;
+  main.startLifetime.mode = ParticleCurveMode.TwoConstants;
+  main.startSpeed.constantMin = 2;
+  main.startSpeed.constantMax = 5;
+  main.startSpeed.mode = ParticleCurveMode.TwoConstants;
+  main.startSize.constantMin = 0.1;
+  main.startSize.constantMax = 0.3;
+  main.startSize.mode = ParticleCurveMode.TwoConstants;
+  main.gravityModifier.constant = -0.5;
+  main.simulationSpace = ParticleSimulationSpace.World;
+  main.maxParticles = 500;
+
+  // Emission with burst cycles
+  emission.rateOverTime.constant = 0;
+
+  // Burst at t=0, 20 particles, repeats 4 times every 0.3s -> fires at 0, 0.3, 0.6, 0.9
+  emission.addBurst(new Burst(0, new ParticleCompositeCurve(20), 4, 0.3));
+
+  const sphereShape = new SphereShape();
+  sphereShape.radius = 0.5;
+  emission.shape = sphereShape;
+
+  // Color over lifetime
+  colorOverLifetime.enabled = true;
+  colorOverLifetime.color.mode = ParticleGradientMode.Gradient;
+  const gradient = colorOverLifetime.color.gradient;
+  gradient.alphaKeys[0].alpha = 0;
+  gradient.alphaKeys[1].alpha = 0;
+  gradient.addAlphaKey(0.1, 1.0);
+  gradient.addAlphaKey(0.7, 1.0);
+
+  // Size over lifetime
+  sizeOverLifetime.enabled = true;
+  sizeOverLifetime.size.mode = ParticleCurveMode.Curve;
+  const curve = sizeOverLifetime.size.curve;
+  curve.keys[0].value = 1;
+  curve.keys[1].value = 0;
+
+  rootEntity.addChild(particleEntity);
+}

--- a/e2e/case/particleRenderer-fire.ts
+++ b/e2e/case/particleRenderer-fire.ts
@@ -44,7 +44,7 @@ WebGLEngine.create({
 
   // Create camera
   const cameraEntity = rootEntity.createChild("camera_entity");
-  cameraEntity.transform.position = new Vector3(-10, 1, 3);// -10 can test bounds transform
+  cameraEntity.transform.position = new Vector3(-10, 1, 3); // -10 can test bounds transform
   const camera = cameraEntity.addComponent(Camera);
   camera.fieldOfView = 60;
 
@@ -357,7 +357,7 @@ function createFireEmbersParticle(fireEntity: Entity, texture: Texture2D): void 
 
   // Emission module
   emission.rateOverTime.constant = 65;
-  emission.addBurst(new Burst(0, new ParticleCompositeCurve(15)));
+  emission.addBurst(new Burst(0, new ParticleCompositeCurve(15), 1, 0.01));
 
   const sphereShape = new SphereShape();
   sphereShape.radius = 0.01;

--- a/e2e/case/particleRenderer-limitVelocity.ts
+++ b/e2e/case/particleRenderer-limitVelocity.ts
@@ -99,7 +99,7 @@ function createParticle(engine: Engine, rootEntity: Entity, texture: Texture2D):
 
   // Emission
   emission.rateOverTime.constant = 0;
-  emission.addBurst(new Burst(0, new ParticleCompositeCurve(10, 30)));
+  emission.addBurst(new Burst(0, new ParticleCompositeCurve(10, 30), 1, 0.01));
   const sphereShape = new SphereShape();
   sphereShape.radius = 0.8;
   emission.shape = sphereShape;

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -442,6 +442,12 @@ export const E2E_CONFIG = {
       caseFileName: "particleRenderer-shape-transform",
       threshold: 0,
       diffPercentage: 0.334
+    },
+    burstCycles: {
+      category: "Particle",
+      caseFileName: "particleRenderer-burst-cycles",
+      threshold: 0,
+      diffPercentage: 0.2
     }
   },
   PostProcess: {

--- a/packages/core/src/particle/modules/Burst.ts
+++ b/packages/core/src/particle/modules/Burst.ts
@@ -8,14 +8,20 @@ export class Burst {
   public time: number;
   @deepClone
   public count: ParticleCompositeCurve;
+  public cycles: number;
+  public repeatInterval: number;
 
   /**
    * Create burst object.
    * @param time - Time to emit the burst
    * @param count - Count of particles to emit
+   * @param cycles - Number of times to repeat the burst
+   * @param repeatInterval - Time interval between each repeated burst
    */
-  constructor(time: number, count: ParticleCompositeCurve) {
+  constructor(time: number, count: ParticleCompositeCurve, cycles: number, repeatInterval: number) {
     this.time = time;
     this.count = count;
+    this.cycles = cycles;
+    this.repeatInterval = repeatInterval;
   }
 }

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -33,6 +33,7 @@ export class EmissionModule extends ParticleGeneratorModule {
   private _bursts: Burst[] = [];
 
   private _currentBurstIndex: number = 0;
+  private _currentBurstCycleIndex: number = 0;
 
   @ignoreClone
   private _burstRand: Rand = new Rand(0, ParticleRandomSubSeeds.Burst);
@@ -147,6 +148,7 @@ export class EmissionModule extends ParticleGeneratorModule {
   _reset(): void {
     this._frameRateTime = 0;
     this._currentBurstIndex = 0;
+    this._currentBurstCycleIndex = 0;
   }
 
   /**
@@ -181,17 +183,21 @@ export class EmissionModule extends ParticleGeneratorModule {
       let middleTime = Math.ceil(lastPlayTime / duration) * duration;
       this._emitBySubBurst(lastPlayTime, middleTime, duration);
       this._currentBurstIndex = 0;
+      this._currentBurstCycleIndex = 0;
 
       for (let i = 0; i < cycleCount; i++) {
         const lastMiddleTime = middleTime;
         middleTime += duration;
         this._emitBySubBurst(lastMiddleTime, middleTime, duration);
         this._currentBurstIndex = 0;
+        this._currentBurstCycleIndex = 0;
       }
 
       this._emitBySubBurst(middleTime, playTime, duration);
     } else {
-      this._emitBySubBurst(lastPlayTime, playTime, duration);
+      if (lastPlayTime < duration) {
+        this._emitBySubBurst(lastPlayTime, Math.min(playTime, duration), duration);
+      }
     }
   }
 
@@ -205,6 +211,8 @@ export class EmissionModule extends ParticleGeneratorModule {
     const startTime = lastPlayTime % duration;
     const endTime = startTime + (playTime - lastPlayTime);
 
+    let firstPendingIndex = -1;
+    let firstPendingCycleIndex = 0;
     let index = this._currentBurstIndex;
     for (let n = bursts.length; index < n; index++) {
       const burst = bursts[index];
@@ -214,11 +222,31 @@ export class EmissionModule extends ParticleGeneratorModule {
         break;
       }
 
-      if (burstTime >= startTime) {
-        const count = burst.count.evaluate(undefined, rand.random());
-        generator._emit(baseTime + burstTime, count);
+      const cycles = burst.cycles;
+      const repeatInterval = Math.max(burst.repeatInterval, 0.01);
+      const infinite = cycles === Infinity;
+      const startCycle = index === this._currentBurstIndex ? this._currentBurstCycleIndex : 0;
+      let c = startCycle;
+      for (; infinite || c < cycles; c++) {
+        const effectiveTime = burstTime + c * repeatInterval;
+        if (effectiveTime >= duration) break;
+        // Repeated cycles (c > 0) use half-open interval [startTime, endTime) to prevent
+        // double-firing at frame boundaries, since _currentBurstIndex may not advance past this burst
+        if (c > 0 ? effectiveTime >= endTime : effectiveTime > endTime) break;
+        if (effectiveTime >= startTime) {
+          const count = burst.count.evaluate(undefined, rand.random());
+          generator._emit(baseTime + effectiveTime, count);
+        }
+      }
+
+      // Track the first burst that still has pending cycles
+      const lastCycleTime = infinite ? duration : cycles > 1 ? burstTime + (cycles - 1) * repeatInterval : burstTime;
+      if ((infinite || cycles > 1 ? lastCycleTime >= endTime : lastCycleTime > endTime) && firstPendingIndex === -1) {
+        firstPendingIndex = index;
+        firstPendingCycleIndex = c;
       }
     }
-    this._currentBurstIndex = index;
+    this._currentBurstIndex = firstPendingIndex !== -1 ? firstPendingIndex : index;
+    this._currentBurstCycleIndex = firstPendingIndex !== -1 ? firstPendingCycleIndex : 0;
   }
 }

--- a/tests/src/core/particle/Burst.test.ts
+++ b/tests/src/core/particle/Burst.test.ts
@@ -1,0 +1,156 @@
+import {
+  Burst,
+  Camera,
+  Engine,
+  ParticleCompositeCurve,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleStopMode
+} from "@galacean/engine-core";
+import { Color } from "@galacean/engine-math";
+import { WebGLEngine } from "@galacean/engine-rhi-webgl";
+import { beforeAll, describe, expect, it } from "vitest";
+
+function updateEngine(engine: Engine, frames: number, deltaTime = 100) {
+  //@ts-ignore
+  engine._vSyncCount = Infinity;
+  //@ts-ignore
+  engine._time._lastSystemTime = 0;
+  let times = 0;
+  performance.now = function () {
+    times++;
+    return times * deltaTime;
+  };
+  for (let i = 0; i < frames; i++) {
+    engine.update();
+  }
+}
+
+describe("Burst", () => {
+  let engine: Engine;
+
+  beforeAll(async function () {
+    engine = await WebGLEngine.create({
+      canvas: document.createElement("canvas")
+    });
+
+    const scene = engine.sceneManager.activeScene;
+    const rootEntity = scene.createRootEntity("root");
+    const cameraEntity = rootEntity.createChild("Camera");
+    cameraEntity.addComponent(Camera);
+    cameraEntity.transform.setPosition(0, 0, 10);
+
+    engine.run();
+  });
+
+  it("Default constructor", () => {
+    const burst = new Burst(0.5, new ParticleCompositeCurve(10), 1, 0.01);
+    expect(burst.time).to.equal(0.5);
+    expect(burst.count.evaluate(undefined, undefined)).to.equal(10);
+    expect(burst.cycles).to.equal(1);
+    expect(burst.repeatInterval).to.equal(0.01);
+  });
+
+  it("Constructor with cycles and repeatInterval", () => {
+    const burst = new Burst(0.5, new ParticleCompositeCurve(10), 3, 0.2);
+    expect(burst.time).to.equal(0.5);
+    expect(burst.count.evaluate(undefined, undefined)).to.equal(10);
+    expect(burst.cycles).to.equal(3);
+    expect(burst.repeatInterval).to.equal(0.2);
+  });
+
+  it("Modify cycles and repeatInterval", () => {
+    const burst = new Burst(0, new ParticleCompositeCurve(5), 1, 0.01);
+    burst.cycles = 5;
+    burst.repeatInterval = 0.1;
+    expect(burst.cycles).to.equal(5);
+    expect(burst.repeatInterval).to.equal(0.1);
+  });
+
+  it("Single cycle backward compatible", () => {
+    const scene = engine.sceneManager.activeScene;
+    const entity = scene.createRootEntity("SingleCycle");
+    const renderer = entity.addComponent(ParticleRenderer);
+    const material = new ParticleMaterial(engine);
+    material.baseColor = new Color(1, 1, 1, 1);
+    renderer.setMaterial(material);
+
+    const generator = renderer.generator;
+    generator.useAutoRandomSeed = false;
+    generator.main.duration = 5;
+    generator.main.isLoop = false;
+    generator.main.maxParticles = 1000;
+    generator.main.startLifetime.constant = 10;
+    generator.emission.rateOverTime.constant = 0;
+
+    // Default cycles=1 should behave like original
+    generator.emission.addBurst(new Burst(0, new ParticleCompositeCurve(10), 1, 0.01));
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    // 20 frames at 100ms = 2s, burst at t=0 fires once
+    updateEngine(engine, 20);
+    expect(generator._getAliveParticleCount()).to.equal(10);
+
+    entity.destroy();
+  });
+
+  it("Burst cycles emit multiple times", () => {
+    const scene = engine.sceneManager.activeScene;
+    const entity = scene.createRootEntity("BurstCycles");
+    const renderer = entity.addComponent(ParticleRenderer);
+    const material = new ParticleMaterial(engine);
+    material.baseColor = new Color(1, 1, 1, 1);
+    renderer.setMaterial(material);
+
+    const generator = renderer.generator;
+    generator.useAutoRandomSeed = false;
+    generator.main.duration = 5;
+    generator.main.isLoop = false;
+    generator.main.maxParticles = 1000;
+    generator.main.startLifetime.constant = 10;
+    generator.emission.rateOverTime.constant = 0;
+
+    // Burst at t=0, count=10, cycles=3, interval=0.5 -> fires at 0s, 0.5s, 1.0s
+    generator.emission.addBurst(new Burst(0, new ParticleCompositeCurve(10), 3, 0.5));
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    // 15 frames at 100ms = 1.5s, all 3 cycles should have fired
+    updateEngine(engine, 15);
+    expect(generator._getAliveParticleCount()).to.equal(30);
+
+    entity.destroy();
+  });
+
+  it("Burst cycles=Infinity emits infinitely within duration", () => {
+    const scene = engine.sceneManager.activeScene;
+    const entity = scene.createRootEntity("InfiniteCycles");
+    const renderer = entity.addComponent(ParticleRenderer);
+    const material = new ParticleMaterial(engine);
+    material.baseColor = new Color(1, 1, 1, 1);
+    renderer.setMaterial(material);
+
+    const generator = renderer.generator;
+    generator.useAutoRandomSeed = false;
+    generator.main.duration = 2;
+    generator.main.isLoop = false;
+    generator.main.maxParticles = 1000;
+    generator.main.startLifetime.constant = 10;
+    generator.emission.rateOverTime.constant = 0;
+
+    // cycles=0 means infinite, interval=0.5 -> fires at 0, 0.5, 1.0, 1.5 within duration=2
+    generator.emission.addBurst(new Burst(0, new ParticleCompositeCurve(5), Infinity, 0.5));
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    // 25 frames at 100ms = 2.5s, should fire 4 times (at 0, 0.5, 1.0, 1.5) = 20 particles
+    updateEngine(engine, 25);
+    expect(generator._getAliveParticleCount()).to.equal(20);
+
+    entity.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `cycles` and `repeatInterval` properties to `Burst` class for repeated burst emission
- `cycles`: number of times to repeat (`Infinity` for unlimited within duration)
- `repeatInterval`: time gap between repeats (clamped to min 0.01, consistent with Unity)
- Track `_currentBurstCycleIndex` for efficient cycle iteration across frames
- Clamp non-looping emission to duration boundary to prevent false re-emission

## Usage
```ts
// Repeat 3 times, every 0.5s → fires at 0s, 0.5s, 1.0s
emission.addBurst(new Burst(0, new ParticleCompositeCurve(10), 3, 0.5));

// Infinite repeat every 0.2s within duration
emission.addBurst(new Burst(0, new ParticleCompositeCurve(5), Infinity, 0.2));
```

## Test plan
- [x] Unit tests: `tests/src/core/particle/Burst.test.ts` (6 cases)
  - Constructor properties
  - Single cycle backward compatibility
  - Multi-cycle emission count
  - Infinite cycles within duration
- [x] E2E case: `particleRenderer-burst-cycles`
- [x] All 76 existing particle tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Particles now support configurable burst cycles, enabling repeated emissions at specified intervals with customizable repeat counts and timing parameters for enhanced particle control.

* **Tests**
  * Added comprehensive test suite for particle burst cycle functionality, validating single-cycle, multi-cycle, and infinite-cycle emission scenarios with deterministic timing verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->