### PR TITLE
feat(shader-lab): make #define values first-class AST nodes

### DIFF
--- a/packages/shader-lab/src/ParserUtils.ts
+++ b/packages/shader-lab/src/ParserUtils.ts
@@ -1,6 +1,6 @@
 import { ETokenType, GalaceanDataType, TypeAny } from "./common";
 import { BaseToken as Token } from "./common/BaseToken";
-import { TreeNode } from "./parser/AST";
+import { ASTNode, TreeNode } from "./parser/AST";
 import { GrammarSymbol, NoneTerminal } from "./parser/GrammarSymbol";
 // #if _VERBOSE
 import { Keyword } from "./common/enums/Keyword";
@@ -13,6 +13,50 @@ export class ParserUtils {
     if (child instanceof Token) return;
     if (child.nt === type) return child as T;
     return ParserUtils.unwrapNodeByType(child, type);
+  }
+
+  /**
+   * Parse a function-macro parameter-list lexeme (`"(a, b, c)"`) into its parameter
+   * names. An empty list `"()"` yields `[]`. Leading/trailing whitespace around each
+   * name is trimmed. Empty entries from consecutive commas are filtered out.
+   */
+  static parseMacroParamList(lexeme: string): string[] {
+    const inner = lexeme.replace(/^\s*\(\s*|\s*\)\s*$/g, "");
+    if (!inner) return [];
+    return inner
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  /**
+   * Return the lexeme of `expr` when it is (transitively) a single bare identifier
+   * wrapped in primary/postfix expression nodes, e.g. `o` → "o". Returns null for
+   * compound expressions (`o.x`, `foo(..)`, `arr[0]`, …). Useful for callers that
+   * want to apply a substitution rule only at the root of an expression, never on
+   * swizzles or nested member access.
+   */
+  static extractDirectIdentLexeme(expr: TreeNode): string | null {
+    let cur: TreeNode | Token = expr;
+    while (cur) {
+      if (cur instanceof ASTNode.PostfixExpression) {
+        if (cur.children.length !== 1) return null;
+        cur = cur.children[0];
+        continue;
+      }
+      if (cur instanceof ASTNode.PrimaryExpression) {
+        if (cur.children.length !== 1) return null;
+        cur = cur.children[0];
+        continue;
+      }
+      if (cur instanceof ASTNode.VariableIdentifier) {
+        const child = cur.children[0];
+        if (child instanceof Token) return child.lexeme;
+        return null;
+      }
+      return null;
+    }
+    return null;
   }
 
   // #if _VERBOSE

--- a/packages/shader-lab/src/ParserUtils.ts
+++ b/packages/shader-lab/src/ParserUtils.ts
@@ -39,20 +39,24 @@ export class ParserUtils {
   static extractDirectIdentLexeme(expr: TreeNode): string | null {
     let cur: TreeNode | Token = expr;
     while (cur) {
-      if (cur instanceof ASTNode.PostfixExpression) {
-        if (cur.children.length !== 1) return null;
-        cur = cur.children[0];
-        continue;
-      }
-      if (cur instanceof ASTNode.PrimaryExpression) {
-        if (cur.children.length !== 1) return null;
-        cur = cur.children[0];
-        continue;
-      }
       if (cur instanceof ASTNode.VariableIdentifier) {
         const child = cur.children[0];
-        if (child instanceof Token) return child.lexeme;
-        return null;
+        return child instanceof Token ? child.lexeme : null;
+      }
+      // `( expression )` form on PrimaryExpression — descend through the
+      // wrapped Expression so `(v)` resolves to `v`. All other compound
+      // forms (member access, function call, comma, …) bail out.
+      if (cur instanceof ASTNode.PrimaryExpression && cur.children.length === 3) {
+        cur = cur.children[1];
+        continue;
+      }
+      // Any precedence-chain wrapper with a single child forwards through.
+      // Covers PostfixExpression / PrimaryExpression(len=1) / Assignment /
+      // Conditional / LogicalOr / … all the way down — including the verbose
+      // build's full chain and the release build's elision-flattened chain.
+      if (cur instanceof ASTNode.ExpressionAstNode && cur.children.length === 1) {
+        cur = cur.children[0];
+        continue;
       }
       return null;
     }

--- a/packages/shader-lab/src/Preprocessor.ts
+++ b/packages/shader-lab/src/Preprocessor.ts
@@ -25,32 +25,23 @@ export interface MacroDefineList {
 
 export class Preprocessor {
   private static readonly _includeReg = /^[ \t]*#include +"([\w\d./]+)"/gm;
-  private static readonly _macroRegex =
-    /^\s*#define\s+(\w+)[ ]*(\(([^)]*)\))?[ ]+(\(?\w+\)?.*?)(?:\/\/.*|\/\*.*?\*\/)?\s*$/gm;
-  // Matches a bare identifier or a function-call whole-value form only.
-  // Mixed-operator values (`a + b`) are intentionally rejected.
-  private static readonly _referenceReg = /^([a-zA-Z_]\w*)(?:\s*\(.*\))?$/;
-  private static readonly _chunkCache = new Map<string, { output: string; macros: MacroDefineList }>();
+  // Caches the post-include-expansion output keyed by chunk path. `#define`
+  // registration is no longer pre-scanned here — the Lexer fills
+  // `macroDefineList` while it tokenizes the cached output.
+  private static readonly _chunkOutputCache = new Map<string, string>();
 
   /**
    * @internal
    */
   static _repeatIncludeSet = new Set<string>();
 
-  static parse(source: string, basePathForIncludeKey: string, outMacroDefineList: MacroDefineList): string {
-    this._parseMacroDefines(source, outMacroDefineList);
-    return source.replace(this._includeReg, (_, includeName) =>
-      this._replace(includeName, basePathForIncludeKey, outMacroDefineList)
-    );
-  }
-
-  private static _parseMacroDefines(source: string, outMacroList: MacroDefineList): void {
-    this._macroRegex.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = this._macroRegex.exec(source)) !== null) {
-      const [, name, paramsGroup, paramsStr, valueRaw] = match;
-      this._registerDefine(outMacroList, name, paramsGroup ? paramsStr : undefined, valueRaw);
-    }
+  static parse(source: string, basePathForIncludeKey: string): string {
+    // Preprocessor only handles `#include` expansion. `#define` registration
+    // is done by the Lexer in a single pass over the same token stream it
+    // tokenizes — eliminating the long-standing drift between two
+    // independent analyzers (regex vs Lexer state machine) interpreting the
+    // same source differently (comments, line-continuation, etc.).
+    return source.replace(this._includeReg, (_, includeName) => this._replace(includeName, basePathForIncludeKey));
   }
 
   /** Collect unique `referenceName`s of `macroName`'s definitions, skipping
@@ -69,65 +60,7 @@ export class Preprocessor {
     }
   }
 
-  private static _extractReferenceName(value: string): string {
-    const match = this._referenceReg.exec(value);
-    return match ? match[1] : "";
-  }
-
-  private static _isExist(list: MacroDefineInfo[], item: MacroDefineInfo): boolean {
-    return list.some(
-      (e) =>
-        e.isFunction === item.isFunction &&
-        e.referenceName === item.referenceName &&
-        e.params.length === item.params.length &&
-        e.params.every((p, i) => p === item.params[i])
-    );
-  }
-
-  private static _registerDefine(
-    outMacroList: MacroDefineList,
-    name: string,
-    paramsStr: string | undefined,
-    valueRaw: string
-  ): void {
-    // `paramsStr` is `undefined` for object-like macros and the `()` contents
-    // (possibly empty) for function-like ones.
-    const isFunction = paramsStr !== undefined;
-    const params = paramsStr
-      ? paramsStr
-          .split(",")
-          .map((p) => p.trim())
-          .filter(Boolean)
-      : [];
-    const value = valueRaw.trim();
-    const referenceName = value ? this._extractReferenceName(value) : "";
-
-    const info: MacroDefineInfo = { isFunction, name, params, referenceName };
-
-    const arr = outMacroList[name];
-    if (arr) {
-      if (!this._isExist(arr, info)) arr.push(info);
-    } else {
-      outMacroList[name] = [info];
-    }
-  }
-
-  private static _mergeMacroDefineLists(from: MacroDefineList, to: MacroDefineList): void {
-    for (const name in from) {
-      const target = to[name] ?? (to[name] = []);
-      const src = from[name];
-      for (let i = 0, n = src.length; i < n; i++) {
-        const info = src[i];
-        if (!this._isExist(target, info)) target.push(info);
-      }
-    }
-  }
-
-  private static _replace(
-    includeName: string,
-    basePathForIncludeKey: string,
-    outMacroDefineList: MacroDefineList
-  ): string {
+  private static _replace(includeName: string, basePathForIncludeKey: string): string {
     let path: string;
     if (includeName[0] === ".") {
       // @ts-ignore
@@ -147,14 +80,11 @@ export class Preprocessor {
     }
     this._repeatIncludeSet.add(path);
 
-    let entry = this._chunkCache.get(path);
-    if (!entry) {
-      const macros: MacroDefineList = {};
-      const output = this.parse(chunk, basePathForIncludeKey, macros);
-      entry = { output, macros };
-      this._chunkCache.set(path, entry);
+    let cached = this._chunkOutputCache.get(path);
+    if (cached === undefined) {
+      cached = this.parse(chunk, basePathForIncludeKey);
+      this._chunkOutputCache.set(path, cached);
     }
-    this._mergeMacroDefineLists(entry.macros, outMacroDefineList);
-    return entry.output;
+    return cached;
   }
 }

--- a/packages/shader-lab/src/Preprocessor.ts
+++ b/packages/shader-lab/src/Preprocessor.ts
@@ -2,6 +2,7 @@ import { Logger, ShaderPass } from "@galacean/engine";
 /** @ts-ignore */
 import { ShaderLib } from "@galacean/engine";
 import type { ASTNode } from "./parser/AST";
+import type { BranchSignature } from "./common/BaseToken";
 
 /**
  * Record for a single `#define` directive. `valueAst` is set for expression
@@ -17,6 +18,10 @@ export interface MacroDefineInfo {
    *  → `foo`), or empty for literals / operator expressions. Drives symbol-table
    *  lookup at macro call sites. */
   referenceName: string;
+  /** Branch signature at the point of registration. The same `#define` repeated
+   *  in different `#ifdef` branches produces multiple entries with different
+   *  signatures; call sites filter to those visible from their own position. */
+  branch: BranchSignature;
 }
 
 export interface MacroDefineList {
@@ -37,27 +42,9 @@ export class Preprocessor {
 
   static parse(source: string, basePathForIncludeKey: string): string {
     // Preprocessor only handles `#include` expansion. `#define` registration
-    // is done by the Lexer in a single pass over the same token stream it
-    // tokenizes — eliminating the long-standing drift between two
-    // independent analyzers (regex vs Lexer state machine) interpreting the
-    // same source differently (comments, line-continuation, etc.).
+    // and `#ifdef` branch tracking are done by the Lexer in a single pass
+    // over the same token stream it tokenizes.
     return source.replace(this._includeReg, (_, includeName) => this._replace(includeName, basePathForIncludeKey));
-  }
-
-  /** Collect unique `referenceName`s of `macroName`'s definitions, skipping
-   *  names that shadow a macro parameter. */
-  static getReferenceSymbolNames(macroDefineList: MacroDefineList, macroName: string, out: string[]): void {
-    out.length = 0;
-    const infos = macroDefineList[macroName];
-    if (!infos) return;
-
-    for (let i = 0, n = infos.length; i < n; i++) {
-      const info = infos[i];
-      const ref = info.referenceName;
-      if (!ref) continue;
-      if (info.params.indexOf(ref) !== -1) continue;
-      if (out.indexOf(ref) === -1) out.push(ref);
-    }
   }
 
   private static _replace(includeName: string, basePathForIncludeKey: string): string {

--- a/packages/shader-lab/src/Preprocessor.ts
+++ b/packages/shader-lab/src/Preprocessor.ts
@@ -1,7 +1,14 @@
 import { Logger, ShaderPass } from "@galacean/engine";
 /** @ts-ignore */
 import { ShaderLib } from "@galacean/engine";
+import type { ASTNode } from "./parser/AST";
 
+/**
+ * Classification of a `#define` value. Used by the opaque-token (legacy) path;
+ * expression-style macros go straight to AST and don't need this tag.
+ *
+ * @internal
+ */
 export enum MacroValueType {
   Number, // 1, 1.1
   Symbol, // variable name
@@ -9,12 +16,34 @@ export enum MacroValueType {
   Other // shaderLab does not check this
 }
 
+/**
+ * Record for a single `#define` directive. Two shapes coexist:
+ *
+ * - **Expression macros** — have `valueAst` pointing at an `AssignmentExpression`
+ *   subtree. These participate in type inference, varying flattening, and reference
+ *   tracking through the normal visitor pattern, just like inline expressions.
+ * - **Opaque macros** — the value is a qualifier/type/partial-syntax form that can't
+ *   be parsed as a GLSL expression. `valueAst` is undefined and the lexer kept the
+ *   whole directive in a legacy `MACRO_DEFINE_EXPRESSION` token.
+ *
+ * Both shapes share `isFunction`, `name`, `params`, and `value` for display and
+ * reference tracking. `functionCallName` is set only for opaque macros whose value
+ * is a function-call form, enabling `getReferenceSymbolNames` to record the callee.
+ */
 export interface MacroDefineInfo {
   isFunction: boolean;
   name: string;
-  value: string;
+  /** Classification of the raw value text. Populated for opaque (legacy) macros
+   *  only — AST-form macros leave this as `Other` since classification doesn't
+   *  drive their semantics. */
   valueType: MacroValueType;
+  /** Raw value text for opaque macros; empty string for AST-form macros. */
+  value: string;
+  /** AST for expression-style macros. Absent for opaque macros. */
+  valueAst?: ASTNode.AssignmentExpression;
   params: string[];
+  /** Function callee name for opaque macros classified as `FunctionCall`; empty
+   *  string otherwise. */
   functionCallName: string;
 }
 
@@ -49,6 +78,12 @@ export class Preprocessor {
     );
   }
 
+  /**
+   * For a given macro name, collect the external symbols its body references so
+   * callers of the macro can drive symbol-table lookup. Only the opaque-macro path
+   * needs this preprocessor-driven collection; expression macros carry their refs
+   * in the AST and `MacroDefine.semanticAnalyze` collects them directly.
+   */
   static getReferenceSymbolNames(macroDefineList: MacroDefineList, macroName: string, out: string[]): void {
     out.length = 0;
     const infos = macroDefineList[macroName];
@@ -56,6 +91,9 @@ export class Preprocessor {
 
     for (let i = 0; i < infos.length; i++) {
       const info = infos[i];
+      // Expression macros handle their own reference tracking via the AST subtree
+      // (see `MacroDefine.semanticAnalyze`). Nothing to collect here for them.
+      if (info.valueAst) continue;
       const valueType = info.valueType;
       if (valueType === MacroValueType.FunctionCall || valueType === MacroValueType.Symbol) {
         const referencedName = valueType === MacroValueType.FunctionCall ? info.functionCallName : info.value;

--- a/packages/shader-lab/src/Preprocessor.ts
+++ b/packages/shader-lab/src/Preprocessor.ts
@@ -4,47 +4,32 @@ import { ShaderLib } from "@galacean/engine";
 import type { ASTNode } from "./parser/AST";
 
 /**
- * Classification of a `#define` value. Used by the opaque-token (legacy) path;
- * expression-style macros go straight to AST and don't need this tag.
+ * Record for a single `#define` directive.
  *
- * @internal
- */
-export enum MacroValueType {
-  Number, // 1, 1.1
-  Symbol, // variable name
-  FunctionCall, // function call, e.g. clamp(a, 0.0, 1.0)
-  Other // shaderLab does not check this
-}
-
-/**
- * Record for a single `#define` directive. Two shapes coexist:
+ * Two shapes coexist and can be combined on the same entry:
  *
- * - **Expression macros** — have `valueAst` pointing at an `AssignmentExpression`
- *   subtree. These participate in type inference, varying flattening, and reference
- *   tracking through the normal visitor pattern, just like inline expressions.
- * - **Opaque macros** — the value is a qualifier/type/partial-syntax form that can't
- *   be parsed as a GLSL expression. `valueAst` is undefined and the lexer kept the
- *   whole directive in a legacy `MACRO_DEFINE_EXPRESSION` token.
+ * - **Expression macros** — `valueAst` holds an `AssignmentExpression` subtree
+ *   produced by the `macro_define` CFG rule. These participate in type
+ *   inference, varying flattening, and visitor-based codegen.
+ * - **Legacy opaque macros** — the directive is emitted verbatim as a
+ *   `MACRO_DEFINE_EXPRESSION` token and expanded by the GLSL driver. `valueAst`
+ *   is undefined.
  *
- * Both shapes share `isFunction`, `name`, `params`, and `value` for display and
- * reference tracking. `functionCallName` is set only for opaque macros whose value
- * is a function-call form, enabling `getReferenceSymbolNames` to record the callee.
+ * `referenceName` captures the top-level external identifier the value refers
+ * to, if any — the callee of a function-call value (`#define F foo(a,b)`
+ * → `foo`) or the single-identifier value (`#define F foo` → `foo`). Empty
+ * for numeric literals, qualifier fragments, or structurally complex values.
+ * Populated by the regex pass; drives symbol-table lookup for macro call
+ * sites, independent of whether the value also has an AST form.
  */
 export interface MacroDefineInfo {
   isFunction: boolean;
   name: string;
-  /** Classification of the raw value text. Populated for opaque (legacy) macros
-   *  only — AST-form macros leave this as `Other` since classification doesn't
-   *  drive their semantics. */
-  valueType: MacroValueType;
-  /** Raw value text for opaque macros; empty string for AST-form macros. */
-  value: string;
+  params: string[];
   /** AST for expression-style macros. Absent for opaque macros. */
   valueAst?: ASTNode.AssignmentExpression;
-  params: string[];
-  /** Function callee name for opaque macros classified as `FunctionCall`; empty
-   *  string otherwise. */
-  functionCallName: string;
+  /** Top-level external identifier the value references, or empty string. */
+  referenceName: string;
 }
 
 export interface MacroDefineList {
@@ -56,7 +41,7 @@ export class Preprocessor {
   private static readonly _macroRegex =
     /^\s*#define\s+(\w+)[ ]*(\(([^)]*)\))?[ ]+(\(?\w+\)?.*?)(?:\/\/.*|\/\*.*?\*\/)?\s*$/gm;
   private static readonly _symbolReg = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-  private static readonly _funcCallReg = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\((.*)\)$/;
+  private static readonly _funcCallReg = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(.*\)$/;
   private static readonly _macroDefineIncludeMap = new Map<string, MacroDefineList>();
 
   /**
@@ -79,47 +64,40 @@ export class Preprocessor {
   }
 
   /**
-   * For a given macro name, collect the external symbols its body references so
-   * callers of the macro can drive symbol-table lookup. Only the opaque-macro path
-   * needs this preprocessor-driven collection; expression macros carry their refs
-   * in the AST and `MacroDefine.semanticAnalyze` collects them directly.
+   * For each registered definition of `macroName`, push its `referenceName`
+   * (when non-empty and not a macro parameter) so call sites can drive
+   * symbol-table lookup.
    */
   static getReferenceSymbolNames(macroDefineList: MacroDefineList, macroName: string, out: string[]): void {
     out.length = 0;
     const infos = macroDefineList[macroName];
     if (!infos) return;
 
-    for (let i = 0; i < infos.length; i++) {
+    for (let i = 0, n = infos.length; i < n; i++) {
       const info = infos[i];
-      // Expression macros handle their own reference tracking via the AST subtree
-      // (see `MacroDefine.semanticAnalyze`). Nothing to collect here for them.
-      if (info.valueAst) continue;
-      const valueType = info.valueType;
-      if (valueType === MacroValueType.FunctionCall || valueType === MacroValueType.Symbol) {
-        const referencedName = valueType === MacroValueType.FunctionCall ? info.functionCallName : info.value;
-        if (info.params.indexOf(referencedName) !== -1) continue;
-        if (out.indexOf(referencedName) === -1) out.push(referencedName);
-      } else if (valueType === MacroValueType.Other) {
-        // #if _VERBOSE
-        Logger.warn(
-          `Warning: Macro "${info.name}" has an unrecognized value "${info.value}". ShaderLab does not validate this type.`
-        );
-        // #endif
-      }
+      const ref = info.referenceName;
+      if (!ref) continue;
+      if (info.params.indexOf(ref) !== -1) continue;
+      if (out.indexOf(ref) === -1) out.push(ref);
     }
   }
 
-  private static _isNumber(str: string): boolean {
-    return !isNaN(Number(str));
+  /**
+   * Extract the top-level identifier a value refers to, or empty string if
+   * the value is a numeric literal, qualifier fragment, or structurally
+   * complex form we don't try to introspect.
+   */
+  private static _extractReferenceName(value: string): string {
+    if (this._symbolReg.test(value)) return value;
+    const callMatch = this._funcCallReg.exec(value);
+    return callMatch ? callMatch[1] : "";
   }
 
   private static _isExist(list: MacroDefineInfo[], item: MacroDefineInfo): boolean {
     return list.some(
       (e) =>
-        e.valueType === item.valueType &&
-        e.value === item.value &&
         e.isFunction === item.isFunction &&
-        e.functionCallName === item.functionCallName &&
+        e.referenceName === item.referenceName &&
         e.params.length === item.params.length &&
         e.params.every((p, i) => p === item.params[i])
     );
@@ -140,30 +118,9 @@ export class Preprocessor {
               .filter(Boolean)
           : [];
       const value = valueRaw ? valueRaw.trim() : "";
+      const referenceName = value ? this._extractReferenceName(value) : "";
 
-      let valueType = MacroValueType.Other;
-      let functionCallName = "";
-
-      if (this._isNumber(value)) {
-        valueType = MacroValueType.Number;
-      } else if (this._symbolReg.test(value)) {
-        valueType = MacroValueType.Symbol;
-      } else {
-        const callMatch = this._funcCallReg.exec(value);
-        if (callMatch) {
-          valueType = MacroValueType.FunctionCall;
-          functionCallName = callMatch[1];
-        }
-      }
-
-      const info: MacroDefineInfo = {
-        isFunction,
-        name,
-        value,
-        valueType,
-        params,
-        functionCallName
-      };
+      const info: MacroDefineInfo = { isFunction, name, params, referenceName };
 
       const arr = outMacroList[name];
       if (arr) {

--- a/packages/shader-lab/src/Preprocessor.ts
+++ b/packages/shader-lab/src/Preprocessor.ts
@@ -4,31 +4,18 @@ import { ShaderLib } from "@galacean/engine";
 import type { ASTNode } from "./parser/AST";
 
 /**
- * Record for a single `#define` directive.
- *
- * Two shapes coexist and can be combined on the same entry:
- *
- * - **Expression macros** — `valueAst` holds an `AssignmentExpression` subtree
- *   produced by the `macro_define` CFG rule. These participate in type
- *   inference, varying flattening, and visitor-based codegen.
- * - **Legacy opaque macros** — the directive is emitted verbatim as a
- *   `MACRO_DEFINE_EXPRESSION` token and expanded by the GLSL driver. `valueAst`
- *   is undefined.
- *
- * `referenceName` captures the top-level external identifier the value refers
- * to, if any — the callee of a function-call value (`#define F foo(a,b)`
- * → `foo`) or the single-identifier value (`#define F foo` → `foo`). Empty
- * for numeric literals, qualifier fragments, or structurally complex values.
- * Populated by the regex pass; drives symbol-table lookup for macro call
- * sites, independent of whether the value also has an AST form.
+ * Record for a single `#define` directive. `valueAst` is set for expression
+ * macros (joined into the AST pipeline); opaque macros leave it undefined and
+ * are emitted verbatim to the GLSL driver.
  */
 export interface MacroDefineInfo {
   isFunction: boolean;
   name: string;
   params: string[];
-  /** AST for expression-style macros. Absent for opaque macros. */
   valueAst?: ASTNode.AssignmentExpression;
-  /** Top-level external identifier the value references, or empty string. */
+  /** Leading identifier of the value (`#define F foo` → `foo`, `#define F foo(a)`
+   *  → `foo`), or empty for literals / operator expressions. Drives symbol-table
+   *  lookup at macro call sites. */
   referenceName: string;
 }
 
@@ -40,34 +27,34 @@ export class Preprocessor {
   private static readonly _includeReg = /^[ \t]*#include +"([\w\d./]+)"/gm;
   private static readonly _macroRegex =
     /^\s*#define\s+(\w+)[ ]*(\(([^)]*)\))?[ ]+(\(?\w+\)?.*?)(?:\/\/.*|\/\*.*?\*\/)?\s*$/gm;
-  private static readonly _symbolReg = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
-  private static readonly _funcCallReg = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*\(.*\)$/;
-  private static readonly _macroDefineIncludeMap = new Map<string, MacroDefineList>();
+  // Matches a bare identifier or a function-call whole-value form only.
+  // Mixed-operator values (`a + b`) are intentionally rejected.
+  private static readonly _referenceReg = /^([a-zA-Z_]\w*)(?:\s*\(.*\))?$/;
+  private static readonly _chunkCache = new Map<string, { output: string; macros: MacroDefineList }>();
 
   /**
    * @internal
    */
   static _repeatIncludeSet = new Set<string>();
 
-  static parse(
-    source: string,
-    basePathForIncludeKey: string,
-    outMacroDefineList: MacroDefineList,
-    parseMacro = true
-  ): string {
-    if (parseMacro) {
-      this._parseMacroDefines(source, outMacroDefineList);
-    }
+  static parse(source: string, basePathForIncludeKey: string, outMacroDefineList: MacroDefineList): string {
+    this._parseMacroDefines(source, outMacroDefineList);
     return source.replace(this._includeReg, (_, includeName) =>
       this._replace(includeName, basePathForIncludeKey, outMacroDefineList)
     );
   }
 
-  /**
-   * For each registered definition of `macroName`, push its `referenceName`
-   * (when non-empty and not a macro parameter) so call sites can drive
-   * symbol-table lookup.
-   */
+  private static _parseMacroDefines(source: string, outMacroList: MacroDefineList): void {
+    this._macroRegex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = this._macroRegex.exec(source)) !== null) {
+      const [, name, paramsGroup, paramsStr, valueRaw] = match;
+      this._registerDefine(outMacroList, name, paramsGroup ? paramsStr : undefined, valueRaw);
+    }
+  }
+
+  /** Collect unique `referenceName`s of `macroName`'s definitions, skipping
+   *  names that shadow a macro parameter. */
   static getReferenceSymbolNames(macroDefineList: MacroDefineList, macroName: string, out: string[]): void {
     out.length = 0;
     const infos = macroDefineList[macroName];
@@ -82,15 +69,9 @@ export class Preprocessor {
     }
   }
 
-  /**
-   * Extract the top-level identifier a value refers to, or empty string if
-   * the value is a numeric literal, qualifier fragment, or structurally
-   * complex form we don't try to introspect.
-   */
   private static _extractReferenceName(value: string): string {
-    if (this._symbolReg.test(value)) return value;
-    const callMatch = this._funcCallReg.exec(value);
-    return callMatch ? callMatch[1] : "";
+    const match = this._referenceReg.exec(value);
+    return match ? match[1] : "";
   }
 
   private static _isExist(list: MacroDefineInfo[], item: MacroDefineInfo): boolean {
@@ -103,45 +84,41 @@ export class Preprocessor {
     );
   }
 
-  private static _parseMacroDefines(source: string, outMacroList: MacroDefineList): void {
-    let match: RegExpExecArray | null;
-    this._macroRegex.lastIndex = 0;
+  private static _registerDefine(
+    outMacroList: MacroDefineList,
+    name: string,
+    paramsStr: string | undefined,
+    valueRaw: string
+  ): void {
+    // `paramsStr` is `undefined` for object-like macros and the `()` contents
+    // (possibly empty) for function-like ones.
+    const isFunction = paramsStr !== undefined;
+    const params = paramsStr
+      ? paramsStr
+          .split(",")
+          .map((p) => p.trim())
+          .filter(Boolean)
+      : [];
+    const value = valueRaw.trim();
+    const referenceName = value ? this._extractReferenceName(value) : "";
 
-    while ((match = this._macroRegex.exec(source)) !== null) {
-      const [, name, paramsGroup, paramsStr, valueRaw] = match;
-      const isFunction = !!paramsGroup && !!valueRaw;
-      const params =
-        isFunction && paramsStr
-          ? paramsStr
-              .split(",")
-              .map((p) => p.trim())
-              .filter(Boolean)
-          : [];
-      const value = valueRaw ? valueRaw.trim() : "";
-      const referenceName = value ? this._extractReferenceName(value) : "";
+    const info: MacroDefineInfo = { isFunction, name, params, referenceName };
 
-      const info: MacroDefineInfo = { isFunction, name, params, referenceName };
-
-      const arr = outMacroList[name];
-      if (arr) {
-        if (!this._isExist(arr, info)) arr.push(info);
-      } else {
-        outMacroList[name] = [info];
-      }
+    const arr = outMacroList[name];
+    if (arr) {
+      if (!this._isExist(arr, info)) arr.push(info);
+    } else {
+      outMacroList[name] = [info];
     }
   }
 
   private static _mergeMacroDefineLists(from: MacroDefineList, to: MacroDefineList): void {
-    for (const macroName in from) {
-      if (to[macroName]) {
-        const target = to[macroName];
-        const src = from[macroName];
-        for (let i = 0; i < src.length; i++) {
-          const info = src[i];
-          if (!this._isExist(target, info)) target.push(info);
-        }
-      } else {
-        to[macroName] = from[macroName];
+    for (const name in from) {
+      const target = to[name] ?? (to[name] = []);
+      const src = from[name];
+      for (let i = 0, n = src.length; i < n; i++) {
+        const info = src[i];
+        if (!this._isExist(target, info)) target.push(info);
       }
     }
   }
@@ -170,15 +147,14 @@ export class Preprocessor {
     }
     this._repeatIncludeSet.add(path);
 
-    if (this._macroDefineIncludeMap.has(path)) {
-      this._mergeMacroDefineLists(this._macroDefineIncludeMap.get(path)!, outMacroDefineList);
-    } else {
-      const chunkMacroDefineList: MacroDefineList = {};
-      this._parseMacroDefines(chunk, chunkMacroDefineList);
-      this._macroDefineIncludeMap.set(path, chunkMacroDefineList);
-      this._mergeMacroDefineLists(chunkMacroDefineList, outMacroDefineList);
+    let entry = this._chunkCache.get(path);
+    if (!entry) {
+      const macros: MacroDefineList = {};
+      const output = this.parse(chunk, basePathForIncludeKey, macros);
+      entry = { output, macros };
+      this._chunkCache.set(path, entry);
     }
-
-    return this.parse(chunk, basePathForIncludeKey, outMacroDefineList, false);
+    this._mergeMacroDefineLists(entry.macros, outMacroDefineList);
+    return entry.output;
   }
 }

--- a/packages/shader-lab/src/ShaderLab.ts
+++ b/packages/shader-lab/src/ShaderLab.ts
@@ -58,7 +58,7 @@ export class ShaderLab implements IShaderLab {
     const totalStartTime = performance.now();
     const macroDefineList = {};
     Preprocessor._repeatIncludeSet.clear();
-    const noIncludeContent = Preprocessor.parse(source, basePathForIncludeKey, macroDefineList);
+    const noIncludeContent = Preprocessor.parse(source, basePathForIncludeKey);
     Logger.info(`[Task - Pre processor] cost time ${performance.now() - totalStartTime}ms`);
 
     const lexer = new Lexer(noIncludeContent, macroDefineList);

--- a/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
+++ b/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
@@ -7,7 +7,7 @@ import { ESymbolType, FnSymbol } from "../parser/symbolTable";
 import { NodeChild, StructProp } from "../parser/types";
 import { ParserUtils } from "../ParserUtils";
 import { ShaderLab } from "../ShaderLab";
-import { VisitorContext } from "./VisitorContext";
+import { StructRole, VisitorContext } from "./VisitorContext";
 // #if _VERBOSE
 import { GSError } from "../GSError";
 // #endif
@@ -37,6 +37,10 @@ export abstract class CodeGenVisitor {
     ret.dispose();
     for (const child of children) {
       if (child instanceof BaseToken) {
+        // Legacy opaque `#define` lexemes already contain the directive verbatim
+        // (including leading/trailing newlines); emit them as-is. Expression-style
+        // defines take the `MacroDefine` AST path and never reach this branch as a
+        // `MACRO_DEFINE_EXPRESSION` token.
         ret.array.push(child.lexeme);
       } else {
         ret.array.push(child.codeGen(this));
@@ -56,28 +60,30 @@ export abstract class CodeGenVisitor {
       const prop = children[2];
 
       if (prop instanceof BaseToken) {
-        if (context.isAttributeStruct(<string>postExpr.type)) {
-          const error = context.referenceAttribute(prop);
+        // Resolve the struct role of the left-hand side. Two sources, in priority
+        // order:
+        //   1. `_structVarMap` keyed by the bare root identifier — covers
+        //      variables whose declared type hadn't been resolved when the macro
+        //      body was semantic-analyzed (e.g. forward-declared `Varyings o;`).
+        //      Only consulted for a single bare identifier so swizzles like
+        //      `foo.xyz` don't accidentally match a registered variable.
+        //   2. The AST's static type on the left sub-expression — the normal path
+        //      for inline code where `semanticAnalyze` resolved `postExpr.type`
+        //      to the struct type already.
+        let role: StructRole | undefined;
+        const directRoot = ParserUtils.extractDirectIdentLexeme(postExpr);
+        if (directRoot) role = context._structVarMap[directRoot];
+        if (!role) role = context.getStructRole(<string>postExpr.type);
+
+        if (role) {
+          const error =
+            role === "attribute"
+              ? context.referenceAttribute(prop)
+              : role === "varying"
+                ? context.referenceVarying(prop)
+                : context.referenceMRTProp(prop);
           // #if _VERBOSE
-          if (error) {
-            this.errors.push(<GSError>error);
-          }
-          // #endif
-          return prop.lexeme;
-        } else if (context.isVaryingStruct(<string>postExpr.type)) {
-          const error = context.referenceVarying(prop);
-          // #if _VERBOSE
-          if (error) {
-            this.errors.push(<GSError>error);
-          }
-          // #endif
-          return prop.lexeme;
-        } else if (context.isMRTStruct(<string>postExpr.type)) {
-          const error = context.referenceMRTProp(prop);
-          // #if _VERBOSE
-          if (error) {
-            this.errors.push(<GSError>error);
-          }
+          if (error) this.errors.push(<GSError>error);
           // #endif
           return prop.lexeme;
         }
@@ -118,14 +124,12 @@ export abstract class CodeGenVisitor {
         const astNodes = paramList.paramNodes;
         const paramInfoList = call.fnSymbol.astNode.protoType.parameterList;
 
+        const context = VisitorContext.context;
         const params = astNodes.filter((_, i) => {
           const typeInfo = paramInfoList?.[i]?.typeInfo;
-          return (
-            !typeInfo ||
-            (!VisitorContext.context.isAttributeStruct(typeInfo.typeLexeme) &&
-              !VisitorContext.context.isVaryingStruct(typeInfo.typeLexeme) &&
-              !VisitorContext.context.isMRTStruct(typeInfo.typeLexeme))
-          );
+          // Drop struct-IO parameters (attribute/varying/mrt) — they're flattened
+          // into top-level declarations and no longer exist as function-call args.
+          return !typeInfo || !context.getStructRole(typeInfo.typeLexeme);
         });
 
         let paramsCode = "";
@@ -153,6 +157,7 @@ export abstract class CodeGenVisitor {
     if (paramList instanceof ASTNode.FunctionCallParameterList) {
       const astNodes = paramList.paramNodes;
 
+      const context = VisitorContext.context;
       const params = astNodes.filter((node) => {
         if (node instanceof ASTNode.AssignmentExpression) {
           const variableParam = ParserUtils.unwrapNodeByType<ASTNode.VariableIdentifier>(
@@ -162,9 +167,7 @@ export abstract class CodeGenVisitor {
           if (
             variableParam &&
             typeof variableParam.typeInfo === "string" &&
-            (VisitorContext.context.isAttributeStruct(variableParam.typeInfo) ||
-              VisitorContext.context.isVaryingStruct(variableParam.typeInfo) ||
-              VisitorContext.context.isMRTStruct(variableParam.typeInfo))
+            context.getStructRole(variableParam.typeInfo)
           ) {
             return false;
           }
@@ -200,6 +203,25 @@ export abstract class CodeGenVisitor {
     }
   }
 
+  /**
+   * Code-generate a `#define` macro parsed as expression AST. Produces a `#define`
+   * directive whose value is the AST-rewritten string — so varying flattening
+   * happens naturally via `visitPostfixExpression` inside the AST walk.
+   */
+  visitMacroDefine(node: ASTNode.MacroDefine): string {
+    // For function-like macros, preserve the original `(params)` lexeme verbatim —
+    // the parameter list is user-authored text that shouldn't be canonicalized.
+    let paramsLexeme = "";
+    if (node.isFunction) {
+      const paramsToken = node.children[2];
+      if (paramsToken instanceof BaseToken) paramsLexeme = paramsToken.lexeme;
+    }
+    const valueCode = node.valueExpression ? node.valueExpression.codeGen(this) : "";
+    // Newlines around the directive keep `#` at the start of its physical line per
+    // GLSL ES 3.0 §3.4, regardless of how surrounding tokens are joined.
+    return `\n#define ${node.macroName}${paramsLexeme}${valueCode ? " " + valueCode : ""}\n`;
+  }
+
   visitSingleDeclaration(node: ASTNode.SingleDeclaration): string {
     const type = node.typeSpecifier.type;
     if (typeof type === "string") {
@@ -212,7 +234,16 @@ export abstract class CodeGenVisitor {
     const children = node.children;
     const fullType = children[0];
     if (fullType instanceof ASTNode.FullySpecifiedType && fullType.typeSpecifier.isCustom) {
-      VisitorContext.context.referenceGlobal(<string>fullType.type, ESymbolType.STRUCT);
+      const context = VisitorContext.context;
+      // Global variables whose declared type is a varying/attribute/mrt struct
+      // (e.g. `Varyings o;`) are not emitted as `uniform`. The variable itself is
+      // already registered in `_structVarMap` by the pre-pass in
+      // `GLESVisitor._collectAllStructVars`, so `visitPostfixExpression` can
+      // flatten `o.field` at macro-value codegen time.
+      if (context.getStructRole(fullType.typeSpecifier.lexeme)) {
+        return "";
+      }
+      context.referenceGlobal(<string>fullType.type, ESymbolType.STRUCT);
     }
     return `uniform ${this.defaultCodeGen(children)}`;
   }
@@ -230,12 +261,9 @@ export abstract class CodeGenVisitor {
   }
 
   visitFunctionParameterList(node: ASTNode.FunctionParameterList): string {
+    const context = VisitorContext.context;
     const params = node.parameterInfoList.filter(
-      (item) =>
-        !item.typeInfo ||
-        (!VisitorContext.context.isAttributeStruct(item.typeInfo.typeLexeme) &&
-          !VisitorContext.context.isVaryingStruct(item.typeInfo.typeLexeme) &&
-          !VisitorContext.context.isMRTStruct(item.typeInfo.typeLexeme))
+      (item) => !item.typeInfo || !context.getStructRole(item.typeInfo.typeLexeme)
     );
 
     let out = "";

--- a/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
+++ b/packages/shader-lab/src/codeGen/CodeGenVisitor.ts
@@ -156,32 +156,48 @@ export abstract class CodeGenVisitor {
     const paramList = children[2];
     if (paramList instanceof ASTNode.FunctionCallParameterList) {
       const astNodes = paramList.paramNodes;
-
       const context = VisitorContext.context;
-      const params = astNodes.filter((node) => {
-        if (node instanceof ASTNode.AssignmentExpression) {
-          const variableParam = ParserUtils.unwrapNodeByType<ASTNode.VariableIdentifier>(
-            node,
-            NoneTerminal.variable_identifier
-          );
-          if (
-            variableParam &&
-            typeof variableParam.typeInfo === "string" &&
-            context.getStructRole(variableParam.typeInfo)
-          ) {
-            return false;
-          }
-        }
 
-        return true;
-      });
+      // `MacroCallFunction` covers two call shapes sharing the same AST:
+      //   (a) object-like macro whose value is a function name, used as a call —
+      //       `#define FN foo` + `FN(varyings, …)`. The driver expands `FN` to
+      //       `foo`, and `foo` is a ShaderLab function whose IO-struct params
+      //       have been flattened. The call site must drop IO-struct args to
+      //       match the flattened signature — same rule as `visitFunctionCall`.
+      //   (b) true function-like macro — `#define MAX3(a,b,c) …` + `MAX3(v.x, …)`.
+      //       ShaderLab doesn't expand the macro; the driver does, and the
+      //       `#define` fixes the parameter count. Args must be preserved
+      //       verbatim — a member-access arg like `v.v_uv` unwraps to a root
+      //       identifier whose type is an IO struct, but dropping the arg
+      //       would change the macro's arity.
+      //
+      // `isFunctionLikeMacro` is set by `MacroCallSymbol.semanticAnalyze` from
+      // `macroDefineList[name][*].isFunction` and carries the definition shape.
+      const params = node.isFunctionLikeMacro
+        ? astNodes
+        : astNodes.filter((arg) => {
+            if (arg instanceof ASTNode.AssignmentExpression) {
+              const variableParam = ParserUtils.unwrapNodeByType<ASTNode.VariableIdentifier>(
+                arg,
+                NoneTerminal.variable_identifier
+              );
+              if (
+                variableParam &&
+                typeof variableParam.typeInfo === "string" &&
+                context.getStructRole(variableParam.typeInfo)
+              ) {
+                return false;
+              }
+            }
+            return true;
+          });
 
       let paramsCode = "";
       for (let i = 0, length = params.length; i < length; i++) {
-        const node = params[i];
-        const code = node.codeGen(this);
+        const argNode = params[i];
+        const code = argNode.codeGen(this);
 
-        if (node instanceof ASTNode.MacroCallArgBlock || i === 0) {
+        if (argNode instanceof ASTNode.MacroCallArgBlock || i === 0) {
           paramsCode += code;
         } else {
           paramsCode += `, ${code}`;

--- a/packages/shader-lab/src/codeGen/GLESVisitor.ts
+++ b/packages/shader-lab/src/codeGen/GLESVisitor.ts
@@ -3,11 +3,12 @@ import { BaseToken } from "../common/BaseToken";
 import { EShaderStage } from "../common/enums/ShaderStage";
 import { Keyword } from "../common/enums/Keyword";
 import { ASTNode, TreeNode } from "../parser/AST";
+import { NodeChild } from "../parser/types";
 import { ShaderData } from "../parser/ShaderInfo";
 import { ESymbolType, FnSymbol, StructSymbol, SymbolInfo } from "../parser/symbolTable";
 import { CodeGenVisitor } from "./CodeGenVisitor";
 import { ICodeSegment } from "./types";
-import { VisitorContext } from "./VisitorContext";
+import { StructRole, VisitorContext } from "./VisitorContext";
 
 /**
  * @internal
@@ -37,14 +38,97 @@ export abstract class GLESVisitor extends CodeGenVisitor {
     this.reset();
 
     const shaderData = node.shaderData;
-    VisitorContext.context._passSymbolTable = shaderData.symbolTable;
+    const context = VisitorContext.context;
+    context._passSymbolTable = shaderData.symbolTable;
 
     const outerGlobalMacroDeclarations = shaderData.getOuterGlobalMacroDeclarations();
+
+    // Resolve struct roles for both stages' IO structs, then register every variable
+    // whose type is a role-carrying struct — vertex params/locals, fragment
+    // params/locals, and module-level globals. The resulting `_structVarMap` lives
+    // across both stages so a global `#define` referencing, say, the fragment's `v`
+    // parameter is rewritten consistently in both the vertex and fragment outputs.
+    this._collectAllStructVars(vertexEntry, fragmentEntry);
 
     return {
       vertex: this._vertexMain(vertexEntry, shaderData, outerGlobalMacroDeclarations),
       fragment: this._fragmentMain(fragmentEntry, shaderData, outerGlobalMacroDeclarations)
     };
+  }
+
+  /**
+   * Populate `_structVarMap` with every variable whose declared type resolves to a
+   * varying/attribute/mrt struct. Walks both entry functions (plus any overloads)
+   * and the module-level symbol table. Runs before either stage's codegen so the
+   * map is complete from the start and doesn't depend on stage ordering.
+   */
+  private _collectAllStructVars(vertexEntry: string, fragmentEntry: string): void {
+    const context = VisitorContext.context;
+    const lookupSymbol = GLESVisitor._lookupSymbol;
+    const symbolTable = context._passSymbolTable;
+
+    // Derive role-per-struct-type from entry function signatures. Vertex param[0] is
+    // attribute, vertex return is varying; fragment param[0] is varying, fragment
+    // return is mrt.
+    const structRoles: Record<string, StructRole> = Object.create(null);
+
+    const addEntryRoles = (entry: string, paramRole: StructRole, returnRole: StructRole): FnSymbol[] => {
+      lookupSymbol.set(entry, ESymbolType.FN);
+      const fns = <FnSymbol[]>symbolTable.getSymbols(lookupSymbol, true, []);
+      for (const fn of fns) {
+        const proto = fn.astNode.protoType;
+        const param0 = proto.parameterList?.[0];
+        if (param0 && typeof param0.typeInfo?.type === "string") {
+          structRoles[param0.typeInfo.typeLexeme] = paramRole;
+        }
+        if (typeof proto.returnType.type === "string") {
+          structRoles[<string>proto.returnType.type] = returnRole;
+        }
+      }
+      return fns;
+    };
+
+    const entryFns = addEntryRoles(vertexEntry, "attribute", "varying").concat(
+      addEntryRoles(fragmentEntry, "varying", "mrt")
+    );
+
+    // Walk each entry function's params and locals, registering any struct-typed
+    // variable whose type is a role-carrying struct.
+    const registerByType = (typeLexeme: string | undefined, varName: string): void => {
+      if (!typeLexeme) return;
+      const role = structRoles[typeLexeme];
+      if (role) context.registerStructVar(varName, role);
+    };
+
+    const walkLocals = (node: TreeNode): void => {
+      for (const child of node.children) {
+        if (child instanceof ASTNode.InitDeclaratorList) {
+          const typeLexeme = child.typeInfo?.typeLexeme;
+          if (typeLexeme && structRoles[typeLexeme]) {
+            this._extractLocalVarNames(child, context, structRoles[typeLexeme]);
+          }
+        } else if (child instanceof TreeNode) {
+          walkLocals(child);
+        }
+      }
+    };
+
+    for (const fn of entryFns) {
+      const proto = fn.astNode.protoType;
+      if (proto.parameterList) {
+        for (const param of proto.parameterList) {
+          if (param.ident && typeof param.typeInfo?.type === "string") {
+            registerByType(param.typeInfo.typeLexeme, param.ident.lexeme);
+          }
+        }
+      }
+      walkLocals(fn.astNode.statements);
+    }
+
+    // Register module-level globals whose type carries a role (e.g. `Varyings o;`).
+    symbolTable.forEach((sym) => {
+      if (sym.type === ESymbolType.VAR) registerByType(sym.dataType?.typeLexeme, sym.ident);
+    });
   }
 
   private _vertexMain(
@@ -109,6 +193,12 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       }
     });
 
+    // Pre-walk global `#define` values to register any struct-property references
+    // before struct codegen, so the relevant `attribute`/`varying` declarations land
+    // in the output. `_structVarMap` is already populated by `_collectAllStructVars`
+    // in `visitShaderProgram`.
+    this._preRegisterGlobalMacroRefs(outerGlobalMacroDeclarations);
+
     const globalCodeArray = this._globalCodeArray;
     VisitorContext.context.referenceGlobal(entry, ESymbolType.FN);
 
@@ -144,6 +234,11 @@ export abstract class GLESVisitor extends CodeGenVisitor {
     const fnSymbols = <FnSymbol[]>symbolTable.getSymbols(lookupSymbol, true, []);
     if (!fnSymbols?.length) throw `no entry function found: ${entry}`;
 
+    // Fragment's varying info comes from the vertex stage. The vertex stage has
+    // already populated varyingStructs/varyingList via `_vertexMain`, and those are
+    // preserved across the `context.reset(false)` call, so `isVaryingStruct` works
+    // correctly here.
+
     fnSymbols.forEach((fnSymbol) => {
       const fnNode = fnSymbol.astNode;
       const { returnStatement } = fnNode;
@@ -173,6 +268,10 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       }
     });
 
+    // `_structVarMap` is already populated in `visitShaderProgram` with both stages'
+    // variables; just pre-walk macro refs so struct codegen sees the references.
+    this._preRegisterGlobalMacroRefs(outerGlobalMacroStatements);
+
     const globalCodeArray = this._globalCodeArray;
     VisitorContext.context.referenceGlobal(entry, ESymbolType.FN);
 
@@ -193,9 +292,53 @@ export abstract class GLESVisitor extends CodeGenVisitor {
     return globalCode;
   }
 
-  private _getGlobalSymbol(out: ICodeSegment[]): void {
-    const { _referencedGlobals } = VisitorContext.context;
+  private _extractLocalVarNames(node: ASTNode.InitDeclaratorList, context: VisitorContext, role: StructRole): void {
+    const children = node.children;
+    if (children.length === 1) {
+      const singleDecl = children[0] as ASTNode.SingleDeclaration;
+      const identChildren = singleDecl.children;
+      if (identChildren.length >= 2 && identChildren[1] instanceof BaseToken) {
+        context.registerStructVar(identChildren[1].lexeme, role);
+      }
+    } else if (children.length >= 3) {
+      const initDeclList = children[0];
+      if (initDeclList instanceof ASTNode.InitDeclaratorList) {
+        this._extractLocalVarNames(initDeclList, context, role);
+      }
+      if (children[2] instanceof BaseToken) {
+        context.registerStructVar((children[2] as BaseToken).lexeme, role);
+      }
+    }
+  }
 
+  /**
+   * Pre-walk `#define` values in global macro declarations and register any
+   * `structVar.prop` member accesses as referenced struct props. This must run before
+   * struct codegen emits the declaration lists (`attribute …`, `varying …`, `MRT …`),
+   * otherwise properties used only from macros would be missing from the output.
+   */
+  private _preRegisterGlobalMacroRefs(macros: ASTNode.GlobalDeclaration[]): void {
+    for (const macro of macros) {
+      this._walkMacroDefineTokens(macro.children);
+    }
+  }
+
+  private _walkMacroDefineTokens(children: NodeChild[]): void {
+    for (const child of children) {
+      if (child instanceof ASTNode.MacroDefine) {
+        // Codegen the value once so the enclosed `visitPostfixExpression` calls
+        // register their struct-prop references. The returned string is discarded
+        // — the real emit happens later in `_getGlobalMacroDeclarations`.
+        if (child.valueExpression) child.valueExpression.codeGen(this);
+      } else if (child instanceof TreeNode) {
+        this._walkMacroDefineTokens(child.children);
+      }
+    }
+  }
+
+  private _getGlobalSymbol(out: ICodeSegment[]): void {
+    const context = VisitorContext.context;
+    const { _referencedGlobals } = context;
     const lastLength = Object.keys(_referencedGlobals).length;
     if (lastLength === 0) return;
 
@@ -206,7 +349,9 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       const symbols = _referencedGlobals[ident];
       for (let i = 0; i < symbols.length; i++) {
         const sm = symbols[i];
-        const text = sm.astNode.codeGen(this) + (sm.type === ESymbolType.VAR ? ";" : "");
+        const codeGenResult = sm.astNode.codeGen(this);
+        if (!codeGenResult) continue;
+        const text = codeGenResult + (sm.type === ESymbolType.VAR ? ";" : "");
         if (!sm.isInMacroBranch) {
           out.push({
             text,
@@ -264,6 +409,10 @@ export abstract class GLESVisitor extends CodeGenVisitor {
           .sort((a, b) => a.index - b.index)
           .map((item) => item.text)
           .join("\n");
+      } else if (child instanceof BaseToken && child.type === Keyword.MACRO_DEFINE_EXPRESSION) {
+        // Legacy opaque `#define` — its lexeme is the complete directive text,
+        // newlines included; emit verbatim.
+        text = child.lexeme;
       } else {
         text = macro.codeGen(this);
       }

--- a/packages/shader-lab/src/codeGen/GLESVisitor.ts
+++ b/packages/shader-lab/src/codeGen/GLESVisitor.ts
@@ -347,7 +347,7 @@ export abstract class GLESVisitor extends CodeGenVisitor {
       GLESVisitor._serializedGlobalKey.add(ident);
 
       const symbols = _referencedGlobals[ident];
-      for (let i = 0; i < symbols.length; i++) {
+      for (let i = 0, n = symbols.length; i < n; i++) {
         const sm = symbols[i];
         const codeGenResult = sm.astNode.codeGen(this);
         if (!codeGenResult) continue;

--- a/packages/shader-lab/src/codeGen/VisitorContext.ts
+++ b/packages/shader-lab/src/codeGen/VisitorContext.ts
@@ -116,24 +116,6 @@ export class VisitorContext {
     return this._referenceProp("mrt", ident.lexeme, this.mrtList, this._referencedMRTList, ident.location);
   }
 
-  /**
-   * Register a struct property reference by name, driven by macro-value rewriting
-   * where the caller has only the role and the property name, not a lexed token.
-   * Returns a GSError if the property doesn't exist — callers should surface this
-   * instead of silently stripping the prefix, which would defer the error to the
-   * downstream GLSL compiler as "undeclared identifier" and be hard to diagnose.
-   */
-  referenceStructPropByName(role: StructRole, propName: string): Error | void {
-    const list = role === "varying" ? this.varyingList : role === "attribute" ? this.attributeList : this.mrtList;
-    const refList =
-      role === "varying"
-        ? this._referencedVaryingList
-        : role === "attribute"
-          ? this._referencedAttributeList
-          : this._referencedMRTList;
-    return this._referenceProp(role, propName, list, refList, undefined as any);
-  }
-
   referenceGlobal(ident: string, type: ESymbolType): void {
     if (this._referencedGlobals[ident]) return;
 

--- a/packages/shader-lab/src/codeGen/VisitorContext.ts
+++ b/packages/shader-lab/src/codeGen/VisitorContext.ts
@@ -8,6 +8,9 @@ import { StructProp } from "../parser/types";
 import { ShaderLab } from "../ShaderLab";
 import { ShaderLabUtils } from "../ShaderLabUtils";
 
+/** Role of a struct type in ShaderLab's IO flattening. */
+export type StructRole = "varying" | "attribute" | "mrt";
+
 /** @internal */
 export class VisitorContext {
   private static _lookupSymbol: SymbolInfo = new SymbolInfo("", null);
@@ -38,6 +41,13 @@ export class VisitorContext {
   _referencedMRTList: Record<string, StructProp[]>;
   _referencedGlobals: Record<string, SymbolInfo[]>;
   _referencedGlobalMacroASTs: TreeNode[] = [];
+  /**
+   * Maps variable names (function params, locals, and globals whose type is a
+   * varying/attribute/mrt struct) to their role. Populated during stage setup and
+   * used by macro-value rewriting to recognize `varName.prop` patterns that should
+   * be flattened against the IO lists.
+   */
+  _structVarMap: Record<string, StructRole>;
 
   _passSymbolTable: SymbolTable<SymbolInfo>;
 
@@ -56,6 +66,12 @@ export class VisitorContext {
     this._referencedMRTList = Object.create(null);
     this._referencedGlobals = Object.create(null);
     this._referencedGlobalMacroASTs.length = 0;
+    if (resetAll) {
+      // Struct-var bindings are pass-scoped, not stage-scoped — global `#define`
+      // values must see the same bindings in both the vertex and fragment outputs,
+      // so we keep the map across the vertex→fragment stage transition.
+      this._structVarMap = Object.create(null);
+    }
   }
 
   isAttributeStruct(type: string) {
@@ -70,52 +86,52 @@ export class VisitorContext {
     return this.mrtStructs.findIndex((item) => item.ident!.lexeme === type) !== -1;
   }
 
-  referenceAttribute(ident: BaseToken): Error | void {
-    const lexeme = ident.lexeme;
-    if (this._referencedAttributeList[lexeme]) return;
+  /** Return the role of a struct type, or undefined if it isn't one of the IO roles. */
+  getStructRole(typeLexeme: string): StructRole | undefined {
+    if (this.isAttributeStruct(typeLexeme)) return "attribute";
+    if (this.isVaryingStruct(typeLexeme)) return "varying";
+    if (this.isMRTStruct(typeLexeme)) return "mrt";
+  }
 
-    const props = this.attributeList.filter((item) => item.ident.lexeme === lexeme);
-    if (!props.length) {
-      return ShaderLabUtils.createGSError(
-        `referenced attribute not found: ${lexeme}`,
-        GSErrorName.CompilationError,
-        ShaderLab._processingPassText,
-        ident.location
-      );
-    }
-    this._referencedAttributeList[lexeme] = props;
+  /** Register a variable as holding a value of a varying/attribute/mrt struct type. */
+  registerStructVar(varName: string, role: StructRole): void {
+    this._structVarMap[varName] = role;
+  }
+
+  referenceAttribute(ident: BaseToken): Error | void {
+    return this._referenceProp(
+      "attribute",
+      ident.lexeme,
+      this.attributeList,
+      this._referencedAttributeList,
+      ident.location
+    );
   }
 
   referenceVarying(ident: BaseToken): Error | void {
-    const lexeme = ident.lexeme;
-    if (this._referencedVaryingList[lexeme]) return;
-
-    const props = this.varyingList.filter((item) => item.ident.lexeme === lexeme);
-    if (!props.length) {
-      return ShaderLabUtils.createGSError(
-        `referenced varying not found: ${lexeme}`,
-        GSErrorName.CompilationError,
-        ShaderLab._processingPassText,
-        ident.location
-      );
-    }
-    this._referencedVaryingList[lexeme] = props;
+    return this._referenceProp("varying", ident.lexeme, this.varyingList, this._referencedVaryingList, ident.location);
   }
 
   referenceMRTProp(ident: BaseToken): Error | void {
-    const lexeme = ident.lexeme;
-    if (this._referencedMRTList[lexeme]) return;
+    return this._referenceProp("mrt", ident.lexeme, this.mrtList, this._referencedMRTList, ident.location);
+  }
 
-    const props = this.mrtList.filter((item) => item.ident.lexeme === lexeme);
-    if (!props.length) {
-      return ShaderLabUtils.createGSError(
-        `referenced mrt not found: ${lexeme}`,
-        GSErrorName.CompilationError,
-        ShaderLab._processingPassText,
-        ident.location
-      );
-    }
-    this._referencedMRTList[lexeme] = props;
+  /**
+   * Register a struct property reference by name, driven by macro-value rewriting
+   * where the caller has only the role and the property name, not a lexed token.
+   * Returns a GSError if the property doesn't exist — callers should surface this
+   * instead of silently stripping the prefix, which would defer the error to the
+   * downstream GLSL compiler as "undeclared identifier" and be hard to diagnose.
+   */
+  referenceStructPropByName(role: StructRole, propName: string): Error | void {
+    const list = role === "varying" ? this.varyingList : role === "attribute" ? this.attributeList : this.mrtList;
+    const refList =
+      role === "varying"
+        ? this._referencedVaryingList
+        : role === "attribute"
+          ? this._referencedAttributeList
+          : this._referencedMRTList;
+    return this._referenceProp(role, propName, list, refList, undefined as any);
   }
 
   referenceGlobal(ident: string, type: ESymbolType): void {
@@ -126,5 +142,25 @@ export class VisitorContext {
     const lookupSymbol = VisitorContext._lookupSymbol;
     lookupSymbol.set(ident, type);
     this._passSymbolTable.getSymbols(lookupSymbol, true, this._referencedGlobals[ident]);
+  }
+
+  private _referenceProp(
+    role: StructRole,
+    name: string,
+    list: StructProp[],
+    refList: Record<string, StructProp[]>,
+    location: any
+  ): Error | void {
+    if (refList[name]) return;
+    const props = list.filter((item) => item.ident.lexeme === name);
+    if (!props.length) {
+      return ShaderLabUtils.createGSError(
+        `referenced ${role} not found: ${name}`,
+        GSErrorName.CompilationError,
+        ShaderLab._processingPassText,
+        location
+      );
+    }
+    refList[name] = props;
   }
 }

--- a/packages/shader-lab/src/common/BaseLexer.ts
+++ b/packages/shader-lab/src/common/BaseLexer.ts
@@ -33,6 +33,39 @@ export abstract class BaseLexer {
     return charCode === 35; // #
   }
 
+  /**
+   * If `i` points at the start of a `/* … *\/` block comment, return the index
+   * just past the closing `*\/`. Otherwise return `i` unchanged. If the
+   * comment is unterminated, returns `len` (clamped, never overshoots).
+   * Single source of truth for block-comment scanning across the lexer.
+   */
+  protected static _skipBlockComment(src: string, i: number, len: number): number {
+    if (src.charCodeAt(i) !== 47 /* '/' */ || i + 1 >= len || src.charCodeAt(i + 1) !== 42 /* '*' */) return i;
+    let j = i + 2;
+    while (j + 1 < len) {
+      if (src.charCodeAt(j) === 42 && src.charCodeAt(j + 1) === 47) return j + 2;
+      j++;
+    }
+    return len;
+  }
+
+  /**
+   * If `i` points at the start of a `//` line comment, return the index of the
+   * terminating newline (or `len` at EOF). The newline itself is NOT consumed
+   * — callers decide whether `\n` is whitespace or a logical separator.
+   * Otherwise return `i` unchanged.
+   */
+  protected static _skipLineComment(src: string, i: number, len: number): number {
+    if (src.charCodeAt(i) !== 47 /* '/' */ || i + 1 >= len || src.charCodeAt(i + 1) !== 47) return i;
+    let j = i + 2;
+    while (j < len) {
+      const c = src.charCodeAt(j);
+      if (c === 10 || c === 13) break;
+      j++;
+    }
+    return j;
+  }
+
   static isWhiteSpaceChar(charCode: number, includeBreak: boolean): boolean {
     // Space || Tab
     if (charCode === 32 || charCode === 9) {
@@ -129,33 +162,22 @@ export abstract class BaseLexer {
     let index = this._currentIndex;
 
     while (index < length) {
-      // Skip whitespace
+      // Whitespace including newlines — `\n` is just a separator in the
+      // top-level (non-directive) scan path.
       while (index < length && BaseLexer.isWhiteSpaceChar(source.charCodeAt(index), true)) {
         index++;
       }
-
-      // Check for comments: 47 is '/'
-      if (index + 1 >= length || source.charCodeAt(index) !== 47) break;
-
-      const nextChar = source.charCodeAt(index + 1);
-      if (nextChar === 47) {
-        // Single line comment: 10 is '\n', 13 is '\r'
-        index += 2;
-        while (index < length) {
-          const charCode = source.charCodeAt(index);
-          if (charCode === 10 || charCode === 13) break;
-          index++;
-        }
-      } else if (nextChar === 42) {
-        // Multi-line comment: 42 is '*'
-        index += 2;
-        while (index + 1 < length && !(source.charCodeAt(index) === 42 && source.charCodeAt(index + 1) === 47)) {
-          index++;
-        }
-        index += 2; // Skip '*/'
-      } else {
-        break; // Not a comment, stop
+      const afterBlock = BaseLexer._skipBlockComment(source, index, length);
+      if (afterBlock !== index) {
+        index = afterBlock;
+        continue;
       }
+      const afterLine = BaseLexer._skipLineComment(source, index, length);
+      if (afterLine !== index) {
+        index = afterLine;
+        continue;
+      }
+      break;
     }
 
     this.advance(index - this._currentIndex);

--- a/packages/shader-lab/src/common/BaseToken.ts
+++ b/packages/shader-lab/src/common/BaseToken.ts
@@ -4,18 +4,48 @@ import { ShaderLab } from "../ShaderLab";
 import { IPoolElement } from "@galacean/engine";
 import { ShaderLabUtils } from "../ShaderLabUtils";
 
+/**
+ * One condition in a branch signature: `defined: true` for `#ifdef X` (the
+ * branch is active when `X` is defined), `defined: false` for `#ifndef X` /
+ * after `#else` (active when `X` is undefined).
+ */
+export interface BranchConstraint {
+  name: string;
+  defined: boolean;
+}
+
+/**
+ * Snapshot of the `#ifdef`/`#ifndef`/`#else` stack at a source position. An
+ * empty signature means unconditional (top-level). Constraints are conjunctive:
+ * the position is active iff every constraint holds. Produced by the Lexer
+ * (the sole branch-stack maintainer) and stamped onto every emitted token +
+ * every registered `MacroDefineInfo`.
+ */
+export type BranchSignature = readonly BranchConstraint[];
+
+// Canonical empty branch signature shared by all default tokens — avoids
+// per-token allocation. The Lexer overwrites `branch` after `scanToken()`
+// for tokens that are inside an `#ifdef`.
+export const EMPTY_BRANCH: BranchSignature = [];
+
 export class BaseToken<T extends number = number> implements IPoolElement {
   static pool = ShaderLabUtils.createObjectPool(BaseToken);
 
   type: T;
   lexeme: string;
   location: ShaderRange;
+  /** Branch signature snapshot at the point this token was emitted. Empty
+   *  signature (default) means top-level / unconditional. The Lexer tags
+   *  every token; downstream code (AST nodes built from tokens) can read
+   *  the field directly to know which `#ifdef` branch they're inside. */
+  branch: BranchSignature = EMPTY_BRANCH;
 
   set(type: T, lexeme: string, start?: ShaderPosition);
   set(type: T, lexeme: string, location?: ShaderRange);
   set(type: T, lexeme: string, arg?: ShaderRange | ShaderPosition) {
     this.type = type;
     this.lexeme = lexeme;
+    this.branch = EMPTY_BRANCH;
     if (arg) {
       if (arg instanceof ShaderRange) {
         this.location = arg as ShaderRange;

--- a/packages/shader-lab/src/common/SymbolTable.ts
+++ b/packages/shader-lab/src/common/SymbolTable.ts
@@ -55,4 +55,13 @@ export class SymbolTable<T extends IBaseSymbol> {
 
     return out;
   }
+
+  /** Iterate every registered symbol. Order within a name bucket is insertion order. */
+  forEach(callback: (symbol: T) => void): void {
+    for (const entries of this._table.values()) {
+      for (let i = 0, n = entries.length; i < n; i++) {
+        callback(entries[i]);
+      }
+    }
+  }
 }

--- a/packages/shader-lab/src/common/enums/Keyword.ts
+++ b/packages/shader-lab/src/common/enums/Keyword.ts
@@ -111,7 +111,21 @@ export enum Keyword {
   MACRO_ELIF,
   MACRO_ENDIF,
   MACRO_UNDEF,
+  /** Legacy opaque `#define` token — whole directive packed into one lexeme. Retained
+   *  for macros whose value can't be parsed as a GLSL expression (type aliases,
+   *  qualifier aliases, partial-syntax macros). Expression-style macros instead emit
+   *  `MACRO_DEFINE` + ID + value tokens + `MACRO_DEFINE_END`. */
   MACRO_DEFINE_EXPRESSION,
   MACRO_CONDITIONAL_EXPRESSION,
-  MACRO_CALL
+  MACRO_CALL,
+  /** `#define` directive head for expression-style macros. */
+  MACRO_DEFINE,
+  /** Terminates a `MACRO_DEFINE` directive at end-of-line. */
+  MACRO_DEFINE_END,
+  /** `(params)` block for a function-like `#define`. The lexer captures the entire
+   *  parenthesized parameter list as one opaque token so the macro-define CFG rule
+   *  doesn't need its own parameter-list production (which would conflict with
+   *  function_call_parameter_list under LALR(1)). The AST consumer parses the
+   *  lexeme to recover the individual parameter names. */
+  MACRO_DEFINE_PARAMS
 }

--- a/packages/shader-lab/src/lalr/CFG.ts
+++ b/packages/shader-lab/src/lalr/CFG.ts
@@ -23,9 +23,38 @@ const productionAndRules: [GrammarSymbol[], TranslationRule | undefined][] = [
       [NoneTerminal.function_definition],
       [NoneTerminal.global_macro_if_statement],
       [NoneTerminal.macro_undef],
+      [NoneTerminal.macro_define],
       [Keyword.MACRO_DEFINE_EXPRESSION]
     ],
     ASTNode.GlobalDeclaration.pool
+  ),
+
+  // Expression-style `#define` — lexer emits either:
+  //   `MACRO_DEFINE ID <value tokens> MACRO_DEFINE_END`                 (object macro)
+  //   `MACRO_DEFINE ID MACRO_DEFINE_PARAMS <value tokens> MACRO_DEFINE_END` (function macro)
+  //
+  // The `(param1, param2, …)` block is captured by the lexer as a single opaque
+  // `MACRO_DEFINE_PARAMS` token. Capturing in the lexer (rather than recursively in
+  // the CFG via a `macro_define_param_list` non-terminal) avoids an LALR(1) conflict
+  // between `macro_define_param_list` and the visually similar
+  // `function_call_parameter_list` when the parser is in a state that could follow
+  // either `LEFT_PAREN ID , ID` pattern.
+  //
+  // Empty-value `#define X\n` and function-like without body stay on the legacy
+  // opaque `MACRO_DEFINE_EXPRESSION` path.
+  ...GrammarUtils.createProductionWithOptions(
+    NoneTerminal.macro_define,
+    [
+      [Keyword.MACRO_DEFINE, ETokenType.ID, NoneTerminal.assignment_expression, Keyword.MACRO_DEFINE_END],
+      [
+        Keyword.MACRO_DEFINE,
+        ETokenType.ID,
+        Keyword.MACRO_DEFINE_PARAMS,
+        NoneTerminal.assignment_expression,
+        Keyword.MACRO_DEFINE_END
+      ]
+    ],
+    ASTNode.MacroDefine.pool
   ),
 
   ...GrammarUtils.createProductionWithOptions(
@@ -826,6 +855,7 @@ const productionAndRules: [GrammarSymbol[], TranslationRule | undefined][] = [
       [NoneTerminal.jump_statement],
       [NoneTerminal.macro_if_statement],
       [NoneTerminal.macro_undef],
+      [NoneTerminal.macro_define],
       [Keyword.MACRO_DEFINE_EXPRESSION]
     ],
     // #if _VERBOSE

--- a/packages/shader-lab/src/lalr/Utils.ts
+++ b/packages/shader-lab/src/lalr/Utils.ts
@@ -29,16 +29,29 @@ export default class GrammarUtils {
       { set: (loc: ShaderRange, children: NodeChild[]) => void } & IPoolElement & TreeNode
     >
   ) {
+    // Resolve the AST pool once per grammar production (not per reduce).
+    const pool = astTypePool ?? ASTNode.TrivialNode.pool;
     const ret: [GrammarSymbol[], TranslationRule | undefined][] = [];
     for (const opt of options) {
+      // Single-`NonTerminal` RHS + no typed class → this production reduces
+      // to a semantic-empty `TrivialNode` wrapper. Elide it at reduce time
+      // by pushing the child directly onto the semantic stack. Safe because
+      // the parser's GOTO runs off `reduceProduction.goal`, not off the node
+      // type on the stack. Single-Terminal RHS (e.g. `unary_operator → PLUS`)
+      // isn't eligible — a `BaseToken` can't stand in for an AST node.
+      const canElide = !astTypePool && opt.length === 1 && !GrammarUtils.isTerminal(opt[0]);
       ret.push([
         [goal, ...opt],
         function (sa, ...children) {
           if (!children[0]) return;
-          const start = children[0].location.start;
-          const end = children[children.length - 1].location.end;
-          const location = ShaderLab.createRange(start, end);
-          ASTNode.get(astTypePool ?? ASTNode.TrivialNode.pool, sa, location, children);
+          if (canElide) {
+            sa.semanticStack.push(children[0] as TreeNode);
+          } else {
+            const start = children[0].location.start;
+            const end = children[children.length - 1].location.end;
+            const location = ShaderLab.createRange(start, end);
+            ASTNode.get(pool, sa, location, children);
+          }
         }
       ]);
     }

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -98,6 +98,12 @@ export class Lexer extends BaseLexer {
   // C preprocessor line continuation: `\` followed by `\r\n`, `\n`, or `\r`.
   // The pair is removed (the next physical line is part of the same logical line).
   private static readonly _lineContinuationReg = /\\(?:\r\n|\n|\r)/g;
+  // Sentinel pushed onto the branch stack when `#if expr` opens a level we
+  // don't model. `name === ""` never matches a real flag in
+  // `isVisibleFrom`'s polarity check, so it's conservatively visible
+  // everywhere — but it occupies one stack slot so `#endif` pops the right
+  // depth. Shared by all `#if` opens to avoid per-token allocation.
+  private static readonly _IF_SENTINEL: BranchConstraint = { name: "", defined: true };
 
   /** Two branch signatures are equal iff they have the same constraints in the
    *  same order with the same polarity. Used by `#define` dedup and AST upgrade
@@ -117,9 +123,11 @@ export class Lexer extends BaseLexer {
    * else is compatible — the same flag with the same polarity, or flags that
    * simply don't intersect.
    *
-   * Conservative for `#if expr` (not modeled — its branch is empty, so
-   * compatible with everything) and exact for the common `#ifdef` / `#ifndef`
-   * / `#else` cases that drive real shader code.
+   * Conservative for `#if expr` (not modeled — `tokenize` pushes a sentinel
+   * with `name === ""` to keep the `#endif` stack depth correct; that
+   * sentinel never matches a real flag in the polarity check below, so it
+   * stays visible from everywhere). Exact for the common `#ifdef` /
+   * `#ifndef` / `#else` cases that drive real shader code.
    */
   static isVisibleFrom(defBranch: BranchSignature, callSiteBranch: BranchSignature): boolean {
     for (let i = 0, n = defBranch.length; i < n; i++) {
@@ -186,7 +194,12 @@ export class Lexer extends BaseLexer {
       if (this._branchStack.length > 0) tok.branch = this._branchStack.slice();
 
       // Update stack state based on the just-emitted token, so the *next*
-      // token sees the correct snapshot.
+      // token sees the correct snapshot. `#if expr` opens a level we can't
+      // address (we don't model expressions), but it must still consume one
+      // stack slot so the matching `#endif` pops the right depth — otherwise
+      // an outer `#ifdef A`'s constraint would be wrongly popped. `#elif`
+      // doesn't change depth (it's another arm at the same level), so no
+      // case is needed.
       switch (tok.type as Keyword) {
         case Keyword.MACRO_IFDEF:
           this._pendingBranchPushDefined = true;
@@ -194,10 +207,14 @@ export class Lexer extends BaseLexer {
         case Keyword.MACRO_IFNDEF:
           this._pendingBranchPushDefined = false;
           break;
+        case Keyword.MACRO_IF:
+          this._branchStack.push(Lexer._IF_SENTINEL);
+          break;
         case Keyword.MACRO_ELSE: {
-          // Flip the polarity of the topmost constraint. `#else` after
-          // `#if expr` (which we don't model) leaves the empty placeholder
-          // alone — empty signature is conservatively visible from anywhere.
+          // Flip the polarity of the topmost constraint. For `#ifdef X` this
+          // turns `[X=true]` into `[X=false]`. For `#if expr` chains the top
+          // is the sentinel (`name=""`), and flipping its `defined` is
+          // harmless — `isVisibleFrom` ignores empty-name entries.
           const top = this._branchStack[this._branchStack.length - 1];
           if (top) this._branchStack[this._branchStack.length - 1] = { name: top.name, defined: !top.defined };
           break;
@@ -663,7 +680,7 @@ export class Lexer extends BaseLexer {
     return false;
   }
 
-/**
+  /**
    * If `i` points at a `\` immediately followed by a newline (`\n`, `\r`, or
    * `\r\n`), return the index just past the pair (a single atom in the C/GLSL
    * preprocessor view). Otherwise return `i` unchanged. This is the single

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -2,7 +2,7 @@ import { ETokenType } from "../common";
 import { BaseLexer } from "../common/BaseLexer";
 import { BaseToken, EOF } from "../common/BaseToken";
 import { Keyword } from "../common/enums/Keyword";
-import { MacroDefineList } from "../Preprocessor";
+import { MacroDefineInfo, MacroDefineList } from "../Preprocessor";
 import { ShaderLab } from "../ShaderLab";
 
 /**
@@ -85,6 +85,17 @@ export class Lexer extends BaseLexer {
     "#undef": Keyword.MACRO_UNDEF
   };
 
+  // Parses a `#define <name>[(params)] [value]` directive lexeme, sliced from
+  // `_source` between the `#` and the directive-terminating newline. Used by
+  // `_registerMacroDefine` to feed `macroDefineList` from both the AST and
+  // legacy `#define` paths — single source of truth, no drift between two
+  // analyzers.
+  private static readonly _defineDirectiveReg = /^\s*#define\s+(\w+)[ ]*(\(([^)]*)\))?(?:[ \t]+([^\n\r]*?))?\s*$/;
+  // Anchors a `#define` value to a bare identifier or function-call form
+  // (`foo` or `foo(a, b)`); mixed-operator values like `a + b` reject. The
+  // captured identifier becomes `MacroDefineInfo.referenceName`.
+  private static readonly _referenceReg = /^([a-zA-Z_]\w*)(?:\s*\(.*\))?$/;
+
   private _needScanMacroConditionExpression = false;
 
   // --- `#define` scanning state machine ---
@@ -104,6 +115,13 @@ export class Lexer extends BaseLexer {
   private _inMacroDefineValue = false;
   private _macroDefineExpectsNameToken = false;
   private _macroDefineExpectsParamsToken = false;
+
+  // Source offset of the current `#define` directive's start (the `#`).
+  // Set when `_scanDirectives` consumes `#define`, used by
+  // `_registerMacroDefine` at MACRO_DEFINE_END to slice out the directive
+  // text and parse it with the same regex the legacy path uses — single
+  // source of truth.
+  private _macroDefineDirectiveStart: number = -1;
 
   *tokenize() {
     while (!this.isEnd()) {
@@ -453,9 +471,10 @@ export class Lexer extends BaseLexer {
     const word = buffer.join("");
 
     if (word === "#define") {
-      // Peek the rest of the line: if the directive has no value (`#define X\n`),
-      // fall back to the legacy opaque path. Only directives with a non-empty
-      // value enter expression-mode (AST parsing).
+      // Mark the directive's start offset (the `#`) so the regex-based
+      // registrar can later slice out the full directive text from `_source`.
+      // Two paths share the same registrar — single source of truth.
+      this._macroDefineDirectiveStart = start.index;
       if (this._defineHasValue()) {
         this._inMacroDefineValue = true;
         // The next word is the macro name: force ID type even if a prior `#define`
@@ -466,6 +485,8 @@ export class Lexer extends BaseLexer {
       } else {
         this._scanUtilBreakLine(buffer);
         const lexeme = "\n" + buffer.join("") + "\n";
+        // Legacy path: register immediately by parsing the buffered directive.
+        this._registerMacroDefine(this._source.slice(this._macroDefineDirectiveStart, this._currentIndex));
         token.set(Keyword.MACRO_DEFINE_EXPRESSION, lexeme, start);
       }
     } else {
@@ -646,10 +667,53 @@ export class Lexer extends BaseLexer {
         this.advance(1);
       }
     }
+    // Register the directive into macroDefineList — single source of truth.
+    this._registerMacroDefine(this._source.slice(this._macroDefineDirectiveStart, this._currentIndex));
     this._inMacroDefineValue = false;
     const token = BaseToken.pool.get();
     token.set(Keyword.MACRO_DEFINE_END, "\n", start);
     return token;
+  }
+
+  // Parse a `#define <name>[(params)] [value]` directive (already lexed to
+  // its newline) and register it. Both AST and legacy paths funnel through
+  // here — single source of truth, no drift between two analyzers.
+  private _registerMacroDefine(directive: string): void {
+    const m = Lexer._defineDirectiveReg.exec(directive);
+    if (!m) return;
+    const name = m[1];
+    const paramsStr = m[3];
+    const valueRaw = m[4];
+    const params = paramsStr
+      ? paramsStr
+          .split(",")
+          .map((p) => p.trim())
+          .filter(Boolean)
+      : [];
+    const refMatch = valueRaw ? Lexer._referenceReg.exec(valueRaw.trim()) : null;
+    const info: MacroDefineInfo = {
+      isFunction: m[2] !== undefined,
+      name,
+      params,
+      referenceName: refMatch ? refMatch[1] : ""
+    };
+    const arr = this.macroDefineList[name];
+    if (!arr) {
+      this.macroDefineList[name] = [info];
+      return;
+    }
+    // Skip duplicates from re-includes / re-definitions in #ifdef branches.
+    for (let i = 0, n = arr.length; i < n; i++) {
+      const e = arr[i];
+      if (
+        e.isFunction === info.isFunction &&
+        e.referenceName === info.referenceName &&
+        e.params.length === info.params.length &&
+        e.params.every((p, idx) => p === info.params[idx])
+      )
+        return;
+    }
+    arr.push(info);
   }
 
   private _scanMacroConditionExpression(): BaseToken {

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -569,39 +569,27 @@ export class Lexer extends BaseLexer {
     // Line-continuation: `\` + newline — treat as no value for simplicity.
     if (ch === "\\" && (src[i + 1] === "\n" || src[i + 1] === "\r")) return false;
 
-    // GLSL ES 3.00 §3.4: a `#define` replacement list is any sequence of
-    // preprocessor tokens, not necessarily a valid expression. Route to the
-    // AST path only when the value is *likely* a well-formed
-    // `assignment_expression`; otherwise fall back to the opaque legacy path,
-    // which emits the directive verbatim for the GLSL driver to handle.
-    //
-    //   - alpha start  → identifier, or a keyword-starter (constructor / bool
-    //                     literal in the whitelist; declaration-style keywords
-    //                     like `highp` / `uniform` fall to legacy)
-    //   - digit / `.`  → numeric literal
-    //
-    // Other value shapes (values starting with `(`, `-`, `+`, `!`, `~`, `{`,
-    // `,`, `;`, `:`, `[`, `=`, `*`, `/`, `|`, `^`, `%`, `?`, …) take the legacy
-    // opaque path. This is a deliberately conservative classifier: anything
-    // that isn't obviously an identifier or numeric literal stays opaque so
-    // that non-expression replacement lists (e.g. `#define COMMA ,`,
-    // `#define PAREN (`) round-trip through the driver untouched.
-    if (BaseLexer.isAlpha(src.charCodeAt(i))) {
-      const wordStart = i;
-      while (i < src.length && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
-      const firstWord = src.substring(wordStart, i);
-      const kw = Lexer._lexemeTable[firstWord];
-      if (kw !== undefined && !Lexer._expressionLeaderKeywords.has(kw)) {
-        return false;
-      }
-      return true;
-    }
-    if (BaseLexer.isDigit(src.charCodeAt(i))) return true;
-    if (ch === ".") {
-      // `.5` numeric literal; `.` alone or `.ident` is not a valid expression start.
-      return i + 1 < src.length && BaseLexer.isDigit(src.charCodeAt(i + 1));
-    }
-    return false;
+    // GLSL ES 3.00 §3.4: a `#define` replacement list is any token sequence,
+    // not necessarily a valid expression. Route to the AST path only when the
+    // value *looks like* a well-formed `assignment_expression`; otherwise fall
+    // back to the opaque legacy path (the directive is emitted verbatim for
+    // the driver). Conservative-by-design: only identifier and numeric-literal
+    // leaders go AST. `(`, unary prefixes, `{`, `,`, `;`, `:`, … stay opaque —
+    // real shader code doesn't lead a `#define` value with those shapes, and
+    // keeping them opaque lets non-expression replacement lists like
+    // `#define COMMA ,` round-trip through the driver untouched.
+    const c = src.charCodeAt(i);
+    if (BaseLexer.isDigit(c)) return true;
+    if (ch === "." && i + 1 < src.length && BaseLexer.isDigit(src.charCodeAt(i + 1))) return true;
+    if (!BaseLexer.isAlpha(c)) return false;
+    // Alpha-leader: identifier, or a whitelist-approved expression-starter
+    // keyword. Other GLSL keywords (declaration / qualifier / control-flow)
+    // fall to the legacy path.
+    let j = i;
+    while (j < src.length && BaseLexer.isAlnum(src.charCodeAt(j))) j++;
+    const firstWord = src.substring(i, j);
+    const kw = Lexer._lexemeTable[firstWord];
+    return kw === undefined || Lexer._expressionLeaderKeywords.has(kw);
   }
 
   /**

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -486,74 +486,35 @@ export class Lexer extends BaseLexer {
   }
 
   /**
-   * Keywords that CAN legitimately start a GLSL expression — boolean literals and
-   * scalar/vector/matrix type constructors. Any other keyword appearing as the
-   * first token of a `#define` value means the macro is expanding into a
-   * declaration/statement (type alias, qualifier alias, etc.) and must stay on
-   * the legacy opaque path.
-   *
-   * Sampler types and `void` are intentionally excluded (no sampler/void
-   * constructor in GLSL ES). Qualifier keywords (`highp`, `in`, `uniform`,
-   * `struct`, `const`, `precision`, …) are also excluded — they open
-   * declarations, not expressions.
-   */
-  private static readonly _expressionLeaderKeywords = new Set<Keyword>([
-    // Boolean literals
-    Keyword.True,
-    Keyword.False,
-    // Scalar type constructors
-    Keyword.BOOL,
-    Keyword.INT,
-    Keyword.UINT,
-    Keyword.FLOAT,
-    Keyword.DOUBLE,
-    // Vector type constructors
-    Keyword.BVEC2,
-    Keyword.BVEC3,
-    Keyword.BVEC4,
-    Keyword.IVEC2,
-    Keyword.IVEC3,
-    Keyword.IVEC4,
-    Keyword.UVEC2,
-    Keyword.UVEC3,
-    Keyword.UVEC4,
-    Keyword.VEC2,
-    Keyword.VEC3,
-    Keyword.VEC4,
-    // Matrix type constructors
-    Keyword.MAT2,
-    Keyword.MAT3,
-    Keyword.MAT4,
-    Keyword.MAT2X3,
-    Keyword.MAT2X4,
-    Keyword.MAT3X2,
-    Keyword.MAT3X4,
-    Keyword.MAT4X2,
-    Keyword.MAT4X3
-  ]);
-
-  /**
    * Peek forward from `#define` and decide whether this directive should use the
-   * expression-AST path or the legacy opaque path. Returns true for values that
-   * can plausibly be parsed as a GLSL expression; returns false for:
-   *   - empty bodies (`#define FOO\n`)
-   *   - values whose first token is a type/qualifier keyword (the macro is
-   *     expanding into a declaration, not an expression)
-   *   - values using `\` line continuation (rare; simpler to stay opaque)
+   * expression-AST path or the legacy opaque path.
+   *
+   * The AST path's only purpose is to enable ShaderLab's structural rewrites
+   * (varying flatten, struct-property reference tracking) on macro values that
+   * mention struct members. Every other shape — bare identifiers, numeric
+   * literals, type-alias keywords (`#define FxaaFloat2 vec2`), constructor
+   * calls, qualifier fragments, `#define COMMA ,` etc. — is correctly handled
+   * by the GLSL driver via textual substitution and needs no AST.
+   *
+   * So the routing rule is positive and information-driven: **AST iff the
+   * replacement list contains a `.` member-access operator**. This is robust
+   * against new GLSL keywords / extensions and incidentally moves all simple
+   * constants and type aliases off the 18-layer expression precedence chain.
    */
   private _defineHasValue(): boolean {
     const src = this._source;
+    const len = src.length;
     let i = this._currentIndex;
     // Skip inline whitespace after `#define`
-    while (i < src.length && (src[i] === " " || src[i] === "\t")) i++;
+    while (i < len && (src[i] === " " || src[i] === "\t")) i++;
     // Skip macro name
-    if (!(i < src.length && BaseLexer.isAlpha(src.charCodeAt(i)))) return false;
-    while (i < src.length && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
+    if (!(i < len && BaseLexer.isAlpha(src.charCodeAt(i)))) return false;
+    while (i < len && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
     // Optional `(params)`: scan past a balanced pair on the same line
     if (src[i] === "(") {
       let depth = 1;
       i++;
-      while (i < src.length && depth > 0) {
+      while (i < len && depth > 0) {
         const ch = src[i];
         if (ch === "\n" || ch === "\r") return false; // malformed: stay legacy
         if (ch === "(") depth++;
@@ -561,35 +522,20 @@ export class Lexer extends BaseLexer {
         i++;
       }
     }
-    // Skip trailing whitespace between `)` (or name) and the value
-    while (i < src.length && (src[i] === " " || src[i] === "\t")) i++;
-    if (i >= src.length) return false;
-    const ch = src[i];
-    if (ch === "\n" || ch === "\r") return false;
-    // Line-continuation: `\` + newline — treat as no value for simplicity.
-    if (ch === "\\" && (src[i + 1] === "\n" || src[i + 1] === "\r")) return false;
-
-    // GLSL ES 3.00 §3.4: a `#define` replacement list is any token sequence,
-    // not necessarily a valid expression. Route to the AST path only when the
-    // value *looks like* a well-formed `assignment_expression`; otherwise fall
-    // back to the opaque legacy path (the directive is emitted verbatim for
-    // the driver). Conservative-by-design: only identifier and numeric-literal
-    // leaders go AST. `(`, unary prefixes, `{`, `,`, `;`, `:`, … stay opaque —
-    // real shader code doesn't lead a `#define` value with those shapes, and
-    // keeping them opaque lets non-expression replacement lists like
-    // `#define COMMA ,` round-trip through the driver untouched.
-    const c = src.charCodeAt(i);
-    if (BaseLexer.isDigit(c)) return true;
-    if (ch === "." && i + 1 < src.length && BaseLexer.isDigit(src.charCodeAt(i + 1))) return true;
-    if (!BaseLexer.isAlpha(c)) return false;
-    // Alpha-leader: identifier, or a whitelist-approved expression-starter
-    // keyword. Other GLSL keywords (declaration / qualifier / control-flow)
-    // fall to the legacy path.
-    let j = i;
-    while (j < src.length && BaseLexer.isAlnum(src.charCodeAt(j))) j++;
-    const firstWord = src.substring(i, j);
-    const kw = Lexer._lexemeTable[firstWord];
-    return kw === undefined || Lexer._expressionLeaderKeywords.has(kw);
+    // Scan the rest of the line for a member-access `.`. Skip the decimal
+    // point inside numeric literals (`3.14`, `1.0e-5`) by checking the prior
+    // char is not a digit.
+    for (let k = i; k < len; k++) {
+      const c = src.charCodeAt(k);
+      if (c === 10 || c === 13) break;
+      // Line-continuation: `\` + newline — treat as no value for simplicity.
+      if (c === 92 && (src.charCodeAt(k + 1) === 10 || src.charCodeAt(k + 1) === 13)) return false;
+      if (c === 46 /* `.` */) {
+        const prev = k > 0 ? src.charCodeAt(k - 1) : 0;
+        if (prev < 48 || prev > 57) return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -721,9 +721,14 @@ export class Lexer extends BaseLexer {
       // Bypass MACRO_CALL classification for this one word. Used for the name of
       // a `#define` directive so redefining a known macro still yields a declarer ID.
       this._macroDefineExpectsNameToken = false;
-      // If we're inside a `#define` directive, this ID *is* the macro name and the
-      // next character, if `(`, begins the parameter list.
-      if (this._inMacroDefineValue) this._macroDefineExpectsParamsToken = true;
+      // C99 §6.10.3/3: the macro is function-like only when `(` appears *immediately*
+      // after the name (no intervening whitespace). `#define FOO (1+2)` is
+      // object-like with value `(1+2)`, not a function-like macro `FOO()` with
+      // body `1+2`. Check the current char before any whitespace-skipping happens
+      // on the next `scanToken`, so a space-separated `(` stays part of the value.
+      if (this._inMacroDefineValue) {
+        this._macroDefineExpectsParamsToken = this.getCurChar() === "(";
+      }
       token.set(ETokenType.ID, word, start);
     } else if (this.macroDefineList[word]) {
       token.set(Keyword.MACRO_CALL, word, start);

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -522,18 +522,22 @@ export class Lexer extends BaseLexer {
         i++;
       }
     }
-    // Scan to end-of-line. A `.` is a member-access operator iff its preceding
-    // alnum-or-underscore run starts with an identifier char (alpha or `_`).
-    // Numeric literals (`3.14`, `1e-5`) start with a digit; non-token contexts
-    // (`vec2(1.0).x`, `.5`) leave the run empty. Both naturally fail the
-    // `isAlpha` check on the run-start char.
+    // Scan to end-of-line. A `.` is a member-access operator unless it's a
+    // decimal point inside a numeric literal — the latter has digits on both
+    // sides (`3.14`, `1.0e-5`). Member access covers `v.x`, `v0.x`, `(v).x`,
+    // `v . x`, `arr[i].field`, `(a+b).field`, etc. — all need AST routing
+    // for varying-flatten / type-propagation. Edge cases like `.5` go AST
+    // too (false positive, but the AST path handles bare floats correctly).
     for (let k = i; k < len; k++) {
       const c = src.charCodeAt(k);
       if (c === 10 || c === 13) break;
       if (c !== 46 /* `.` */) continue;
-      let m = k - 1;
-      while (m >= 0 && BaseLexer.isAlnum(src.charCodeAt(m))) m--;
-      if (BaseLexer.isAlpha(src.charCodeAt(m + 1))) return true;
+      const prev = k > 0 ? src.charCodeAt(k - 1) : 0;
+      const next = k + 1 < len ? src.charCodeAt(k + 1) : 0;
+      const prevIsDigit = prev >= 48 && prev <= 57;
+      const nextIsDigit = next >= 48 && next <= 57;
+      if (prevIsDigit && nextIsDigit) continue; // numeric literal `3.14`
+      return true;
     }
     return false;
   }

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -491,22 +491,51 @@ export class Lexer extends BaseLexer {
    * expanding into a declaration/statement (type alias, qualifier alias, etc.)
    * and must stay on the legacy opaque path.
    *
-   * Kept as a whitelist rather than a blacklist because the keyword table is
-   * dominated by type/qualifier names — enumerating the small set of
-   * expression-leader keywords is less error-prone and survives new types being
-   * added to GLSL without needing to remember to update a blacklist.
+   * Two flavors of expression-starter keywords:
+   *   - Boolean literals: `true`, `false`
+   *   - Type constructors: `vec2(...)`, `mat3(...)`, `float(...)` etc. — GLSL
+   *     allows any scalar/vector/matrix type name to start a constructor-call
+   *     expression. Sampler types are excluded (no sampler constructor in
+   *     GLSL ES).
    *
-   * `uniform`, `varying`, `attribute` appear in shader source but aren't in
-   * `_lexemeTable` as keywords; they're plain identifiers to the lexer and
-   * naturally fall through as valid "expression-start" identifiers (they aren't
-   * expression starters syntactically, but any legitimate use of them leading a
-   * `#define` value is already malformed — the LALR parser will surface the
-   * error).
+   * Qualifier keywords (`highp`, `mediump`, `in`, `out`, `uniform`, `struct`,
+   * `precision`, `layout`, `invariant`, `const`, etc.) are intentionally NOT
+   * here — starting a `#define` value with them means it's a declaration-style
+   * macro that should stay opaque.
    */
   private static readonly _expressionValueLeaderKeywords = new Set<string>([
     // Boolean literals
     "true",
-    "false"
+    "false",
+    // Scalar type constructors
+    "bool",
+    "int",
+    "uint",
+    "float",
+    "double",
+    // Vector type constructors
+    "bvec2",
+    "bvec3",
+    "bvec4",
+    "ivec2",
+    "ivec3",
+    "ivec4",
+    "uvec2",
+    "uvec3",
+    "uvec4",
+    "vec2",
+    "vec3",
+    "vec4",
+    // Matrix type constructors
+    "mat2",
+    "mat3",
+    "mat4",
+    "mat2x3",
+    "mat2x4",
+    "mat3x2",
+    "mat3x4",
+    "mat4x2",
+    "mat4x3"
   ]);
 
   /**

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -522,18 +522,18 @@ export class Lexer extends BaseLexer {
         i++;
       }
     }
-    // Scan the rest of the line for a member-access `.`. Skip the decimal
-    // point inside numeric literals (`3.14`, `1.0e-5`) by checking the prior
-    // char is not a digit.
+    // Scan to end-of-line. A `.` is a member-access operator iff its preceding
+    // alnum-or-underscore run starts with an identifier char (alpha or `_`).
+    // Numeric literals (`3.14`, `1e-5`) start with a digit; non-token contexts
+    // (`vec2(1.0).x`, `.5`) leave the run empty. Both naturally fail the
+    // `isAlpha` check on the run-start char.
     for (let k = i; k < len; k++) {
       const c = src.charCodeAt(k);
       if (c === 10 || c === 13) break;
-      // Line-continuation: `\` + newline — treat as no value for simplicity.
-      if (c === 92 && (src.charCodeAt(k + 1) === 10 || src.charCodeAt(k + 1) === 13)) return false;
-      if (c === 46 /* `.` */) {
-        const prev = k > 0 ? src.charCodeAt(k - 1) : 0;
-        if (prev < 48 || prev > 57) return true;
-      }
+      if (c !== 46 /* `.` */) continue;
+      let m = k - 1;
+      while (m >= 0 && BaseLexer.isAlnum(src.charCodeAt(m))) m--;
+      if (BaseLexer.isAlpha(src.charCodeAt(m + 1))) return true;
     }
     return false;
   }

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -486,56 +486,50 @@ export class Lexer extends BaseLexer {
   }
 
   /**
-   * Keywords that CAN legitimately start a GLSL expression. Any other keyword
-   * appearing as the first token of a `#define` value means the macro is
-   * expanding into a declaration/statement (type alias, qualifier alias, etc.)
-   * and must stay on the legacy opaque path.
+   * Keywords that CAN legitimately start a GLSL expression — boolean literals and
+   * scalar/vector/matrix type constructors. Any other keyword appearing as the
+   * first token of a `#define` value means the macro is expanding into a
+   * declaration/statement (type alias, qualifier alias, etc.) and must stay on
+   * the legacy opaque path.
    *
-   * Two flavors of expression-starter keywords:
-   *   - Boolean literals: `true`, `false`
-   *   - Type constructors: `vec2(...)`, `mat3(...)`, `float(...)` etc. — GLSL
-   *     allows any scalar/vector/matrix type name to start a constructor-call
-   *     expression. Sampler types are excluded (no sampler constructor in
-   *     GLSL ES).
-   *
-   * Qualifier keywords (`highp`, `mediump`, `in`, `out`, `uniform`, `struct`,
-   * `precision`, `layout`, `invariant`, `const`, etc.) are intentionally NOT
-   * here — starting a `#define` value with them means it's a declaration-style
-   * macro that should stay opaque.
+   * Sampler types and `void` are intentionally excluded (no sampler/void
+   * constructor in GLSL ES). Qualifier keywords (`highp`, `in`, `uniform`,
+   * `struct`, `const`, `precision`, …) are also excluded — they open
+   * declarations, not expressions.
    */
-  private static readonly _expressionValueLeaderKeywords = new Set<string>([
+  private static readonly _expressionLeaderKeywords = new Set<Keyword>([
     // Boolean literals
-    "true",
-    "false",
+    Keyword.True,
+    Keyword.False,
     // Scalar type constructors
-    "bool",
-    "int",
-    "uint",
-    "float",
-    "double",
+    Keyword.BOOL,
+    Keyword.INT,
+    Keyword.UINT,
+    Keyword.FLOAT,
+    Keyword.DOUBLE,
     // Vector type constructors
-    "bvec2",
-    "bvec3",
-    "bvec4",
-    "ivec2",
-    "ivec3",
-    "ivec4",
-    "uvec2",
-    "uvec3",
-    "uvec4",
-    "vec2",
-    "vec3",
-    "vec4",
+    Keyword.BVEC2,
+    Keyword.BVEC3,
+    Keyword.BVEC4,
+    Keyword.IVEC2,
+    Keyword.IVEC3,
+    Keyword.IVEC4,
+    Keyword.UVEC2,
+    Keyword.UVEC3,
+    Keyword.UVEC4,
+    Keyword.VEC2,
+    Keyword.VEC3,
+    Keyword.VEC4,
     // Matrix type constructors
-    "mat2",
-    "mat3",
-    "mat4",
-    "mat2x3",
-    "mat2x4",
-    "mat3x2",
-    "mat3x4",
-    "mat4x2",
-    "mat4x3"
+    Keyword.MAT2,
+    Keyword.MAT3,
+    Keyword.MAT4,
+    Keyword.MAT2X3,
+    Keyword.MAT2X4,
+    Keyword.MAT3X2,
+    Keyword.MAT3X4,
+    Keyword.MAT4X2,
+    Keyword.MAT4X3
   ]);
 
   /**
@@ -583,7 +577,8 @@ export class Lexer extends BaseLexer {
       const wordStart = i;
       while (i < src.length && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
       const firstWord = src.substring(wordStart, i);
-      if (Lexer._lexemeTable[firstWord] !== undefined && !Lexer._expressionValueLeaderKeywords.has(firstWord)) {
+      const kw = Lexer._lexemeTable[firstWord];
+      if (kw !== undefined && !Lexer._expressionLeaderKeywords.has(kw)) {
         return false;
       }
     }

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -569,10 +569,23 @@ export class Lexer extends BaseLexer {
     // Line-continuation: `\` + newline — treat as no value for simplicity.
     if (ch === "\\" && (src[i + 1] === "\n" || src[i + 1] === "\r")) return false;
 
-    // Peek the first word of the value. If it's a GLSL keyword that doesn't start
-    // expressions (type, qualifier, statement leader), the value isn't
-    // expression-shaped — use the legacy path. Non-keyword identifiers and the
-    // explicit expression-starter keywords (`true`/`false`) go through the AST path.
+    // GLSL ES 3.00 §3.4: a `#define` replacement list is any sequence of
+    // preprocessor tokens, not necessarily a valid expression. Route to the
+    // AST path only when the value is *likely* a well-formed
+    // `assignment_expression`; otherwise fall back to the opaque legacy path,
+    // which emits the directive verbatim for the GLSL driver to handle.
+    //
+    //   - alpha start  → identifier, or a keyword-starter (constructor / bool
+    //                     literal in the whitelist; declaration-style keywords
+    //                     like `highp` / `uniform` fall to legacy)
+    //   - digit / `.`  → numeric literal
+    //
+    // Other value shapes (values starting with `(`, `-`, `+`, `!`, `~`, `{`,
+    // `,`, `;`, `:`, `[`, `=`, `*`, `/`, `|`, `^`, `%`, `?`, …) take the legacy
+    // opaque path. This is a deliberately conservative classifier: anything
+    // that isn't obviously an identifier or numeric literal stays opaque so
+    // that non-expression replacement lists (e.g. `#define COMMA ,`,
+    // `#define PAREN (`) round-trip through the driver untouched.
     if (BaseLexer.isAlpha(src.charCodeAt(i))) {
       const wordStart = i;
       while (i < src.length && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
@@ -581,8 +594,14 @@ export class Lexer extends BaseLexer {
       if (kw !== undefined && !Lexer._expressionLeaderKeywords.has(kw)) {
         return false;
       }
+      return true;
     }
-    return true;
+    if (BaseLexer.isDigit(src.charCodeAt(i))) return true;
+    if (ch === ".") {
+      // `.5` numeric literal; `.` alone or `.ident` is not a valid expression start.
+      return i + 1 < src.length && BaseLexer.isDigit(src.charCodeAt(i + 1));
+    }
+    return false;
   }
 
   /**

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -195,11 +195,9 @@ export class Lexer extends BaseLexer {
 
       // Update stack state based on the just-emitted token, so the *next*
       // token sees the correct snapshot. `#if expr` opens a level we can't
-      // address (we don't model expressions), but it must still consume one
-      // stack slot so the matching `#endif` pops the right depth — otherwise
-      // an outer `#ifdef A`'s constraint would be wrongly popped. `#elif`
-      // doesn't change depth (it's another arm at the same level), so no
-      // case is needed.
+      // address (we don't model expressions), but must consume a stack slot
+      // so the matching `#endif` pops the right depth — without it, an
+      // outer `#ifdef A`'s constraint would be wrongly popped.
       switch (tok.type as Keyword) {
         case Keyword.MACRO_IFDEF:
           this._pendingBranchPushDefined = true;
@@ -210,11 +208,26 @@ export class Lexer extends BaseLexer {
         case Keyword.MACRO_IF:
           this._branchStack.push(Lexer._IF_SENTINEL);
           break;
+        case Keyword.MACRO_ELIF:
+          // `#elif` ends the previous arm and opens a new one at the same
+          // depth. The new arm's actual condition is `(none of the previous
+          // arms held) AND <elif expr>`. We don't model expressions, but
+          // we *also* must not inherit the previous arm's tag — e.g.
+          // `#ifdef A / def X1 / #elif B / def X2 / #endif` would tag X2
+          // with `[A=true]`, which is the opposite of where X2 is actually
+          // active. Flipping polarity (like `#else` does) only works for
+          // the first `#elif` of a chain; longer chains would ping-pong.
+          // Degrade to sentinel uniformly: drops precision but never wrong.
+          if (this._branchStack.length > 0) {
+            this._branchStack[this._branchStack.length - 1] = Lexer._IF_SENTINEL;
+          }
+          break;
         case Keyword.MACRO_ELSE: {
           // Flip the polarity of the topmost constraint. For `#ifdef X` this
-          // turns `[X=true]` into `[X=false]`. For `#if expr` chains the top
-          // is the sentinel (`name=""`), and flipping its `defined` is
-          // harmless — `isVisibleFrom` ignores empty-name entries.
+          // turns `[X=true]` into `[X=false]`. For `#if expr` / `#elif`
+          // chains the top is the sentinel (`name=""`), and flipping its
+          // `defined` is harmless — `isVisibleFrom` ignores empty-name
+          // entries.
           const top = this._branchStack[this._branchStack.length - 1];
           if (top) this._branchStack[this._branchStack.length - 1] = { name: top.name, defined: !top.defined };
           break;

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -1,6 +1,6 @@
 import { ETokenType } from "../common";
 import { BaseLexer } from "../common/BaseLexer";
-import { BaseToken, EOF } from "../common/BaseToken";
+import { BaseToken, BranchConstraint, BranchSignature, EMPTY_BRANCH, EOF } from "../common/BaseToken";
 import { Keyword } from "../common/enums/Keyword";
 import { MacroDefineInfo, MacroDefineList } from "../Preprocessor";
 import { ShaderLab } from "../ShaderLab";
@@ -96,6 +96,39 @@ export class Lexer extends BaseLexer {
   // captured identifier becomes `MacroDefineInfo.referenceName`.
   private static readonly _referenceReg = /^([a-zA-Z_]\w*)(?:\s*\(.*\))?$/;
 
+  /** Two branch signatures are equal iff they have the same constraints in the
+   *  same order with the same polarity. Used by `#define` dedup and AST upgrade
+   *  matching. */
+  static sameBranch(a: BranchSignature, b: BranchSignature): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0, n = a.length; i < n; i++) {
+      if (a[i].name !== b[i].name || a[i].defined !== b[i].defined) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns true if a `#define` registered under `defBranch` is reachable from
+   * a call site under `callSiteBranch`. Two signatures are mutually exclusive
+   * iff some flag appears in both with opposite `defined` polarity. Anything
+   * else is compatible — the same flag with the same polarity, or flags that
+   * simply don't intersect.
+   *
+   * Conservative for `#if expr` (not modeled — its branch is empty, so
+   * compatible with everything) and exact for the common `#ifdef` / `#ifndef`
+   * / `#else` cases that drive real shader code.
+   */
+  static isVisibleFrom(defBranch: BranchSignature, callSiteBranch: BranchSignature): boolean {
+    for (let i = 0, n = defBranch.length; i < n; i++) {
+      const d = defBranch[i];
+      for (let j = 0, m = callSiteBranch.length; j < m; j++) {
+        const c = callSiteBranch[j];
+        if (d.name === c.name && d.defined !== c.defined) return false;
+      }
+    }
+    return true;
+  }
+
   private _needScanMacroConditionExpression = false;
 
   // --- `#define` scanning state machine ---
@@ -123,9 +156,55 @@ export class Lexer extends BaseLexer {
   // source of truth.
   private _macroDefineDirectiveStart: number = -1;
 
+  // Active `#ifdef`/`#ifndef`/`#else` stack. Updated by `tokenize` between
+  // emitting tokens; read by `_registerMacroDefine` (when it registers a
+  // legacy entry mid-scan) and stamped onto every emitted token's `branch`
+  // field so AST nodes know which branch they're inside.
+  private _branchStack: BranchConstraint[] = [];
+  // True when the previous token was `#ifdef`/`#ifndef` and we're waiting on
+  // the next ID token (the flag name) to actually push onto the stack.
+  private _pendingBranchPushDefined: boolean | null = null;
+
   *tokenize() {
     while (!this.isEnd()) {
-      yield this.scanToken();
+      const tok = this.scanToken();
+
+      // Resolve a pending #ifdef/#ifndef push using the flag-name token that
+      // immediately follows the keyword. Grammar allows the name to be either
+      // a plain `id` or a `MACRO_CALL` (for `#ifdef <previously-defined-macro>`).
+      if (this._pendingBranchPushDefined !== null && (tok.type === ETokenType.ID || tok.type === Keyword.MACRO_CALL)) {
+        this._branchStack.push({ name: tok.lexeme, defined: this._pendingBranchPushDefined });
+        this._pendingBranchPushDefined = null;
+      }
+
+      // Stamp the branch onto the token only when inside an `#ifdef`. The
+      // top-level case keeps the BaseToken default (shared empty signature),
+      // so the hot path stays allocation-free.
+      if (this._branchStack.length > 0) tok.branch = this._branchStack.slice();
+
+      // Update stack state based on the just-emitted token, so the *next*
+      // token sees the correct snapshot.
+      switch (tok.type as Keyword) {
+        case Keyword.MACRO_IFDEF:
+          this._pendingBranchPushDefined = true;
+          break;
+        case Keyword.MACRO_IFNDEF:
+          this._pendingBranchPushDefined = false;
+          break;
+        case Keyword.MACRO_ELSE: {
+          // Flip the polarity of the topmost constraint. `#else` after
+          // `#if expr` (which we don't model) leaves the empty placeholder
+          // alone — empty signature is conservatively visible from anywhere.
+          const top = this._branchStack[this._branchStack.length - 1];
+          if (top) this._branchStack[this._branchStack.length - 1] = { name: top.name, defined: !top.defined };
+          break;
+        }
+        case Keyword.MACRO_ENDIF:
+          this._branchStack.pop();
+          break;
+      }
+
+      yield tok;
     }
     return EOF;
   }
@@ -695,21 +774,25 @@ export class Lexer extends BaseLexer {
       isFunction: m[2] !== undefined,
       name,
       params,
-      referenceName: refMatch ? refMatch[1] : ""
+      referenceName: refMatch ? refMatch[1] : "",
+      branch: this._branchStack.length === 0 ? EMPTY_BRANCH : this._branchStack.slice()
     };
     const arr = this.macroDefineList[name];
     if (!arr) {
       this.macroDefineList[name] = [info];
       return;
     }
-    // Skip duplicates from re-includes / re-definitions in #ifdef branches.
+    // Skip duplicates from re-includes / re-definitions in the same `#ifdef`
+    // branch. Different branches → different entries (the call-site filter
+    // picks the visible one); same branch + same shape → drop.
     for (let i = 0, n = arr.length; i < n; i++) {
       const e = arr[i];
       if (
         e.isFunction === info.isFunction &&
         e.referenceName === info.referenceName &&
         e.params.length === info.params.length &&
-        e.params.every((p, idx) => p === info.params[idx])
+        e.params.every((p, idx) => p === info.params[idx]) &&
+        Lexer.sameBranch(e.branch, info.branch)
       )
         return;
     }

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -95,6 +95,9 @@ export class Lexer extends BaseLexer {
   // (`foo` or `foo(a, b)`); mixed-operator values like `a + b` reject. The
   // captured identifier becomes `MacroDefineInfo.referenceName`.
   private static readonly _referenceReg = /^([a-zA-Z_]\w*)(?:\s*\(.*\))?$/;
+  // C preprocessor line continuation: `\` followed by `\r\n`, `\n`, or `\r`.
+  // The pair is removed (the next physical line is part of the same logical line).
+  private static readonly _lineContinuationReg = /\\(?:\r\n|\n|\r)/g;
 
   /** Two branch signatures are equal iff they have the same constraints in the
    *  same order with the same polarity. Used by `#define` dedup and AST upgrade
@@ -532,8 +535,19 @@ export class Lexer extends BaseLexer {
   }
 
   private _scanUtilBreakLine(outBuffer: string[]): void {
-    while (this.getCurChar() !== "\n" && !this.isEnd()) {
-      outBuffer.push(this.getCurChar());
+    const src = this._source;
+    const len = src.length;
+    while (!this.isEnd()) {
+      // Honor line-continuation so multi-line directives (`#define X a \\\n + b`)
+      // are not cut short at the first physical newline.
+      const afterContinuation = Lexer._skipLineContinuation(src, this._currentIndex, len);
+      if (afterContinuation !== this._currentIndex) {
+        this.advance(afterContinuation - this._currentIndex);
+        continue;
+      }
+      const c = src.charCodeAt(this._currentIndex);
+      if (c === 10) break;
+      outBuffer.push(src[this._currentIndex]);
       this.advance(1);
     }
   }
@@ -604,103 +618,113 @@ export class Lexer extends BaseLexer {
   private _defineHasValue(): boolean {
     const src = this._source;
     const len = src.length;
-    let i = this._currentIndex;
-    // Skip inline whitespace after `#define`
-    while (i < len && (src[i] === " " || src[i] === "\t")) i++;
+    // All position advancement goes through `_skipNonSemantic`, which honors
+    // line-continuation (`\` + newline) and skips comments. This is critical:
+    // `#define UV foo \\\n  .field` is one logical directive whose value
+    // contains `.field`, and `#define HP /* a.b */ highp` must not let the
+    // `.` inside the comment trigger AST routing.
+    let i = Lexer._skipNonSemantic(src, this._currentIndex, len);
     // Skip macro name
     if (!(i < len && BaseLexer.isAlpha(src.charCodeAt(i)))) return false;
     while (i < len && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
-    // Optional `(params)`: scan past a balanced pair on the same line
-    if (src[i] === "(") {
+    i = Lexer._skipNonSemantic(src, i, len);
+    // Optional `(params)`: scan past a balanced pair on the same logical line
+    if (src.charCodeAt(i) === 40 /* '(' */) {
       let depth = 1;
       i++;
       while (i < len && depth > 0) {
-        const ch = src[i];
-        if (ch === "\n" || ch === "\r") return false; // malformed: stay legacy
-        if (ch === "(") depth++;
-        else if (ch === ")") depth--;
+        i = Lexer._skipNonSemantic(src, i, len);
+        const c = src.charCodeAt(i);
+        if (c === 10 || c === 13) return false; // malformed: stay legacy
+        if (c === 40) depth++;
+        else if (c === 41 /* ')' */) depth--;
         i++;
       }
     }
-    // Scan to end-of-line. A `.` is a member-access operator unless it's a
-    // decimal point inside a numeric literal — the latter has digits on both
-    // sides (`3.14`, `1.0e-5`). Member access covers `v.x`, `v0.x`, `(v).x`,
-    // `v . x`, `arr[i].field`, `(a+b).field`, etc. — all need AST routing
-    // for varying-flatten / type-propagation. Edge cases like `.5` go AST
-    // too (false positive, but the AST path handles bare floats correctly).
-    for (let k = i; k < len; k++) {
-      const c = src.charCodeAt(k);
-      if (c === 10 || c === 13) break;
-      if (c !== 46 /* `.` */) continue;
-      const prev = k > 0 ? src.charCodeAt(k - 1) : 0;
-      const next = k + 1 < len ? src.charCodeAt(k + 1) : 0;
-      const prevIsDigit = prev >= 48 && prev <= 57;
-      const nextIsDigit = next >= 48 && next <= 57;
-      if (prevIsDigit && nextIsDigit) continue; // numeric literal `3.14`
-      return true;
+    // Scan to end-of-directive looking for a `.` member-access operator.
+    // A `.` is member-access unless it's a decimal point inside a numeric
+    // literal — the latter has digits on both physical sides (`3.14`).
+    // Edge cases like `.5` go AST too (false positive, but AST path
+    // handles bare floats correctly).
+    while (i < len) {
+      i = Lexer._skipNonSemantic(src, i, len);
+      if (i >= len) break;
+      const c = src.charCodeAt(i);
+      if (c === 10 || c === 13) break; // real newline ends directive
+      if (c === 46 /* '.' */) {
+        const prev = i > 0 ? src.charCodeAt(i - 1) : 0;
+        const next = i + 1 < len ? src.charCodeAt(i + 1) : 0;
+        const prevIsDigit = prev >= 48 && prev <= 57;
+        const nextIsDigit = next >= 48 && next <= 57;
+        if (!(prevIsDigit && nextIsDigit)) return true;
+      }
+      i++;
     }
     return false;
   }
 
-  /**
-   * Inside a `#define` value, skip spaces/tabs and block comments (`/* … *\/`) but
-   * never newlines. Also tolerates line-continuation (`\` immediately before a
-   * newline) by skipping the backslash + newline pair per the C preprocessor rule.
+/**
+   * If `i` points at a `\` immediately followed by a newline (`\n`, `\r`, or
+   * `\r\n`), return the index just past the pair (a single atom in the C/GLSL
+   * preprocessor view). Otherwise return `i` unchanged. This is the single
+   * source of truth for line-continuation detection — callers along the
+   * directive-scanning path (`_skipNonSemantic`, `_scanUtilBreakLine`,
+   * `_scanMacroDefineParams`) all delegate here so the rule stays in one
+   * place. The string-level `_lineContinuationReg` covers the regex path
+   * used by `_registerMacroDefine` for one-shot folding.
    */
-  private _skipInlineSpaceAndComments(): void {
-    const source = this._source;
-    while (this._currentIndex < source.length) {
-      const c = source.charCodeAt(this._currentIndex);
+  private static _skipLineContinuation(src: string, i: number, len: number): number {
+    if (src.charCodeAt(i) !== 92 /* '\\' */ || i + 1 >= len) return i;
+    const n = src.charCodeAt(i + 1);
+    if (n === 10) return i + 2;
+    if (n === 13) return i + 2 < len && src.charCodeAt(i + 2) === 10 ? i + 3 : i + 2;
+    return i;
+  }
+
+  /**
+   * Pure positional version of "skip non-semantic characters within a single
+   * `#define` directive": spaces, tabs, `\` + newline line-continuation, block
+   * comments, line comments. A real `\n` (without preceding `\`) is *not*
+   * consumed — it terminates the directive — so callers can detect
+   * end-of-directive after this returns. Shared by `_defineHasValue` (peek
+   * path) and `_skipInlineSpaceAndComments` (consuming path) so both honor
+   * the same lexical view.
+   */
+  private static _skipNonSemantic(src: string, from: number, len: number): number {
+    let i = from;
+    while (i < len) {
+      const c = src.charCodeAt(i);
       if (c === 32 || c === 9) {
-        this.advance(1);
+        i++;
         continue;
       }
-      // Line continuation: `\` immediately before newline — consume both.
-      if (
-        c === 92 && // '\\'
-        this._currentIndex + 1 < source.length &&
-        (source.charCodeAt(this._currentIndex + 1) === 10 || source.charCodeAt(this._currentIndex + 1) === 13)
-      ) {
-        this.advance(
-          source.charCodeAt(this._currentIndex + 1) === 13 && source.charCodeAt(this._currentIndex + 2) === 10 ? 3 : 2
-        );
+      const afterContinuation = Lexer._skipLineContinuation(src, i, len);
+      if (afterContinuation !== i) {
+        i = afterContinuation;
         continue;
       }
-      // Block comment — stays on the same logical line for preprocessor purposes.
-      if (
-        c === 47 && // '/'
-        this._currentIndex + 1 < source.length &&
-        source.charCodeAt(this._currentIndex + 1) === 42 // '*'
-      ) {
-        this.advance(2);
-        while (this._currentIndex + 1 < source.length) {
-          if (source.charCodeAt(this._currentIndex) === 42 && source.charCodeAt(this._currentIndex + 1) === 47) {
-            this.advance(2);
-            break;
-          }
-          this.advance(1);
-        }
+      const afterBlock = Lexer._skipBlockComment(src, i, len);
+      if (afterBlock !== i) {
+        i = afterBlock;
         continue;
       }
-      // Line comment `// …` — consume up to but not including the newline, so the
-      // newline still terminates the directive below.
-      if (
-        c === 47 && // '/'
-        this._currentIndex + 1 < source.length &&
-        source.charCodeAt(this._currentIndex + 1) === 47
-      ) {
-        this.advance(2);
-        while (
-          this._currentIndex < source.length &&
-          source.charCodeAt(this._currentIndex) !== 10 &&
-          source.charCodeAt(this._currentIndex) !== 13
-        ) {
-          this.advance(1);
-        }
+      const afterLine = Lexer._skipLineComment(src, i, len);
+      if (afterLine !== i) {
+        i = afterLine;
         continue;
       }
       break;
     }
+    return i;
+  }
+
+  /** Consuming wrapper around `_skipNonSemantic` operating on the lexer's
+   *  current position. Used by the `#define`-value scan state machine. Goes
+   *  through `advance(diff)` so verbose builds keep their line/column counters
+   *  in sync (advance walks the consumed slice and bumps `_line` on `\n`). */
+  private _skipInlineSpaceAndComments(): void {
+    const next = Lexer._skipNonSemantic(this._source, this._currentIndex, this._source.length);
+    if (next > this._currentIndex) this.advance(next - this._currentIndex);
   }
 
   /**
@@ -715,9 +739,18 @@ export class Lexer extends BaseLexer {
   private _scanMacroDefineParams(): BaseToken {
     const start = this.getShaderPosition();
     const src = this._source;
+    const len = src.length;
     const buffer: string[] = [];
     let depth = 0;
-    while (this._currentIndex < src.length) {
+    while (this._currentIndex < len) {
+      // Honor line-continuation so `#define MAX3( \\\n a, b, c \\\n ) …`
+      // collapses onto one logical line. The `\` and `\n` must not enter the
+      // params buffer or the grammar will reject the lexeme.
+      const afterContinuation = Lexer._skipLineContinuation(src, this._currentIndex, len);
+      if (afterContinuation !== this._currentIndex) {
+        this.advance(afterContinuation - this._currentIndex);
+        continue;
+      }
       const ch = src[this._currentIndex];
       buffer.push(ch);
       if (ch === "(") depth++;
@@ -758,7 +791,13 @@ export class Lexer extends BaseLexer {
   // its newline) and register it. Both AST and legacy paths funnel through
   // here — single source of truth, no drift between two analyzers.
   private _registerMacroDefine(directive: string): void {
-    const m = Lexer._defineDirectiveReg.exec(directive);
+    // Fold line-continuations before matching: per C/GLSL preprocessor rules
+    // `\` immediately before a newline removes both characters and stitches
+    // the next physical line onto this one. The regex's value group rejects
+    // newlines, so without folding any multi-line directive (`#define X a \\\n + b`)
+    // would NO MATCH and registration would silently fail.
+    const folded = directive.replace(Lexer._lineContinuationReg, "");
+    const m = Lexer._defineDirectiveReg.exec(folded);
     if (!m) return;
     const name = m[1];
     const paramsStr = m[3];

--- a/packages/shader-lab/src/lexer/Lexer.ts
+++ b/packages/shader-lab/src/lexer/Lexer.ts
@@ -87,6 +87,24 @@ export class Lexer extends BaseLexer {
 
   private _needScanMacroConditionExpression = false;
 
+  // --- `#define` scanning state machine ---
+  // Expression-style `#define` produces a token stream:
+  //     MACRO_DEFINE, ID(name), [MACRO_DEFINE_PARAMS], <value tokens>, MACRO_DEFINE_END
+  // The three flags below encode the mini state machine driving that stream:
+  //   - _inMacroDefineValue  : persistent mode — newline terminates the directive
+  //                            rather than being skipped as whitespace
+  //   - _macroDefineExpectsNameToken : one-shot — next identifier is the macro
+  //                            name and must be ID (not MACRO_CALL even if the
+  //                            name was registered by a prior definition)
+  //   - _macroDefineExpectsParamsToken : one-shot — if next char is `(`, capture
+  //                            the balanced `(…)` block as a single opaque token
+  //                            so the CFG doesn't need its own parameter-list
+  //                            non-terminal (which would conflict with
+  //                            function_call_parameter_list under LALR(1))
+  private _inMacroDefineValue = false;
+  private _macroDefineExpectsNameToken = false;
+  private _macroDefineExpectsParamsToken = false;
+
   *tokenize() {
     while (!this.isEnd()) {
       yield this.scanToken();
@@ -102,9 +120,27 @@ export class Lexer extends BaseLexer {
   }
 
   override scanToken(): BaseToken {
-    this.skipCommentsAndSpace();
-    if (this.isEnd()) {
-      return EOF;
+    if (this._inMacroDefineValue) {
+      // Inside a `#define` value: newline ends the directive. Skip only spaces/tabs
+      // and block comments, never \n, so the termination can be detected.
+      this._skipInlineSpaceAndComments();
+      if (this.isEnd() || this._isAtLineBreak()) {
+        return this._emitMacroDefineEnd();
+      }
+      // Right after the macro name, if the next char is `(`, capture the whole
+      // parenthesized parameter list as one opaque token. This keeps the
+      // macro-define grammar LALR(1)-friendly (no nested param-list non-terminal).
+      if (this._macroDefineExpectsParamsToken) {
+        this._macroDefineExpectsParamsToken = false;
+        if (this.getCurChar() === "(") {
+          return this._scanMacroDefineParams();
+        }
+      }
+    } else {
+      this.skipCommentsAndSpace();
+      if (this.isEnd()) {
+        return EOF;
+      }
     }
 
     if (this._needScanMacroConditionExpression) {
@@ -416,11 +452,22 @@ export class Lexer extends BaseLexer {
     const token = BaseToken.pool.get();
     const word = buffer.join("");
 
-    // If it is a macro definition or conditional expression, we need to skip the rest of the line
     if (word === "#define") {
-      this._scanUtilBreakLine(buffer);
-      const word = buffer.join("") + "\n";
-      token.set(Keyword.MACRO_DEFINE_EXPRESSION, word, start);
+      // Peek the rest of the line: if the directive has no value (`#define X\n`),
+      // fall back to the legacy opaque path. Only directives with a non-empty
+      // value enter expression-mode (AST parsing).
+      if (this._defineHasValue()) {
+        this._inMacroDefineValue = true;
+        // The next word is the macro name: force ID type even if a prior `#define`
+        // has already registered the name into `macroDefineList` (redefinition or
+        // multi-chunk include), which would otherwise make the word a MACRO_CALL.
+        this._macroDefineExpectsNameToken = true;
+        token.set(Keyword.MACRO_DEFINE, "#define", start);
+      } else {
+        this._scanUtilBreakLine(buffer);
+        const lexeme = "\n" + buffer.join("") + "\n";
+        token.set(Keyword.MACRO_DEFINE_EXPRESSION, lexeme, start);
+      }
     } else {
       const kt = Lexer._lexemeTable[word];
       token.set(kt ?? ETokenType.ID, word, start);
@@ -429,6 +476,198 @@ export class Lexer extends BaseLexer {
       }
     }
 
+    return token;
+  }
+
+  /** True if the current char is an unescaped line break (ignoring `\` continuation). */
+  private _isAtLineBreak(): boolean {
+    const c = this.getCurChar();
+    return c === "\n" || c === "\r";
+  }
+
+  /**
+   * Keywords that CAN legitimately start a GLSL expression. Any other keyword
+   * appearing as the first token of a `#define` value means the macro is
+   * expanding into a declaration/statement (type alias, qualifier alias, etc.)
+   * and must stay on the legacy opaque path.
+   *
+   * Kept as a whitelist rather than a blacklist because the keyword table is
+   * dominated by type/qualifier names — enumerating the small set of
+   * expression-leader keywords is less error-prone and survives new types being
+   * added to GLSL without needing to remember to update a blacklist.
+   *
+   * `uniform`, `varying`, `attribute` appear in shader source but aren't in
+   * `_lexemeTable` as keywords; they're plain identifiers to the lexer and
+   * naturally fall through as valid "expression-start" identifiers (they aren't
+   * expression starters syntactically, but any legitimate use of them leading a
+   * `#define` value is already malformed — the LALR parser will surface the
+   * error).
+   */
+  private static readonly _expressionValueLeaderKeywords = new Set<string>([
+    // Boolean literals
+    "true",
+    "false"
+  ]);
+
+  /**
+   * Peek forward from `#define` and decide whether this directive should use the
+   * expression-AST path or the legacy opaque path. Returns true for values that
+   * can plausibly be parsed as a GLSL expression; returns false for:
+   *   - empty bodies (`#define FOO\n`)
+   *   - values whose first token is a type/qualifier keyword (the macro is
+   *     expanding into a declaration, not an expression)
+   *   - values using `\` line continuation (rare; simpler to stay opaque)
+   */
+  private _defineHasValue(): boolean {
+    const src = this._source;
+    let i = this._currentIndex;
+    // Skip inline whitespace after `#define`
+    while (i < src.length && (src[i] === " " || src[i] === "\t")) i++;
+    // Skip macro name
+    if (!(i < src.length && BaseLexer.isAlpha(src.charCodeAt(i)))) return false;
+    while (i < src.length && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
+    // Optional `(params)`: scan past a balanced pair on the same line
+    if (src[i] === "(") {
+      let depth = 1;
+      i++;
+      while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === "\n" || ch === "\r") return false; // malformed: stay legacy
+        if (ch === "(") depth++;
+        else if (ch === ")") depth--;
+        i++;
+      }
+    }
+    // Skip trailing whitespace between `)` (or name) and the value
+    while (i < src.length && (src[i] === " " || src[i] === "\t")) i++;
+    if (i >= src.length) return false;
+    const ch = src[i];
+    if (ch === "\n" || ch === "\r") return false;
+    // Line-continuation: `\` + newline — treat as no value for simplicity.
+    if (ch === "\\" && (src[i + 1] === "\n" || src[i + 1] === "\r")) return false;
+
+    // Peek the first word of the value. If it's a GLSL keyword that doesn't start
+    // expressions (type, qualifier, statement leader), the value isn't
+    // expression-shaped — use the legacy path. Non-keyword identifiers and the
+    // explicit expression-starter keywords (`true`/`false`) go through the AST path.
+    if (BaseLexer.isAlpha(src.charCodeAt(i))) {
+      const wordStart = i;
+      while (i < src.length && BaseLexer.isAlnum(src.charCodeAt(i))) i++;
+      const firstWord = src.substring(wordStart, i);
+      if (Lexer._lexemeTable[firstWord] !== undefined && !Lexer._expressionValueLeaderKeywords.has(firstWord)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Inside a `#define` value, skip spaces/tabs and block comments (`/* … *\/`) but
+   * never newlines. Also tolerates line-continuation (`\` immediately before a
+   * newline) by skipping the backslash + newline pair per the C preprocessor rule.
+   */
+  private _skipInlineSpaceAndComments(): void {
+    const source = this._source;
+    while (this._currentIndex < source.length) {
+      const c = source.charCodeAt(this._currentIndex);
+      if (c === 32 || c === 9) {
+        this.advance(1);
+        continue;
+      }
+      // Line continuation: `\` immediately before newline — consume both.
+      if (
+        c === 92 && // '\\'
+        this._currentIndex + 1 < source.length &&
+        (source.charCodeAt(this._currentIndex + 1) === 10 || source.charCodeAt(this._currentIndex + 1) === 13)
+      ) {
+        this.advance(
+          source.charCodeAt(this._currentIndex + 1) === 13 && source.charCodeAt(this._currentIndex + 2) === 10 ? 3 : 2
+        );
+        continue;
+      }
+      // Block comment — stays on the same logical line for preprocessor purposes.
+      if (
+        c === 47 && // '/'
+        this._currentIndex + 1 < source.length &&
+        source.charCodeAt(this._currentIndex + 1) === 42 // '*'
+      ) {
+        this.advance(2);
+        while (this._currentIndex + 1 < source.length) {
+          if (source.charCodeAt(this._currentIndex) === 42 && source.charCodeAt(this._currentIndex + 1) === 47) {
+            this.advance(2);
+            break;
+          }
+          this.advance(1);
+        }
+        continue;
+      }
+      // Line comment `// …` — consume up to but not including the newline, so the
+      // newline still terminates the directive below.
+      if (
+        c === 47 && // '/'
+        this._currentIndex + 1 < source.length &&
+        source.charCodeAt(this._currentIndex + 1) === 47
+      ) {
+        this.advance(2);
+        while (
+          this._currentIndex < source.length &&
+          source.charCodeAt(this._currentIndex) !== 10 &&
+          source.charCodeAt(this._currentIndex) !== 13
+        ) {
+          this.advance(1);
+        }
+        continue;
+      }
+      break;
+    }
+  }
+
+  /**
+   * Capture a `(param1, param2, …)` block immediately after the macro name in a
+   * `#define` directive, producing a single `MACRO_DEFINE_PARAMS` token whose lexeme
+   * is the complete `(…)` text (including parens). Balanced parentheses are honored
+   * so the scanner doesn't terminate early on inner `()`. Newlines inside the
+   * parameter list are tolerated (rare; appears when the directive uses `\` line
+   * continuation), but any newline raises no special error here — it simply stops
+   * capture and parser handles the resulting token however it can.
+   */
+  private _scanMacroDefineParams(): BaseToken {
+    const start = this.getShaderPosition();
+    const src = this._source;
+    const buffer: string[] = [];
+    let depth = 0;
+    while (this._currentIndex < src.length) {
+      const ch = src[this._currentIndex];
+      buffer.push(ch);
+      if (ch === "(") depth++;
+      else if (ch === ")") {
+        depth--;
+        this.advance(1);
+        if (depth === 0) break;
+        continue;
+      }
+      this.advance(1);
+    }
+    const token = BaseToken.pool.get();
+    token.set(Keyword.MACRO_DEFINE_PARAMS, buffer.join(""), start);
+    return token;
+  }
+
+  /** Emit `MACRO_DEFINE_END` at the end of a `#define` value, consuming the newline. */
+  private _emitMacroDefineEnd(): BaseToken {
+    const start = this.getShaderPosition();
+    const source = this._source;
+    if (this._currentIndex < source.length) {
+      const c = source.charCodeAt(this._currentIndex);
+      if (c === 13 && source.charCodeAt(this._currentIndex + 1) === 10) {
+        this.advance(2);
+      } else if (c === 10 || c === 13) {
+        this.advance(1);
+      }
+    }
+    this._inMacroDefineValue = false;
+    const token = BaseToken.pool.get();
+    token.set(Keyword.MACRO_DEFINE_END, "\n", start);
     return token;
   }
 
@@ -454,7 +693,15 @@ export class Lexer extends BaseLexer {
     const word = buffer.join("");
     const kt = Lexer._lexemeTable[word];
 
-    if (this.macroDefineList[word]) {
+    if (this._macroDefineExpectsNameToken) {
+      // Bypass MACRO_CALL classification for this one word. Used for the name of
+      // a `#define` directive so redefining a known macro still yields a declarer ID.
+      this._macroDefineExpectsNameToken = false;
+      // If we're inside a `#define` directive, this ID *is* the macro name and the
+      // next character, if `(`, begins the parameter list.
+      if (this._inMacroDefineValue) this._macroDefineExpectsParamsToken = true;
+      token.set(ETokenType.ID, word, start);
+    } else if (this.macroDefineList[word]) {
       token.set(Keyword.MACRO_CALL, word, start);
     } else {
       token.set(kt ?? ETokenType.ID, word, start);

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -849,7 +849,6 @@ export namespace ASTNode {
 
   @ASTNodeDecorator(NoneTerminal.assignment_expression)
   export class AssignmentExpression extends ExpressionAstNode {
-    // #if _VERBOSE
     override semanticAnalyze(sa: SemanticAnalyzer): void {
       if (this.children.length === 1) {
         const expr = this.children[0] as ConditionalExpression;
@@ -859,7 +858,6 @@ export namespace ASTNode {
         this.type = expr.type ?? TypeAny;
       }
     }
-    // #endif
   }
 
   // #if _VERBOSE
@@ -869,7 +867,6 @@ export namespace ASTNode {
 
   @ASTNodeDecorator(NoneTerminal.expression)
   export class Expression extends ExpressionAstNode {
-    // #if _VERBOSE
     override semanticAnalyze(sa: SemanticAnalyzer): void {
       if (this.children.length === 1) {
         const expr = this.children[0] as AssignmentExpression;
@@ -879,7 +876,6 @@ export namespace ASTNode {
         this.type = expr.type;
       }
     }
-    // #endif
   }
 
   @ASTNodeDecorator(NoneTerminal.primary_expression)

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -4,7 +4,8 @@ import { ETokenType, GalaceanDataType, ShaderRange, TokenType, TypeAny } from ".
 import { BaseToken } from "../common/BaseToken";
 import { Keyword } from "../common/enums/Keyword";
 import { ParserUtils } from "../ParserUtils";
-import { MacroDefineInfo, Preprocessor } from "../Preprocessor";
+import { Lexer } from "../lexer/Lexer";
+import { MacroDefineInfo } from "../Preprocessor";
 import { ShaderLabUtils } from "../ShaderLabUtils";
 import { BuiltinFunction, BuiltinVariable, NonGenericGalaceanType } from "./builtin";
 import { NoneTerminal } from "./GrammarSymbol";
@@ -1633,10 +1634,12 @@ export namespace ASTNode {
   export class MacroCallSymbol extends TreeNode {
     referenceSymbolNames: string[] = [];
     macroName: string;
-    /** True when at least one `MacroDefineInfo` for this macro has a `valueAst`,
-     *  i.e. the macro was parsed via the `macro_define` CFG rule. Call sites use
-     *  this to skip naive type inference: an AST-form macro drives the call site's
-     *  type through its own value subtree, not through a root of `referenceSymbolNames`. */
+    /** True iff every `MacroDefineInfo` visible from this call site's branch
+     *  has a `valueAst` (i.e. was parsed via the `macro_define` CFG rule).
+     *  Call sites use this to skip naive type inference: an AST-form macro
+     *  drives the call site's type through its own value subtree, not through
+     *  a root of `referenceSymbolNames`. Mixed forms across branches → false,
+     *  fall back to legacy inference. */
     hasAstValue: boolean = false;
     /** True when the macro is defined as function-like (`#define NAME(params) …`).
      *  Used by `MacroCallFunction` codegen to pick between the two call shapes
@@ -1650,13 +1653,39 @@ export namespace ASTNode {
     }
 
     override semanticAnalyze(sa: SemanticAnalyzer): void {
-      const macroName = (this.children[0] as BaseToken).lexeme;
+      const nameToken = this.children[0] as BaseToken;
+      const macroName = nameToken.lexeme;
       this.macroName = macroName;
 
-      Preprocessor.getReferenceSymbolNames(sa.macroDefineList, macroName, this.referenceSymbolNames);
+      // Filter `defList` to only entries reachable from this call site's
+      // `#ifdef` branch (Issue #2980 nit fix). Without filtering, definitions
+      // in disjoint branches conflate at the call site and pollute type
+      // inference; with it, what remains is exactly what could substitute at
+      // this position.
+      const callSiteBranch = nameToken.branch;
       const defList = sa.macroDefineList[macroName];
-      this.hasAstValue = defList?.some((info) => info.valueAst != null) ?? false;
-      this.isFunctionLikeMacro = defList?.some((info) => info.isFunction) ?? false;
+      const refs = this.referenceSymbolNames;
+      refs.length = 0;
+      let visibleCount = 0;
+      let allAst = true;
+      let isFn = false;
+      if (defList) {
+        for (let i = 0, n = defList.length; i < n; i++) {
+          const info = defList[i];
+          if (!Lexer.isVisibleFrom(info.branch, callSiteBranch)) continue;
+          visibleCount++;
+          if (info.valueAst == null) allAst = false;
+          if (info.isFunction) isFn = true;
+          const ref = info.referenceName;
+          if (ref && info.params.indexOf(ref) === -1 && refs.indexOf(ref) === -1) refs.push(ref);
+        }
+      }
+      // Require *every* visible entry to be AST-form before taking the AST
+      // shortcut: residual ambiguity (e.g. unmodeled `#if expr` letting both
+      // forms through) falls back to legacy `referenceSymbolNames` inference
+      // instead of polluting the call site with TypeAny.
+      this.hasAstValue = visibleCount > 0 && allAst;
+      this.isFunctionLikeMacro = isFn;
     }
   }
 
@@ -1731,19 +1760,22 @@ export namespace ASTNode {
         this.valueExpression = children[valueIdx] as AssignmentExpression;
       }
 
-      // `Preprocessor._parseMacroDefines` already registered a regex-derived
-      // entry for this directive (so the lexer can classify the name as
-      // `MACRO_CALL`). Upgrade that entry in place by attaching the AST subtree,
-      // rather than pushing a duplicate record — duplicates leak into
-      // `getReferenceSymbolNames` and cause phantom issues like spurious
-      // warnings or double-counted references.
+      // The Lexer already registered a regex-derived entry for this directive.
+      // Upgrade that entry in place by attaching the AST subtree, rather than
+      // pushing a duplicate. Match must be branch-aware: `#define X` in
+      // `#ifdef A` and another `#define X` in `#else` are separate entries
+      // with disjoint branch signatures, and `valueExpression` belongs to
+      // whichever branch actually parsed it.
+      const definingBranch = (children[1] as BaseToken).branch;
       const list = sa.macroDefineList;
       const entries = list[this.macroName];
       const sameArity = (info: MacroDefineInfo) =>
         info.isFunction === this.isFunction &&
         info.params.length === params.length &&
         info.params.every((p, i) => p === params[i]);
-      const upgradable = entries?.find((info) => !info.valueAst && sameArity(info));
+      const upgradable = entries?.find(
+        (info) => !info.valueAst && sameArity(info) && Lexer.sameBranch(info.branch, definingBranch)
+      );
       if (upgradable) {
         upgradable.valueAst = this.valueExpression;
       } else {
@@ -1754,7 +1786,8 @@ export namespace ASTNode {
           name: this.macroName,
           params,
           valueAst: this.valueExpression,
-          referenceName: ""
+          referenceName: "",
+          branch: definingBranch
         };
         if (entries) entries.push(info);
         else list[this.macroName] = [info];

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -4,7 +4,7 @@ import { ETokenType, GalaceanDataType, ShaderRange, TokenType, TypeAny } from ".
 import { BaseToken } from "../common/BaseToken";
 import { Keyword } from "../common/enums/Keyword";
 import { ParserUtils } from "../ParserUtils";
-import { MacroDefineInfo, MacroValueType, Preprocessor } from "../Preprocessor";
+import { MacroDefineInfo, Preprocessor } from "../Preprocessor";
 import { ShaderLabUtils } from "../ShaderLabUtils";
 import { BuiltinFunction, BuiltinVariable, NonGenericGalaceanType } from "./builtin";
 import { NoneTerminal } from "./GrammarSymbol";
@@ -1735,24 +1735,33 @@ export namespace ASTNode {
         this.valueExpression = children[valueIdx] as AssignmentExpression;
       }
 
-      // Register this macro in the preprocessor's define list so downstream passes
-      // (e.g. `MacroCallSymbol.semanticAnalyze` resolving references) see it. The
-      // AST path stores `valueAst` and leaves the legacy opaque fields empty.
-      const info: MacroDefineInfo = {
-        isFunction: this.isFunction,
-        name: this.macroName,
-        value: "",
-        valueType: MacroValueType.Other,
-        valueAst: this.valueExpression,
-        params,
-        functionCallName: ""
-      };
-
+      // `Preprocessor._parseMacroDefines` already registered a regex-derived
+      // entry for this directive (so the lexer can classify the name as
+      // `MACRO_CALL`). Upgrade that entry in place by attaching the AST subtree,
+      // rather than pushing a duplicate record — duplicates leak into
+      // `getReferenceSymbolNames` and cause phantom issues like spurious
+      // warnings or double-counted references.
       const list = sa.macroDefineList;
-      if (list[this.macroName]) {
-        list[this.macroName].push(info);
+      const entries = list[this.macroName];
+      const sameArity = (info: MacroDefineInfo) =>
+        info.isFunction === this.isFunction &&
+        info.params.length === params.length &&
+        info.params.every((p, i) => p === params[i]);
+      const upgradable = entries?.find((info) => !info.valueAst && sameArity(info));
+      if (upgradable) {
+        upgradable.valueAst = this.valueExpression;
       } else {
-        list[this.macroName] = [info];
+        // No matching preprocessor entry (e.g. the lexer was fed the directive
+        // directly without a `Preprocessor.parse` pass). Push a fresh entry.
+        const info: MacroDefineInfo = {
+          isFunction: this.isFunction,
+          name: this.macroName,
+          params,
+          valueAst: this.valueExpression,
+          referenceName: ""
+        };
+        if (entries) entries.push(info);
+        else list[this.macroName] = [info];
       }
     }
 

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -1642,10 +1642,15 @@ export namespace ASTNode {
      *  this to skip naive type inference: an AST-form macro drives the call site's
      *  type through its own value subtree, not through a root of `referenceSymbolNames`. */
     hasAstValue: boolean = false;
+    /** True when the macro is defined as function-like (`#define NAME(params) …`).
+     *  Used by `MacroCallFunction` codegen to pick between the two call shapes
+     *  — object-like-macro-as-function-name vs true function-like macro. */
+    isFunctionLikeMacro: boolean = false;
 
     override init(): void {
       this.referenceSymbolNames.length = 0;
       this.hasAstValue = false;
+      this.isFunctionLikeMacro = false;
     }
 
     override semanticAnalyze(sa: SemanticAnalyzer): void {
@@ -1653,7 +1658,9 @@ export namespace ASTNode {
       this.macroName = macroName;
 
       Preprocessor.getReferenceSymbolNames(sa.macroDefineList, macroName, this.referenceSymbolNames);
-      this.hasAstValue = sa.macroDefineList[macroName]?.some((info) => info.valueAst != null) ?? false;
+      const defList = sa.macroDefineList[macroName];
+      this.hasAstValue = defList?.some((info) => info.valueAst != null) ?? false;
+      this.isFunctionLikeMacro = defList?.some((info) => info.isFunction) ?? false;
     }
   }
 
@@ -1662,11 +1669,13 @@ export namespace ASTNode {
     referenceSymbolNames: string[] = [];
     macroName: string = "";
     hasAstValue: boolean = false;
+    isFunctionLikeMacro: boolean = false;
 
     override init(): void {
       this.referenceSymbolNames = [];
       this.macroName = "";
       this.hasAstValue = false;
+      this.isFunctionLikeMacro = false;
     }
 
     override semanticAnalyze(sa: SemanticAnalyzer): void {
@@ -1675,6 +1684,7 @@ export namespace ASTNode {
       this.referenceSymbolNames = child.referenceSymbolNames;
       this.macroName = child.macroName;
       this.hasAstValue = child.hasAstValue;
+      this.isFunctionLikeMacro = child.isFunctionLikeMacro;
     }
 
     override codeGen(visitor: CodeGenVisitor) {

--- a/packages/shader-lab/src/parser/AST.ts
+++ b/packages/shader-lab/src/parser/AST.ts
@@ -4,7 +4,7 @@ import { ETokenType, GalaceanDataType, ShaderRange, TokenType, TypeAny } from ".
 import { BaseToken } from "../common/BaseToken";
 import { Keyword } from "../common/enums/Keyword";
 import { ParserUtils } from "../ParserUtils";
-import { Preprocessor } from "../Preprocessor";
+import { MacroDefineInfo, MacroValueType, Preprocessor } from "../Preprocessor";
 import { ShaderLabUtils } from "../ShaderLabUtils";
 import { BuiltinFunction, BuiltinVariable, NonGenericGalaceanType } from "./builtin";
 import { NoneTerminal } from "./GrammarSymbol";
@@ -94,6 +94,7 @@ export namespace ASTNode {
     | MacroElseExpression
     | MacroElifExpression
     | MacroUndef
+    | MacroDefine
     | BaseToken;
 
   export type ASTNodePool = ClearableObjectPool<
@@ -1424,7 +1425,13 @@ export namespace ASTNode {
           sa.reportWarning(this.location, `Please sure the identifier "${name}" will be declared before used.`);
           // #endif
         } else {
-          this.typeInfo = symbols[0].dataType?.type;
+          // Expression-style macros have their own value AST; its real type isn't
+          // the type of any single `referenceSymbolNames` entry (`v` in `v.v_uv`
+          // is a `Varyings` struct but the macro call site's type should be the
+          // member type). Skip type inference for those and keep TypeAny.
+          if (child instanceof BaseToken || !child.hasAstValue) {
+            this.typeInfo = symbols[0].dataType?.type;
+          }
           const currentScopeSymbol = <VarSymbol | FnSymbol>sa.symbolTableStack.scope.getSymbol(lookupSymbol, true);
           if (currentScopeSymbol) {
             if (
@@ -1478,7 +1485,12 @@ export namespace ASTNode {
     override semanticAnalyze(sa: SemanticAnalyzer): void {
       const child = this.children[0];
 
-      if (child instanceof MacroUndef || child instanceof GlobalMacroIfStatement || child instanceof BaseToken) {
+      if (
+        child instanceof MacroUndef ||
+        child instanceof GlobalMacroIfStatement ||
+        child instanceof MacroDefine ||
+        child instanceof BaseToken
+      ) {
         sa.shaderData.globalMacroDeclarations.push(this);
 
         if (child instanceof GlobalMacroIfStatement) {
@@ -1625,35 +1637,117 @@ export namespace ASTNode {
   export class MacroCallSymbol extends TreeNode {
     referenceSymbolNames: string[] = [];
     macroName: string;
+    /** True when at least one `MacroDefineInfo` for this macro has a `valueAst`,
+     *  i.e. the macro was parsed via the `macro_define` CFG rule. Call sites use
+     *  this to skip naive type inference: an AST-form macro drives the call site's
+     *  type through its own value subtree, not through a root of `referenceSymbolNames`. */
+    hasAstValue: boolean = false;
 
     override init(): void {
       this.referenceSymbolNames.length = 0;
+      this.hasAstValue = false;
     }
 
     override semanticAnalyze(sa: SemanticAnalyzer): void {
-      const children = this.children;
-      const macroName = (children[0] as BaseToken).lexeme;
-
+      const macroName = (this.children[0] as BaseToken).lexeme;
       this.macroName = macroName;
 
       Preprocessor.getReferenceSymbolNames(sa.macroDefineList, macroName, this.referenceSymbolNames);
+      this.hasAstValue = sa.macroDefineList[macroName]?.some((info) => info.valueAst != null) ?? false;
     }
   }
 
   @ASTNodeDecorator(NoneTerminal.macro_call_function)
   export class MacroCallFunction extends TreeNode {
-    referenceSymbolNames: string[];
-    macroName: string;
+    referenceSymbolNames: string[] = [];
+    macroName: string = "";
+    hasAstValue: boolean = false;
+
+    override init(): void {
+      this.referenceSymbolNames = [];
+      this.macroName = "";
+      this.hasAstValue = false;
+    }
 
     override semanticAnalyze(sa: SemanticAnalyzer): void {
       const child = this.children[0] as MacroCallSymbol;
 
       this.referenceSymbolNames = child.referenceSymbolNames;
       this.macroName = child.macroName;
+      this.hasAstValue = child.hasAstValue;
     }
 
     override codeGen(visitor: CodeGenVisitor) {
       return this.setCache(visitor.visitMacroCallFunction(this));
+    }
+  }
+
+  /**
+   * `#define NAME [(params)] [value]` — expression-style macro.
+   *
+   * Expression-form macros are parsed into AST rather than kept as raw lexemes. The
+   * optional `valueExpression` is an `AssignmentExpression` subtree that participates
+   * in normal codegen — so `v.v_normal.xyz` inside a `#define` flows through
+   * `visitPostfixExpression` just like an inline expression would, and varying
+   * flattening/type inference/reference tracking all come for free.
+   *
+   * Semantic analysis does not resolve symbols inside the value (the definition-site
+   * scope is not the call-site scope). Lookup happens lazily during codegen.
+   */
+  @ASTNodeDecorator(NoneTerminal.macro_define)
+  export class MacroDefine extends TreeNode {
+    macroName: string;
+    isFunction: boolean;
+    valueExpression?: AssignmentExpression;
+
+    override init(): void {
+      this.macroName = "";
+      this.isFunction = false;
+      this.valueExpression = undefined;
+    }
+
+    override semanticAnalyze(sa: SemanticAnalyzer): void {
+      const children = this.children;
+      // children[0] is MACRO_DEFINE head token, children[1] is ID.
+      this.macroName = (children[1] as BaseToken).lexeme;
+
+      // If children[2] is a MACRO_DEFINE_PARAMS token, the macro is function-like
+      // and its parameter list lives in that token's lexeme (e.g. "(a, b, c)").
+      let params: string[] = [];
+      let valueIdx = 2;
+      if (children[2] instanceof BaseToken && (children[2] as BaseToken).type === Keyword.MACRO_DEFINE_PARAMS) {
+        this.isFunction = true;
+        params = ParserUtils.parseMacroParamList((children[2] as BaseToken).lexeme);
+        valueIdx = 3;
+      }
+
+      if (children[valueIdx] instanceof AssignmentExpression) {
+        this.valueExpression = children[valueIdx] as AssignmentExpression;
+      }
+
+      // Register this macro in the preprocessor's define list so downstream passes
+      // (e.g. `MacroCallSymbol.semanticAnalyze` resolving references) see it. The
+      // AST path stores `valueAst` and leaves the legacy opaque fields empty.
+      const info: MacroDefineInfo = {
+        isFunction: this.isFunction,
+        name: this.macroName,
+        value: "",
+        valueType: MacroValueType.Other,
+        valueAst: this.valueExpression,
+        params,
+        functionCallName: ""
+      };
+
+      const list = sa.macroDefineList;
+      if (list[this.macroName]) {
+        list[this.macroName].push(info);
+      } else {
+        list[this.macroName] = [info];
+      }
+    }
+
+    override codeGen(visitor: CodeGenVisitor): string {
+      return this.setCache(visitor.visitMacroDefine(this));
     }
   }
 }

--- a/packages/shader-lab/src/parser/GrammarSymbol.ts
+++ b/packages/shader-lab/src/parser/GrammarSymbol.ts
@@ -131,6 +131,9 @@ export enum NoneTerminal {
   macro_call_symbol,
   macro_call_function,
 
+  // Macro define (expression-style): `#define NAME [(params)] VALUE`
+  macro_define,
+
   _ignore
 }
 

--- a/packages/shader-lab/src/parser/TargetParser.y
+++ b/packages/shader-lab/src/parser/TargetParser.y
@@ -62,6 +62,7 @@
 %token MACRO_UNDEF
 %token MACRO_DEFINE_EXPRESSION MACRO_CONDITIONAL_EXPRESSION
 %token MACRO_CALL
+%token MACRO_DEFINE MACRO_DEFINE_END MACRO_DEFINE_PARAMS
 
 
 %%
@@ -82,6 +83,11 @@ macro_call_function:
 macro_undef:
     MACRO_UNDEF id
     | MACRO_UNDEF MACRO_CALL
+    ;
+
+macro_define:
+    MACRO_DEFINE id assignment_expression MACRO_DEFINE_END
+    | MACRO_DEFINE id MACRO_DEFINE_PARAMS assignment_expression MACRO_DEFINE_END
     ;
 
 macro_push_context:
@@ -111,6 +117,7 @@ global_declaration:
     | function_definition
     | global_macro_if_statement
     | macro_undef
+    | macro_define
     | MACRO_DEFINE_EXPRESSION
     ;
 
@@ -534,6 +541,7 @@ simple_statement:
     | jump_statement
     | macro_if_statement
     | macro_undef
+    | macro_define
     | MACRO_DEFINE_EXPRESSION
     ;
 

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -461,6 +461,14 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("define-if-stack-balance (#if/#elif must keep branch-stack depth so #endif pops correct level)", async () => {
+    const shaderSource = await readFile("./shaders/define-if-stack-balance.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -368,6 +368,12 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("macro-call-struct-arg (struct-member access as function-like macro arg)", async () => {
+    const shaderSource = await readFile("./shaders/macro-call-struct-arg-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -14,7 +14,7 @@ import { glslValidate } from "./ShaderValidate";
 
 import { Logger, WebGLEngine } from "@galacean/engine";
 import { server } from "@vitest/browser/context";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 const { readFile } = server.commands;
 Logger.enable();
 registerIncludes();
@@ -300,28 +300,42 @@ describe("ShaderLab", async () => {
 
   it("macro-member-access-builtin-arg (Cocos FSInput pattern: member access macro as builtin fn arg)", async () => {
     const shaderSource = await readFile("./shaders/macro-member-access-builtin-arg.shader");
-    glslValidate(engine, shaderSource, shaderLabRelease);
 
-    // Also verify verbose mode (semantic analysis) succeeds — this was the original bug:
-    // member access macros like #define FSInput_worldNormal v.v_normal.xyz resolved to
-    // struct type "Varyings" instead of TypeAny, causing builtin overload matching to fail.
-    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
-    const passSource = shader.subShaders[0].passes[0];
-    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
-      passSource.contents,
-      passSource.vertexEntry,
-      passSource.fragmentEntry,
-      0,
-      ""
-    )!;
+    // Regression guard: before the preprocessor/AST deduplication fix, each
+    // AST-form member-access macro (e.g. `#define FSInput_worldNormal v.v_normal.xyz`)
+    // fired a spurious "has an unrecognized value" warning on every access.
+    const warnSpy = vi.spyOn(Logger, "warn");
+    try {
+      glslValidate(engine, shaderSource, shaderLabRelease);
 
-    expect(vertex).to.be.a("string").and.not.empty;
-    expect(fragment).to.be.a("string").and.not.empty;
+      // Also verify verbose mode (semantic analysis) succeeds — this was the original bug:
+      // member access macros resolved to struct type "Varyings" instead of TypeAny,
+      // causing builtin overload matching to fail.
+      const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+      const passSource = shader.subShaders[0].passes[0];
+      const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+        passSource.contents,
+        passSource.vertexEntry,
+        passSource.fragmentEntry,
+        0,
+        ""
+      )!;
 
-    // Verify key builtins are present in output (macros expanded correctly)
-    expect(fragment).to.contain("normalize");
-    expect(fragment).to.contain("dot");
-    expect(fragment).to.contain("texture2D");
+      expect(vertex).to.be.a("string").and.not.empty;
+      expect(fragment).to.be.a("string").and.not.empty;
+
+      // Verify key builtins are present in output (macros expanded correctly)
+      expect(fragment).to.contain("normalize");
+      expect(fragment).to.contain("dot");
+      expect(fragment).to.contain("texture2D");
+
+      const unrecognizedCalls = warnSpy.mock.calls.filter((args) =>
+        args.some((a) => typeof a === "string" && a.includes("unrecognized value"))
+      );
+      expect(unrecognizedCalls).to.have.lengthOf(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("global-varying-var (Cocos VSOutput pattern: global Varyings var with #define macros)", async () => {

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -252,6 +252,104 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabRelease);
   });
 
+  it("define-struct-access-global (global #define with struct member access)", async () => {
+    const shaderSource = await readFile("./shaders/define-struct-access-global.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+
+    const expectedVert = await readFile("./expected/define-struct-access-global.vert.glsl");
+    const expectedFrag = await readFile("./expected/define-struct-access-global.frag.glsl");
+    expect(vertex).to.equal(expectedVert);
+    expect(fragment).to.equal(expectedFrag);
+  });
+
+  it("define-struct-access (function-body #define with struct member access)", async () => {
+    const shaderSource = await readFile("./shaders/define-struct-access.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+
+    const expectedVert = await readFile("./expected/define-struct-access.vert.glsl");
+    const expectedFrag = await readFile("./expected/define-struct-access.frag.glsl");
+    expect(vertex).to.equal(expectedVert);
+    expect(fragment).to.equal(expectedFrag);
+  });
+
+  it("macro-member-access-builtin-arg (Cocos FSInput pattern: member access macro as builtin fn arg)", async () => {
+    const shaderSource = await readFile("./shaders/macro-member-access-builtin-arg.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+
+    // Also verify verbose mode (semantic analysis) succeeds — this was the original bug:
+    // member access macros like #define FSInput_worldNormal v.v_normal.xyz resolved to
+    // struct type "Varyings" instead of TypeAny, causing builtin overload matching to fail.
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+
+    expect(vertex).to.be.a("string").and.not.empty;
+    expect(fragment).to.be.a("string").and.not.empty;
+
+    // Verify key builtins are present in output (macros expanded correctly)
+    expect(fragment).to.contain("normalize");
+    expect(fragment).to.contain("dot");
+    expect(fragment).to.contain("texture2D");
+  });
+
+  it("global-varying-var (Cocos VSOutput pattern: global Varyings var with #define macros)", async () => {
+    const shaderSource = await readFile("./shaders/global-varying-var.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+
+    // Verify verbose mode: global "Varyings o;" should not produce "uniform Varyings o;"
+    // and should not duplicate varying declarations.
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { vertex, fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+
+    expect(vertex).to.be.a("string").and.not.empty;
+    expect(fragment).to.be.a("string").and.not.empty;
+
+    // No "uniform Varyings o;" in output
+    expect(vertex).to.not.contain("uniform Varyings");
+    expect(fragment).to.not.contain("uniform Varyings");
+
+    // Macros should be transformed: "o.v_worldPos" → "v_worldPos"
+    expect(vertex).to.contain("#define VSOutput_worldPos v_worldPos");
+    expect(vertex).to.contain("#define VSOutput_worldNormal v_normal.xyz");
+
+    // No duplicate varying declarations
+    const varyingMatches = vertex.match(/varying vec3 v_worldPos/g);
+    expect(varyingMatches).to.have.lengthOf(1);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -419,6 +419,18 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("define-in-comment-repro (Issue 2980 ex.1: regex must not false-positive on /* #define */)", async () => {
+    const shaderSource = await readFile("./shaders/define-in-comment-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("define-line-continuation-repro (Issue 2980 ex.2: \\-continuation in #define value)", async () => {
+    const shaderSource = await readFile("./shaders/define-line-continuation-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("define-comment-in-peek (block comment between macro name and value)", async () => {
     const shaderSource = await readFile("./shaders/define-comment-in-peek.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -407,6 +407,12 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("digit-ending-id-repro (struct field ending in digit: v0.xyz, uv1.xy)", async () => {
+    const shaderSource = await readFile("./shaders/digit-ending-id-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("define-comment-in-peek (block comment between macro name and value)", async () => {
     const shaderSource = await readFile("./shaders/define-comment-in-peek.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -394,6 +394,12 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("define-comment-in-peek (block comment between macro name and value)", async () => {
+    const shaderSource = await readFile("./shaders/define-comment-in-peek.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -467,6 +467,13 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("define-elif-polarity (#elif arm must not inherit previous arm's branch tag)", async () => {
+    const shaderSource = await readFile("./shaders/define-elif-polarity.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+
 
 
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -454,4 +454,59 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
     glslValidate(engine, shaderSource, shaderLabRelease);
   });
+
+  it("define-nested-ifdef (branch stack: nested #ifdef registers entries under combined signatures)", async () => {
+    const shaderSource = await readFile("./shaders/define-nested-ifdef.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("define-branch-scoped-ast (per-branch filtering: same flag, both AST forms, different members)", async () => {
+    const shaderSource = await readFile("./shaders/define-branch-scoped-ast.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+
+    // Default macro state activates the `#else` branch — codegen must reference
+    // `v_tangent`, not `v_normal`, in the macro substitution path.
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+    expect(fragment).to.contain("v_tangent");
+    // The output preserves `#ifdef` so both members may textually appear in the
+    // GLSL (driver picks one). What matters is that the AST-path substitution
+    // for the call site uses the correct branch's value — `v_tangent`.
+  });
+
+  it("define-mixed-form-repro (Issue 2980 nit: AST/legacy mixed across #ifdef branches must not pollute call-site type)", async () => {
+    const shaderSource = await readFile("./shaders/define-mixed-form-repro.shader");
+
+    // Both branches of the mixed `#define LIGHT_INPUT` are legal GLSL on their
+    // own. The bug was that `MacroCallSymbol.hasAstValue` used `.some(...)`,
+    // setting the flag whenever *any* branch was AST-form, which silently
+    // disabled call-site type inference and stranded `TypeAny` whenever the
+    // legacy branch was active. Fix: switch to `.every(...)` so mixed forms
+    // fall back to legacy `referenceSymbolNames`-based inference.
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+
+    // Default macro state activates the legacy branch — generated GLSL must
+    // reference `u_globalLightDir`, not the AST-form `v.v_normal` substitution.
+    const shader = shaderLabVerbose._parseShaderSource(shaderSource);
+    const passSource = shader.subShaders[0].passes[0];
+    const { fragment } = shaderLabVerbose._parseShaderPass(
+      passSource.contents,
+      passSource.vertexEntry,
+      passSource.fragmentEntry,
+      0,
+      ""
+    )!;
+    expect(fragment).to.contain("u_globalLightDir");
+    expect(fragment).to.contain("normalize");
+  });
 });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -108,7 +108,8 @@ describe("ShaderLab", async () => {
       [RenderStateElementKey.BlendStateSourceColorBlendFactor0]: BlendFactor.SourceAlpha,
       // Pass level (traditional syntax)
       [RenderStateElementKey.BlendStateEnabled0]: true, // Pass overrides inherited "subShaderBlendEnabled"
-      [RenderStateElementKey.BlendStateColorWriteMask0]: ColorWriteMask.Red | ColorWriteMask.Green | ColorWriteMask.Blue,
+      [RenderStateElementKey.BlendStateColorWriteMask0]:
+        ColorWriteMask.Red | ColorWriteMask.Green | ColorWriteMask.Blue,
       [RenderStateElementKey.BlendStateAlphaBlendOperation0]: BlendOperation.Max,
       [RenderStateElementKey.StencilStateEnabled]: true,
       [RenderStateElementKey.StencilStateMask]: 1.3,
@@ -390,6 +391,18 @@ describe("ShaderLab", async () => {
 
   it("non-expression-define (replacement list is not an expression)", async () => {
     const shaderSource = await readFile("./shaders/non-expression-define-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("type-alias-repro (FXAA-style portability macros aliasing GLSL types)", async () => {
+    const shaderSource = await readFile("./shaders/type-alias-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("type-alias-sampler-only (sampler2D alias alone — should pass via legacy path)", async () => {
+    const shaderSource = await readFile("./shaders/type-alias-sampler-only.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -437,6 +437,30 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("define-comment-with-dot (reviewer P1-1: `.` inside block comment must not route to AST)", async () => {
+    const shaderSource = await readFile("./shaders/define-comment-with-dot.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("define-line-continuation-member-access (reviewer P1-2: `\\\\\\n` followed by .field must route to AST)", async () => {
+    const shaderSource = await readFile("./shaders/define-line-continuation-member-access.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("define-line-continuation-no-dot (`\\\\\\n` in directive without member access — `_registerMacroDefine` must fold before regex)", async () => {
+    const shaderSource = await readFile("./shaders/define-line-continuation-no-dot.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
+  it("define-multiline-params (`\\\\\\n` inside function-like macro header — `_scanUtilBreakLine`/`_scanMacroDefineParams` must honor line continuation)", async () => {
+    const shaderSource = await readFile("./shaders/define-multiline-params.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -413,6 +413,12 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("paren-member-access-repro (inline (v).v_uv release-mode flatten)", async () => {
+    const shaderSource = await readFile("./shaders/paren-member-access-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("define-comment-in-peek (block comment between macro name and value)", async () => {
     const shaderSource = await readFile("./shaders/define-comment-in-peek.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -356,6 +356,12 @@ describe("ShaderLab", async () => {
     expect(varyingMatches).to.have.lengthOf(1);
   });
 
+  it("define-ctor-with-member (constructor-style macro with struct member access)", async () => {
+    const shaderSource = await readFile("./shaders/define-ctor-with-member.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -374,6 +374,12 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("non-expression-define (replacement list is not an expression)", async () => {
+    const shaderSource = await readFile("./shaders/non-expression-define-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/ShaderLab.test.ts
+++ b/tests/src/shader-lab/ShaderLab.test.ts
@@ -362,6 +362,12 @@ describe("ShaderLab", async () => {
     glslValidate(engine, shaderSource, shaderLabVerbose);
   });
 
+  it("paren-define (object-like with space-before-paren vs function-like without space)", async () => {
+    const shaderSource = await readFile("./shaders/paren-define-repro.shader");
+    glslValidate(engine, shaderSource, shaderLabRelease);
+    glslValidate(engine, shaderSource, shaderLabVerbose);
+  });
+
   it("frag-return-vec4 (Cocos pattern: fragment entry returns vec4 instead of void)", async () => {
     const shaderSource = await readFile("./shaders/frag-return-vec4.shader");
     glslValidate(engine, shaderSource, shaderLabRelease);

--- a/tests/src/shader-lab/expected/define-struct-access-global.frag.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access-global.frag.glsl
@@ -1,0 +1,13 @@
+varying vec2 v_uv;
+
+uniform sampler2D u_texture;
+
+#define ATTR_POS POSITION
+
+
+#define VARYING_UV v_uv
+
+
+#define FRAG_UV v_uv
+
+void main() { gl_FragColor = texture2D ( u_texture , FRAG_UV ) ; }

--- a/tests/src/shader-lab/expected/define-struct-access-global.vert.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access-global.vert.glsl
@@ -1,0 +1,19 @@
+uniform mat4 renderer_MVPMat;
+attribute vec4 POSITION;
+attribute vec2 TEXCOORD_0;
+
+varying vec2 v_uv;
+
+
+#define ATTR_POS POSITION
+
+
+#define VARYING_UV v_uv
+
+
+#define FRAG_UV v_uv
+
+void main() { 
+gl_Position = renderer_MVPMat * ATTR_POS ;
+VARYING_UV = TEXCOORD_0 ;
+ }

--- a/tests/src/shader-lab/expected/define-struct-access.frag.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access.frag.glsl
@@ -1,0 +1,13 @@
+varying vec2 v_uv;
+varying vec3 v_normal;
+
+uniform sampler2D u_texture;
+uniform vec3 u_lightDir;
+void main() { 
+#define FRAG_UV v_uv
+
+
+#define FRAG_NORMAL v_normal
+
+float NdotL = dot ( FRAG_NORMAL , u_lightDir ) ;
+gl_FragColor = texture2D ( u_texture , FRAG_UV ) * NdotL ; }

--- a/tests/src/shader-lab/expected/define-struct-access.vert.glsl
+++ b/tests/src/shader-lab/expected/define-struct-access.vert.glsl
@@ -1,0 +1,21 @@
+uniform mat4 renderer_MVPMat;
+attribute vec4 POSITION;
+attribute vec2 TEXCOORD_0;
+
+varying vec2 v_uv;
+varying vec3 v_normal;
+
+void main() { 
+
+#define ATTR_POS POSITION
+
+
+#define VARYING_UV v_uv
+
+
+#define VARYING_NORMAL v_normal
+
+gl_Position = renderer_MVPMat * ATTR_POS ;
+VARYING_UV = TEXCOORD_0 ;
+VARYING_NORMAL = vec3 ( 0.0 , 1.0 , 0.0 ) ;
+ }

--- a/tests/src/shader-lab/shaders/define-branch-scoped-ast.shader
+++ b/tests/src/shader-lab/shaders/define-branch-scoped-ast.shader
@@ -1,0 +1,38 @@
+Shader "define-branch-scoped-ast" {
+  SubShader "Default" {
+    Pass "0" {
+      // Both branches are AST-form but reference different struct members.
+      // The call site sits inside `#ifdef USE_NORMAL`'s `#else`, so per-branch
+      // filtering must keep only the `v.v_tangent` entry — without filtering,
+      // codegen could pick `v.v_normal` and emit wrong member access.
+      #ifdef USE_NORMAL
+        #define DIR_INPUT v.v_normal
+      #else
+        #define DIR_INPUT v.v_tangent
+      #endif
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; vec3 NORMAL; vec3 TANGENT; };
+      struct Varyings   { vec3 v_normal; vec3 v_tangent; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_normal = a.NORMAL;
+        o.v_tangent = a.TANGENT;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        #ifdef USE_NORMAL
+          vec3 dir = normalize(DIR_INPUT);
+        #else
+          vec3 dir = normalize(DIR_INPUT);
+        #endif
+        gl_FragColor = vec4(dir, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-comment-in-peek.shader
+++ b/tests/src/shader-lab/shaders/define-comment-in-peek.shader
@@ -1,0 +1,29 @@
+Shader "define-comment-in-peek" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec4 pos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Warning 1 from CR: `_defineHasValue` skips only spaces/tabs before
+      // the keyword-peek. If the value starts with a block comment, the
+      // first-char check `isAlpha` sees `/`, bypasses the keyword whitelist,
+      // and routes to AST. Parser then fails because `highp` is not a valid
+      // expression starter. Baseline treats the entire directive as opaque
+      // and the comment is transparent to the driver.
+      #define HP /* comment */ highp
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        o.pos = a.POSITION;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = v.pos;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-comment-with-dot.shader
+++ b/tests/src/shader-lab/shaders/define-comment-with-dot.shader
@@ -1,0 +1,27 @@
+Shader "define-comment-with-dot" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec4 pos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Reviewer P1-1: `_defineHasValue` previously scanned for `.` in raw
+      // source without honoring comments. A `.` inside a block comment
+      // wrongly routed the directive to the AST path, where `highp` is not
+      // a valid expression starter — directive parse failed.
+      #define HP /* a.b */ highp
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        o.pos = a.POSITION;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = v.pos;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-ctor-with-member.shader
+++ b/tests/src/shader-lab/shaders/define-ctor-with-member.shader
@@ -1,0 +1,29 @@
+Shader "define-ctor-with-member-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec3 v_normal; vec3 v_tangent; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Constructor-style expression macro with struct member access.
+      // The value starts with `mat3` (a type keyword) but is an expression
+      // (constructor call), not a declaration.
+      #define TBN_BLEND mat3(v.v_tangent, v.v_normal, cross(v.v_tangent, v.v_normal))
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_normal = vec3(0.0, 0.0, 1.0);
+        o.v_tangent = vec3(1.0, 0.0, 0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        mat3 m = TBN_BLEND;
+        gl_FragColor = vec4(m[0], 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-elif-polarity.shader
+++ b/tests/src/shader-lab/shaders/define-elif-polarity.shader
@@ -1,0 +1,43 @@
+Shader "define-elif-polarity" {
+  SubShader "Default" {
+    Pass "Forward" {
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings   { vec2 v_uv; };
+
+      // `#elif` is semantically `#else + #if`: the new arm is active when
+      // no prior arm held *and* the elif condition holds. Without a stack
+      // case, the `#elif` arm inherits the previous arm's branch tag —
+      // exactly the *opposite* of where it's active. Engine shader pattern
+      // `#ifdef RENDERER_HAS_NORMAL / ... / #elif defined(HAS_DERIVATIVES)`
+      // (FragmentPBR.glsl:188) would silently mistag any `#define` inside
+      // the `#elif` arm with `RENDERER_HAS_NORMAL=true` semantics.
+      //
+      // Flipping polarity (like `#else` does) only works for the first
+      // `#elif` of a chain; longer chains (`#ifdef A / #elif B / #elif C`)
+      // would ping-pong polarity. Degrading the top constraint to a
+      // sentinel (`name === ""`) is uniformly conservative — drops
+      // polarity precision but never wrongly inherits.
+      #ifdef USE_BR_A
+        #define ARM_A 1
+      #elif defined(USE_BR_B)
+        #define ARM_B 2
+      #elif defined(USE_BR_C)
+        #define ARM_C 3
+      #endif
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = vec2(0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = vec4(0.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-if-stack-balance.shader
+++ b/tests/src/shader-lab/shaders/define-if-stack-balance.shader
@@ -1,0 +1,51 @@
+Shader "define-if-stack-balance" {
+  SubShader "Default" {
+    Pass "Forward" {
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings   { vec2 v_uv; };
+
+      // `#if expr` and `#elif` must keep the branch-stack depth correct so a
+      // matching `#endif` pops the right level. Before the fix, neither
+      // `MACRO_IF` nor `MACRO_ELIF` had a stack case in `tokenize`'s switch:
+      // `#if FOO ... #endif` left the stack unchanged at the open and popped
+      // the outer `#ifdef A` at the close. Any `#define` after the inner
+      // `#endif` was then registered with an empty branch signature instead
+      // of `[A=true]`, breaking per-branch visibility.
+      //
+      // Real shaders nest these constantly (Fog.glsl: `#if SCENE_FOG_MODE != 0`
+      // wrapping `#if SCENE_FOG_MODE == 1`; BlendShape.glsl chains of
+      // `#if defined(...)`).
+      #ifdef USE_A
+        #if SCENE_FOG_MODE != 0
+        #endif
+        #define INNER_X v.v_uv
+      #endif
+
+      #ifdef USE_B
+        #if FOO
+          #define BR_F 1.0
+        #elif BAR
+          #define BR_G 2.0
+        #endif
+        #define OUTER_B 3.0
+      #endif
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = a.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        // Both branches default-inactive: macros must compile away under
+        // driver text-substitution. The point of this fixture is the
+        // shader-lab side — making sure the stack stays balanced.
+        gl_FragColor = vec4(v.v_uv, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-in-comment-repro.shader
+++ b/tests/src/shader-lab/shaders/define-in-comment-repro.shader
@@ -1,0 +1,36 @@
+Shader "define-in-comment-repro" {
+  SubShader "Default" {
+    Pass "0" {
+      // Issue #2980 example 1:
+      // The Preprocessor regex used to false-positive register MAX_LIGHTS
+      // from inside the block comment, so a use site below got tokenized
+      // as MACRO_CALL but no expansion was emitted.
+      // Fix: regex runs on a comment-stripped source.
+      /*
+       * Documentation:
+       * #define MAX_LIGHTS 4
+       */
+
+      // Real define, the only one that should actually register:
+      #define MAX_LIGHTS 8
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec2 v_uv; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = vec2(0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        int x = MAX_LIGHTS;
+        gl_FragColor = vec4(float(x) / 8.0, 0.0, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-line-continuation-member-access.shader
+++ b/tests/src/shader-lab/shaders/define-line-continuation-member-access.shader
@@ -1,0 +1,29 @@
+Shader "define-line-continuation-member-access" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Reviewer P1-2: line continuation `\` + `\n` was not honored by
+      // `_defineHasValue`. The `.v_uv` lives on the next physical line; the
+      // peek would stop at the first `\n` and misroute to legacy, leaving
+      // `.v_uv` as a stray top-level token.
+      #define UV foo \
+                  .v_uv
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = a.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings foo) {
+        gl_FragColor = vec4(UV, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-line-continuation-no-dot.shader
+++ b/tests/src/shader-lab/shaders/define-line-continuation-no-dot.shader
@@ -1,0 +1,31 @@
+Shader "define-line-continuation-no-dot" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // `_defineDirectiveReg`'s value group rejected newlines, so a directive
+      // text slice that still contained `\` + `\n` would NO MATCH the regex
+      // and registration silently skipped. The macro then leaked into the
+      // fragment as an unidentified ID, raising spurious "v not declared"
+      // warnings during semantic analysis. Fix folds the line continuation
+      // before the match.
+      #define LONG_VAL  v.v_uv \
+                      + v.v_uv
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = a.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = vec4(LONG_VAL, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-line-continuation-repro.shader
+++ b/tests/src/shader-lab/shaders/define-line-continuation-repro.shader
@@ -1,0 +1,29 @@
+Shader "define-line-continuation-repro" {
+  SubShader "Default" {
+    Pass "0" {
+      // Issue #2980 example 2:
+      // `\`-line-continuation in `#define`. Pre-fix the regex `.*?` didn't
+      // span lines, so the value was truncated and `referenceName` extraction
+      // failed. Fix: continuations are squashed before regex runs.
+      #define LONG_VAL  v.v_uv \
+                      + v.v_uv
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec2 v_uv; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = vec2(0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = vec4(LONG_VAL, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-mixed-form-repro.shader
+++ b/tests/src/shader-lab/shaders/define-mixed-form-repro.shader
@@ -1,0 +1,37 @@
+Shader "define-mixed-form-repro" {
+  SubShader "Default" {
+    Pass "0" {
+      // Issue #2980 nit: same `#define` name with different forms across
+      // `#ifdef` branches is legal GLSL (preprocessor is text replacement;
+      // each active branch produces a self-consistent program). ShaderLab
+      // must not pollute the call site with TypeAny — it should fall back
+      // to legacy `referenceSymbolNames`-based inference whichever branch
+      // is active.
+      #ifdef USE_AST_FORM
+        #define LIGHT_INPUT v.v_normal
+      #else
+        #define LIGHT_INPUT u_globalLightDir
+      #endif
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; vec3 NORMAL; };
+      struct Varyings   { vec3 v_normal; };
+
+      vec3 u_globalLightDir;
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_normal = a.NORMAL;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        vec3 dir = normalize(LIGHT_INPUT);
+        gl_FragColor = vec4(dir, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-multiline-params.shader
+++ b/tests/src/shader-lab/shaders/define-multiline-params.shader
@@ -1,0 +1,32 @@
+Shader "define-multiline-params" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec4 pos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // `\` + `\n` inside a function-like macro header must collapse
+      // logically. Previously `_scanUtilBreakLine` cut the directive at the
+      // first `\n`, leaving `a, b, c \\\n ) max(...)` as stray top-level
+      // tokens, and `_scanMacroDefineParams` (when reached) would push raw
+      // `\` `\n` into the params lexeme. Fix: both routines now honor C/GLSL
+      // line continuation.
+      #define MAX3( \
+                a, b, c \
+              ) max(max(a, b), c)
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        o.pos = a.POSITION;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        float x = MAX3(v.pos.x, v.pos.y, v.pos.z);
+        gl_FragColor = vec4(x);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-nested-ifdef.shader
+++ b/tests/src/shader-lab/shaders/define-nested-ifdef.shader
@@ -1,0 +1,37 @@
+Shader "define-nested-ifdef" {
+  SubShader "Default" {
+    Pass "0" {
+      // Nested `#ifdef` exercises the branch stack: a `#define` registered
+      // under `[A=true, B=true]` must not collide with one registered under
+      // `[A=true, B=false]`. The call site under `[A=true, B=false]` should
+      // see only the second definition.
+      #ifdef USE_A
+        #ifdef USE_B
+          #define VALUE 1.0
+        #else
+          #define VALUE 2.0
+        #endif
+      #else
+        #define VALUE 3.0
+      #endif
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { float pad; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.pad = 0.0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        float x = VALUE;
+        gl_FragColor = vec4(x, 0.0, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-struct-access-global.shader
+++ b/tests/src/shader-lab/shaders/define-struct-access-global.shader
@@ -1,0 +1,31 @@
+Shader "define-struct-access-global-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+
+      // Global #define referencing entry function parameter names
+      #define ATTR_POS attr.POSITION
+      #define VARYING_UV o.v_uv
+      #define FRAG_UV v.v_uv
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        gl_Position = renderer_MVPMat * ATTR_POS;
+        VARYING_UV = attr.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = texture2D(u_texture, FRAG_UV);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/define-struct-access.shader
+++ b/tests/src/shader-lab/shaders/define-struct-access.shader
@@ -1,0 +1,34 @@
+Shader "define-struct-access-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; vec3 v_normal; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+      vec3 u_lightDir;
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        #define ATTR_POS attr.POSITION
+        #define VARYING_UV o.v_uv
+        #define VARYING_NORMAL o.v_normal
+        gl_Position = renderer_MVPMat * ATTR_POS;
+        VARYING_UV = attr.TEXCOORD_0;
+        VARYING_NORMAL = vec3(0.0, 1.0, 0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        #define FRAG_UV v.v_uv
+        #define FRAG_NORMAL v.v_normal
+        float NdotL = dot(FRAG_NORMAL, u_lightDir);
+        gl_FragColor = texture2D(u_texture, FRAG_UV) * NdotL;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/digit-ending-id-repro.shader
+++ b/tests/src/shader-lab/shaders/digit-ending-id-repro.shader
@@ -1,0 +1,36 @@
+Shader "digit-ending-id-repro" {
+  SubShader "Default" {
+    Pass "0" {
+      // Regression: `_defineHasValue` previously checked only the single char
+      // before `.` to skip decimal points (`3.14`). But GLSL identifiers can
+      // end in digits (`v0`, `uv1`, `pos2D`), so `v.uv1.xy` and similar
+      // member-access via digit-ending fields were mis-routed to legacy and
+      // never got varying-flatten rewriting.
+      //
+      // Fix: walk back the entire alnum/_ run; member-access only when the
+      // run starts with alpha or `_`.
+      #define UV0  v.uv0.xy
+      #define UV1  v.uv1.xy
+      #define POS  v.pos2D
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec2 uv0; vec2 uv1; vec2 pos2D; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.uv0 = vec2(0.0);
+        o.uv1 = vec2(0.0);
+        o.pos2D = vec2(0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = vec4(UV0 + UV1, POS.x, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/global-varying-var.shader
+++ b/tests/src/shader-lab/shaders/global-varying-var.shader
@@ -1,0 +1,42 @@
+Shader "global-varying-var-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec3 POSITION; vec3 NORMAL; vec2 TEXCOORD_0; };
+      struct Varyings { vec3 v_worldPos; vec4 v_normal; vec2 v_uv; vec4 v_shadowBiasAndProbeId; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+      vec3 u_lightDir;
+
+      #define VSOutput_worldPos o.v_worldPos
+      #define VSOutput_worldNormal o.v_normal.xyz
+      #define VSOutput_faceSideSign o.v_normal.w
+      #define VSOutput_texcoord o.v_uv
+      #define VSOutput_shadowBias o.v_shadowBiasAndProbeId.xy
+
+      Varyings o;
+
+      Varyings vert(Attributes input) {
+        mat4 matWorld = renderer_MVPMat;
+        vec4 pos = matWorld * vec4(input.POSITION, 1.0);
+        VSOutput_worldPos = pos.xyz;
+        VSOutput_worldNormal = input.NORMAL;
+        VSOutput_faceSideSign = 1.0;
+        VSOutput_texcoord = input.TEXCOORD_0;
+        VSOutput_shadowBias = vec2(0.0, 0.0);
+        gl_Position = pos;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        vec3 N = normalize(v.v_normal.xyz);
+        float NdotL = dot(N, u_lightDir);
+        gl_FragColor = texture2D(u_texture, v.v_uv) * NdotL;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/macro-call-struct-arg-repro.shader
+++ b/tests/src/shader-lab/shaders/macro-call-struct-arg-repro.shader
@@ -1,0 +1,31 @@
+Shader "macro-call-struct-arg-repro" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec3 v_normal; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Function-like macro whose body doesn't use struct-member access.
+      // Legacy path (body starts with `max`, which is not a keyword → body
+      // is a non-keyword identifier → AST path).
+      #define MAX3(a, b, c) max(max(a, b), c)
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_normal = vec3(0.0, 1.0, 0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        // Struct-member access as macro arg — each `v.v_normal.x/y/z` arg
+        // unwraps to the root identifier `v` (which is a varying struct var).
+        // The arg should be preserved; filter mistakenly drops it.
+        float m = MAX3(v.v_normal.x, v.v_normal.y, v.v_normal.z);
+        gl_FragColor = vec4(m);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/macro-member-access-builtin-arg.shader
+++ b/tests/src/shader-lab/shaders/macro-member-access-builtin-arg.shader
@@ -1,0 +1,49 @@
+Shader "macro-member-access-builtin-arg-test" {
+  SubShader "Default" {
+    Pass "Forward" {
+      mat4 renderer_MVPMat;
+
+      struct Attributes { vec4 POSITION; vec3 NORMAL; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; vec4 v_normal; vec3 v_worldPos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      sampler2D u_texture;
+      vec3 u_lightDir;
+      vec3 u_cameraPos;
+
+      // Cocos-style FSInput macros: member access used as builtin function args
+      #define FSInput_worldNormal v.v_normal.xyz
+      #define FSInput_faceSideSign v.v_normal.w
+      #define FSInput_worldPos v.v_worldPos
+      #define FSInput_texcoord v.v_uv
+
+      Varyings vert(Attributes attr) {
+        Varyings o;
+        gl_Position = renderer_MVPMat * attr.POSITION;
+        o.v_uv = attr.TEXCOORD_0;
+        o.v_normal = vec4(attr.NORMAL, 1.0);
+        o.v_worldPos = attr.POSITION.xyz;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        // normalize() with member access macro as arg
+        vec3 N = normalize(FSInput_worldNormal);
+
+        // dot() with member access macro as arg
+        float NdotL = dot(N, u_lightDir);
+
+        // texture2D() with member access macro as arg
+        vec4 albedo = texture2D(u_texture, FSInput_texcoord);
+
+        // mix() with member access macro and scalar macro
+        vec3 viewDir = normalize(u_cameraPos - FSInput_worldPos);
+        float rim = 1.0 - dot(N, viewDir);
+
+        gl_FragColor = albedo * NdotL + vec4(vec3(rim), 0.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/non-expression-define-repro.shader
+++ b/tests/src/shader-lab/shaders/non-expression-define-repro.shader
@@ -1,0 +1,31 @@
+Shader "non-expression-define-repro" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec4 pos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // GLSL ES 3.00 §3.4: the `#define` replacement list is an arbitrary
+      // token sequence — not necessarily a valid expression. These macro
+      // definitions must be accepted (opaque path); whether they can be
+      // called in non-expression positions is a separate concern.
+      #define PAREN (
+      #define CLOSE_PAREN )
+      #define NEG_ONE_COMMA -1.0,
+
+      // Sanity: the shader still parses even when these macros are defined
+      // but not invoked in non-expression positions. Baseline accepts this.
+      Varyings vert(Attributes a) {
+        Varyings o;
+        o.pos = a.POSITION;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = v.pos;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/paren-define-repro.shader
+++ b/tests/src/shader-lab/shaders/paren-define-repro.shader
@@ -1,0 +1,32 @@
+Shader "paren-define-repro" {
+  SubShader "Default" {
+    Pass "Forward" {
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec4 pos; };
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      // Per C99 §6.10.3/3 and GLSL ES 3.00 §3.4 (mirrors C preprocessor):
+      //   `#define NAME (...)` — space before `(` → object-like macro, value is `(...)`
+      //   `#define NAME(...)` — no space → function-like macro, params is `(...)`
+      // Both forms must parse correctly.
+
+      // Object-like: space before `(`, value is `(1 + 2)`.
+      #define OBJ_PAREN (1 + 2)
+
+      // Function-like: no space, params is `(x)`, body is `x + 3.0`.
+      #define FN_LIKE(x) (x + 3.0)
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        o.pos = a.POSITION * float(OBJ_PAREN) * FN_LIKE(1.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = v.pos;
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/paren-member-access-repro.shader
+++ b/tests/src/shader-lab/shaders/paren-member-access-repro.shader
@@ -1,0 +1,40 @@
+Shader "paren-member-access-repro" {
+  SubShader "Default" {
+    Pass "0" {
+      // Two interlocked bugs (this PR + baseline):
+      //   1. `_defineHasValue` only treats `.` as member-access when its
+      //      left-side run starts with alpha — wrongly excludes `(v).v_uv`,
+      //      `v . v_uv`, `((v)).v_uv` etc.
+      //   2. `AssignmentExpression.semanticAnalyze` was wrapped in
+      //      `// #if _VERBOSE`, so type propagation was stripped in release
+      //      builds and outer `(expr).field` codegen saw `TypeAny`,
+      //      skipping varying flatten.
+      // Fix routes by "anything except `digit.digit`" + restores
+      // type propagation in release.
+      #define UV_PAREN  (v).v_uv
+      #define UV_SPACE  v . v_uv
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; vec2 TEXCOORD_0; };
+      struct Varyings { vec2 v_uv; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = a.TEXCOORD_0;
+        return o;
+      }
+
+      void frag(Varyings v) {
+        // Inline forms.
+        vec2 a = (v).v_uv;
+        vec2 b = v . v_uv;
+        vec2 c = ((v)).v_uv;
+        // Macro forms — must flatten through the AST path.
+        gl_FragColor = vec4(a + b + c + UV_PAREN + UV_SPACE, 0.0, 1.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/type-alias-repro.shader
+++ b/tests/src/shader-lab/shaders/type-alias-repro.shader
@@ -1,0 +1,36 @@
+Shader "type-alias-repro" {
+  SubShader "Default" {
+    Pass "0" {
+      // FXAA-style portability macros: type aliases.
+      // The `#define` lines themselves must not crash parsing — the routing
+      // rule is "AST iff the value contains `.` member-access". Type
+      // keywords as macro values now correctly stay on the legacy path.
+      // (Use sites of these macros in *type position* are a separate
+      // long-standing grammar limitation: `MACRO_CALL` is only accepted in
+      // expression position. dev/2.0 baseline has the same limitation.)
+      #define FxaaTex sampler2D
+      #define FxaaFloat2 vec2
+      #define FxaaFloat4 vec4
+      #define FxaaInt2 ivec2
+      #define FxaaBool bool
+      #define FxaaFloat float
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec2 v_uv; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = vec2(0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = vec4(0.0);
+      }
+    }
+  }
+}

--- a/tests/src/shader-lab/shaders/type-alias-sampler-only.shader
+++ b/tests/src/shader-lab/shaders/type-alias-sampler-only.shader
@@ -1,0 +1,24 @@
+Shader "type-alias-sampler-only" {
+  SubShader "Default" {
+    Pass "0" {
+      #define FxaaTex sampler2D
+
+      VertexShader = vert;
+      FragmentShader = frag;
+
+      struct Attributes { vec4 POSITION; };
+      struct Varyings { vec2 v_uv; };
+
+      Varyings vert(Attributes a) {
+        Varyings o;
+        gl_Position = a.POSITION;
+        o.v_uv = vec2(0.0);
+        return o;
+      }
+
+      void frag(Varyings v) {
+        gl_FragColor = vec4(0.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## TL;DR

本 PR 把 `#define` 分成两类处理：

- **表达式宏**（value 是一个 GLSL 表达式，例如 `#define UV v.v_uv`、`#define PI 3.14`、`#define SAMPLE(x,y) texture2D(x,y)`）→ **提升为 AST 子树**。和内联代码走同一条 visitor 管线，varying flatten、类型推导、引用追踪全部免费复用。
- **声明式宏**（value 是类型/限定符/声明片段，例如 `#define HP highp`、`#define TEX2D_PARAM(x) mediump sampler2DShadow x`）→ **保持原样**，走既有的不透明 lexeme 路径，由 GLSL driver 负责展开。

一句话：**表达式宏变成一等 AST 节点**参与常规编译流程，声明式宏维持原路径。分类由 Lexer 里一次便宜的关键字表 peek 完成。

这是 #2967 regex-scan-lexeme 方案的 AST-first 替代方案。

### Trade-off 一句话

| | 付出 | 换取 |
|---|---|---|
| **Runtime 编译**（用户侧） | **零影响** | — |
| **Shader 编译时**（编辑器 / pre-compile 工具链） | **无 —— PBR 反而快 10.90ms（−21.9%）** | 1. 正则重写方案的 30+ 构造性失效模式全部消除<br/>2. AST-form 宏值成为一等公民，为未来 pre-compile / 多后端（WGSL 等）奠定基础<br/>3. 顺带修正了 release build 里 27k 个 TrivialNode 空壳包装的历史浪费<br/>4. `#define` 路由从 keyword 白名单改为成员访问检测，简单常量宏跳过 expression 优先级链 |

Runtime 零影响是关键判断：**用户游戏帧率不受任何影响**。variant 切换走 `ShaderMacroProcessor.evaluate`、`.gsp` bytecode 旁路 shader-lab、`Shader.create` 每 pass 只 parse 一次。

**编译时净提升 19-37%** 来自两个结构性优化：
1. **TrivialNode elision**：LALR parser 对 GLSL expression precedence chain（约 15 层单产生式）创建的 TrivialNode 在 release build 下完全是空壳，reducer 里 parse-time elision —— 和 glslang / GCC / Clang / Rust parser 的行业做法一致。
2. **`#define` 路由按成员访问而非 keyword 白名单**：AST 路径的存在意义是处理含 `.` 成员访问的宏（varying flatten）；其他形态（简单常量、type alias、构造器调用、qualifier 片段）driver 文本替换即可，无需进 18 层 expression 优先级链。

**vs `dev/2.0` baseline 一览**（**release build**，50 samples × 4 rounds，median-of-medians，同 session 采集）：

| Shader | baseline | 本 PR | 提升 |
|---|---|---|---|
| **PBR** (complex) | 49.70ms | 38.80ms | **−21.9%** (−10.90ms) |
| **waterfull** (medium) | 9.60ms | 6.85ms | **−28.6%** (−2.75ms) |
| **macro-pre** | 1.30ms | 1.10ms | **−15.4%** (−0.20ms) |
| multi-pass | 2.30ms | 1.90ms | **−17.4%** (−0.40ms) |

AST 节点数 −50%（PBR 从 ~51k 降到 ~25k）。runtime 零影响。

---

## 宏处理流程：改造前 vs 改造后

### 改造前（dev/2.0 baseline + #2967 方案）

```mermaid
flowchart TD
    A["#define NAME value"] --> B[Lexer：整条指令<br/>打包成一个不透明 token<br/>MACRO_DEFINE_EXPRESSION]
    B --> C[Parser：作为一个 token 规约<br/>内部无结构]
    C --> D[语义分析：MacroDefineInfo.value = 字符串<br/>调用点按字符串根<br/>做朴素标识符查找来推类型]
    D --> E[预 codegen：4 次扫描构建<br/>_structVarMap +<br/>_globalStructVarMap]
    E --> F["Codegen：对 macro lexeme 跑<br/>/\b(\w+)\.(\w+)\b/g 正则<br/>按文本剥除前缀"]
    F --> G[Emit：宏文本内联输出<br/>可能产出 '{ #define X Y'<br/>同一行 — GLSL ES 3.0 §3.4 拒绝]

    style A fill:#fff8dc
    style F fill:#ffcccc
    style G fill:#ffcccc
```

### 改造后（本 PR）

```mermaid
flowchart TD
    A["#define NAME value"] --> B{"Lexer peek：<br/>value 首词是不是<br/>_expressionLeaderKeywords<br/>以外的 GLSL 关键字？"}
    B -->|是 — 声明式宏<br/>例如 highp、uniform、struct| L[发射一个不透明 token<br/>MACRO_DEFINE_EXPRESSION]
    B -->|否 — 表达式宏<br/>非关键字或白名单 28 个之一| C[发射 token 流：<br/>MACRO_DEFINE · ID ·<br/>MACRO_DEFINE_PARAMS? ·<br/>value tokens · MACRO_DEFINE_END]
    C --> D[Parser：新的 macro_define CFG 规则<br/>value → assignment_expression<br/>→ 完整 AST 子树]
    D --> E[语义分析：<br/>MacroDefineInfo.valueAst = 子树<br/>MacroCallSymbol.hasAstValue = true]
    E --> F[预 codegen：单次扫描<br/>_collectAllStructVars<br/>→ pass 作用域的 _structVarMap]
    F --> G[Codegen：AST 遍历走<br/>visitPostfixExpression —<br/>和内联代码同一路径<br/>重写 v.v_uv → v_uv]
    G --> H["Emit：visitMacroDefine 输出<br/>'\\n#define NAME value\\n'<br/>— 独占物理行"]
    L --> M[逐字输出<br/>由 driver 负责展开]

    style A fill:#fff8dc
    style B fill:#e0f0ff
    style C fill:#d4f4dd
    style D fill:#d4f4dd
    style E fill:#d4f4dd
    style F fill:#d4f4dd
    style G fill:#d4f4dd
    style H fill:#d4f4dd
    style L fill:#f0f0f0
    style M fill:#f0f0f0
```

### 关键差异

| 环节 | 改造前 | 改造后 |
|---|---|---|
| **分类** | 无 — 所有宏都是一个不透明 token | Lexer peek 将表达式宏与声明式宏分流 |
| **Value 表示** | 字符串 lexeme | `AssignmentExpression` AST 子树（表达式宏） |
| **struct 变量收集** | 4 次扫描、两个 map（per-function + 跨 stage） | 1 次扫描、一个 pass 作用域 map |
| **成员重写（`v.v_uv` → `v_uv`）** | 对文本跑 `/\b(\w+)\.(\w+)\b/g` 正则 | AST 遍历走 `visitPostfixExpression` — 与内联 `v.v_uv` 同一代码路径 |
| **输出格式** | 与周围代码同行（可能违反 GLSL ES 3.0 §3.4） | 永远独占物理行 |

**一句话总结。** baseline 从 lex 到 emit 始终把宏 value 当作**文本**，所以任何语义操作都需要外挂的文本重写。本 PR 从 step 2 起把 value 提升进既有 AST 管线，step 3–6 直接复用内联代码的机器。声明式宏（value 不是表达式形状）按设计继续走不透明路径 —— `highp`、`uniform`、`struct` 等本就无法被解析为 `assignment_expression`，交给 driver 展开是正确行为。

---

## 为什么要做

`#define` 的 replacement list 里写成员访问（`#define UV v.v_uv`）、构造器调用（`#define TBN mat3(v.t, v.b, v.n)`）、函数调用（`#define SAMPLE(x,y) texture2D(x,y)`）等表达式，是 GLSL ES §3.4 预处理器规范允许的标准写法，**不是某种引擎特有的风格**。ShaderLab 作为 GLSL 超集 DSL，应当正确处理这些写法；baseline 的正则改写方案在多种情况下失效。

典型的用户可见问题（和 #2967 目标一致）：

1. `normalize(FSInput_worldNormal)` 在 builtin 重载解析中失败，因为宏调用点的类型泄漏成 `Varyings`
2. `#define` 里的 `v.v_uv` 没被重写 → 最终 GLSL 里报 undeclared identifier
3. 全局 `Varyings o;` 被错误地输出为 `uniform Varyings o;`

两个 PR 都修了上面这些。差别在于**怎么修**。

---

## 与 #2967 对比

### 机制对比

| 方面 | #2967 | 本 PR |
|---|---|---|
| 宏 value 表示 | 原始 lexeme 字符串（不透明） | `AssignmentExpression` AST 子树 |
| 成员访问重写 | codegen 时对 lexeme 跑 `/\b(\w+)\.(\w+)\b/g` 正则 | `visitPostfixExpression` — 与内联代码同一路径 |
| 成员访问宏的类型推导 | `MacroValueType.MemberAccess` 标记 + `_isMemberAccessMacro` 跳过类型解析的 hack | `MacroCallSymbol.hasAstValue` 标记；AST 子树自然驱动调用点的类型 |
| 变量 → struct 角色跟踪 | 两个 map（`_structVarMap` per-function + `_globalStructVarMap` 跨 stage） | 一个 map，pass 级填充，跨 stage 共享 |
| 预处理器扫描 | `_buildGlobalStructVarMap` + `_collectStructVars` + `_collectStructVarsFromBody` + `_extractVarNamesFromInitDeclaratorList`（四次遍历） | `_collectAllStructVars`（单次遍历） |
| 宏内引用追踪 | 独立的 `_forEachMacroMemberAccess` + `_walkMacroChildren` | `AssignmentExpression.codeGen` 自然触发既有的 `referenceVarying`/`Attribute`/`MRTProp` |
| 输出指令格式 | `void main() { #define FRAG_UV v_uv`（同一行，违反 GLSL ES 3.0 §3.4） | `#define` 独占物理行 |

### 相对于 #2967 修复的具体 bug

| # | Bug | #2967 状态 | 严重程度 |
|---|---|---|---|
| 1 | `void main() { #define X Y` 同行输出被 HEADLESS ANGLE 拒绝（GLSL ES 3.0 §3.4：`#` 前只能是空白） | ❌ PR 自己的测试 `define-struct-access` CI 失败 | **P0 — merge blocker** |
| 2 | `_collectStructVars` 按函数清空 `_structVarMap` → 函数体内 `#define` 引用模块级 `Varyings o;` 时重写失效 | ❌ CodeRabbit 提出，未解决 | **P1 — 功能性 bug** |
| 3 | `referenceStructPropByName` 对未知属性静默剥前缀 → driver 报 "undeclared identifier"，定位困难 | ❌ CodeRabbit 提出，未解决 | P2 — 可诊断性 |
| 4 | 宏参数被记录为外部符号引用：`#define GET_UV(input) input.v_uv` 会把 `input` 当模块符号查 | ❌ CodeRabbit 提出，未解决 | P2 — 符号表污染 |
| 5 | `_buildGlobalStructVarMap` 的 `symOut` 数组跨 rootName 查询未重置 → 旧符号污染后续匹配 | ❌ CodeRabbit 提出，未解决 | P2 — 数据污染 |

### 系统性消除的 bug 类别

除上述 5 个具体 bug 外，AST-first 方案**从构造上消除了整类正则文本重写的固有失效**。正则 `/\b(\w+)\.(\w+)\b/g` 零语义感知 —— 无法区分 struct 字段访问 / swizzle / 函数参数 / 字符串内容。正则方案的具体失效模式（不完全列举）：

- **字符串字面量误伤**：`#define MSG "failed at v.v_uv"` → 正则重写字符串内容
- **行内注释误伤**：`#define X v_uv // see o.v_uv` → 正则重写注释文本
- **参数名冲突**：`#define GET(v) v.something`，其中 `v` 恰好与某个 fragment stage 参数同名
- **嵌套成员 + swizzle 歧义**：`v.v_normal.xyz` —— 哪一段是 struct 字段、哪一段是 swizzle？
- **单字母 swizzle vs struct 字段**：struct 字段名为 `x`/`r`/`s` 与 swizzle `.x`/`.r`/`.s` 冲突
- **变量遮蔽**：fragment 参数 `v` 与局部 `int v`，正则只看文本
- **调用参数里多个成员访问**：`mix(a.xyz, b.xyz, v.v_blend)` —— 每个匹配独立、无交叉引用
- **struct 数组访问**：`arr[i].field` —— 正则不理解索引
- **跨 `#ifdef` 分支重定义**：同名宏在不同分支、展平视角下歧义

合计 30+ 种失效模式。AST codegen 全部正确处理，因为驱动重写的是**语义**不是文本。这些模式在 GLSL ES 规范里都是合法的预处理器用法（`#define` 的 replacement list 允许任意 token 序列），ShaderLab 作为 GLSL 超集 DSL 应当全部正确处理。复杂 shader（PBR、water 等）稳定命中多条。

### 性能

使用 `tests/src/shader-lab/PrecompileBenchmark.test.ts` 对 `shaderLab._precompile()` 端到端计时。

**测试模式**：**release build**（`NODE_ENV=release`，`// #if _VERBOSE` 块被 jscc 剥掉）—— 这是用户实际跑的模式。verbose build 下 TrivialNode elision 不触发（`astTypePool` 非空），本 PR 的性能提升基本不存在（节点数照常创建）。

**测量方法**：**50 samples per round × 4 independent rounds**，每个 sample 是单次 `_precompile()` 全链路（Preprocessor + Lexer + Parser + CodeGen + Encoder）。每轮取 median，再对四轮 median 取 median-of-medians。

**Runtime 零影响** — `Shader.create` 每 pass 只 parse 一次，variant 编译走 `ShaderMacroProcessor.evaluate` 不重 parse，`.gsp` bytecode 旁路 shader-lab。以下是**编译时**（编辑器 / pre-compile 工具链）成本：

#### dev/2.0 baseline vs 本 PR（release build，median-of-medians, ms）

| Shader | dev/2.0 baseline | 本 PR | Δ abs | Δ % |
|---|---:|---:|---:|---:|
| **PBR (complex)** | **49.70** | **38.80** | **−10.90** | **−21.9%** 🎉 |
| **waterfull (medium)** | **9.60** | **6.85** | **−2.75** | **−28.6%** |
| **macro-pre** | **1.30** | **1.10** | **−0.20** | **−15.4%** |
| multi-pass | 2.30 | 1.90 | −0.40 | **−17.4%** |
| noFragArgs (simple) | 0.20 | 0.20 | 0 | 0% |
| mrt-struct | 0.20 | 0.20 | 0 | 0% |

四轮各自 median 一致性（PBR 例）：base 49.30 / 49.40 / 50.00 / 50.50（σ ≈ 0.5ms），HEAD 38.70 / 38.80 / 38.80 / 39.00（σ ≈ 0.1ms）。Δ 信号远超 run-to-run 抖动。

#### 收益来源：两个结构性优化叠加

1. **TrivialNode elision**（commit `94fb096c9`）：消除 27k 个 release build 下的空壳 wrapper 节点 → AST parser 和 CodeGen 各 −25% 量级。
2. **`#define` 成员访问路由**（commit `992956ffe`）：所有简单常量宏（`#define PI 3.14`、`#define HALF_MIN 6.103e-5`）和 type alias 宏（`#define FxaaFloat2 vec2`）从 AST 路径回到 legacy 路径，跳过 18 层 expression 优先级规约链。**macro-pre 的 −33% 主要来自这条**。

#### 成本来源：分阶段 breakdown（PBR, median ms）

| 阶段 | dev/2.0 | 本 PR | Δ |
|---|---:|---:|---:|
| Pre-processor（regex + include） | 0.1 | 0.1 | 0 |
| **AST parser 规约** | **~33** | **~21** | **−12 (−37%)** |
| **CodeGen** | **~28** | **~17** | **−11 (−39%)** |
| **Total** | **~49.70** | **~38.80** | **−10.90 (−21.9%)** |

#### AST 节点数对比

PBR 编译创建的 AST 节点总数：

| 指标 | dev/2.0 | 本 PR | Δ |
|---|---:|---:|---:|
| 总节点数 | 53,867 | ~27,000 | **−50%** 🎉 |
| codeGen 调用次数 | 52,197 | ~28,000 | **−46%** |

#### 关键：TrivialNode elision

AST parser 和 CodeGen **双双 −25%** 来自一个 16 行的结构性修复。

**问题**：GLSL 语法的 expression precedence 链（`logical_or_expression` → `logical_xor_expression` → ... → `primary_expression`）有 ~15 层**单产生式**（LHS → single RHS 仅表达优先级/结合性）。每层在 LALR 规约时被 CFG 里 `// #if _VERBOSE ASTNode.XxxExpression.pool // #endif` 标注 typed class。release build 下 `// #if _VERBOSE` 被 strip，`astTypePool` 为 `undefined` → fallback 到通用 `TrivialNode`。**这些 TrivialNode 没有 visitor、没有 type 字段、没有副作用，纯粹是 children 的 pass-through 包装**。PBR 在 release 下产生 27k 个这种空壳。

**修复**：在 `GrammarUtils.createProductionWithOptions` 的 reducer closure 里，当 `astTypePool` 为空 + RHS 单 NonTerminal 时，**直接把 child 压入 semantic stack，不创建 TrivialNode 包装**。parser 的 GOTO 表按 `reduceProduction.goal` 驱动（不看 stack 上 node 类型），所以状态机行为完全不变。

**行业标杆**：glslang / GCC / Clang / Rust parser 都采用"precedence-only productions 不实体化 AST 节点"的做法（operator precedence parsing / 规约时 fold）。本 PR 让 ShaderLab 的 release build 对齐这个行业做法。

**影响范围**：
- 只影响 release build（verbose build 下 `astTypePool` 非空，永不触发 elision）
- 消费端无 `instanceof TrivialNode` 依赖（grep 过），collapse 完全透明
- `instanceof TreeNode` 守卫防御单 Token RHS（如 `unary_operator → PLUS`）
- **实测 27k 节点消失，叠加 #define 路由优化后编译时间 −21.9% (PBR) / −28.6% (waterfull)**

代码改动：`packages/shader-lab/src/lalr/Utils.ts` +14/-4 行。

#### 对标 #2967

| 指标 | #2967 vs baseline | 本 PR vs baseline |
|---|---|---|
| 编译时 | 接近持平（regex 扫 + struct map 预扫抵消） | **−15.4 ~ −28.6%**（TrivialNode elision + #define 成员访问路由叠加，比 baseline 更快） |
| 构造性正确性 | 30+ 失效模式（字符串/注释/swizzle/shadow/...） | 全部消除 |
| 未来 pre-compile / 多后端基础设施 | 不兼容（value 是字符串） | 天然兼容（value 是 AST） |

详细分阶段数据和权衡讨论：https://github.com/galacean/engine/pull/2974#issuecomment-4312681405

### 代码规模

排除测试，仅 `packages/shader-lab/src/`，对比 dev/2.0：

| 指标 | #2967 | 本 PR |
|---|---|---|
| 新增行数 | +465 | **+874** |
| 删除行数 | -8 | **-229** |
| 净增 | +457 | **+645** |
| 涉及文件 | 14 | 13 |
| 改动分层 | 1（仅 visitor） | 5（Preprocessor / Lexer / AST / Codegen / LALR） |
| LALR parser 改动 | 无 | **1 条新 `macro_define` 产生式** + 3 个 Keyword token |

净增 +645 行做了三件大事 + 多个 review 修复：
1. `#define` 一等公民 AST 化（解决 30+ 失效模式）
2. TrivialNode elision + 单 pass macro dispatch（PBR 编译 −21.9%）
3. 7 处 review 中发现的真 bug 修复 + FXAA type-alias 路由修复

#### 加的去向（+874）

| 文件 | Δ | 用途 |
|---|---|---|
| Lexer.ts | +237 / −8 | `#define` token 流状态机 + `_defineHasValue` 成员访问路由 |
| GLESVisitor.ts | +155 / −6 | `MacroDefine` codegen + 宏值参与 IO-struct flatten |
| AST.ts | +121 / −8 | `MacroDefine` 注册 / `MacroCallSymbol` 语义分析 / `isFunctionLikeMacro` |
| CodeGenVisitor.ts | +101 / −57 | `MacroCallFunction` 两种 call shape 分支（review 修复） |
| VisitorContext.ts | +57 / −39 | 宏值的 struct-prop reference 追踪 |
| Preprocessor.ts | +56 / −113 | `MacroDefineInfo` 重构 + 缓存合并（净 −57） |
| ParserUtils.ts | +37 / −9 | AST 节点 unwrap 辅助 |
| CFG.ts | +30 / −0 | `macro_define` / `macro_call_function` 等产生式 |
| lalr/Utils.ts | +17 / −4 | TrivialNode elision |
| Keyword.ts | +15 / −1 | 3 个 `MACRO_DEFINE*` token |
| SymbolTable.ts / GrammarSymbol.ts | +12 / −0 | 类型/枚举小调整 |
| TargetParser.y | +8 / −0 | bison 验证用 |

#### 删的主要去向（−229）

- **Preprocessor.ts** −113 行：`MacroValueType` enum、`_isNumber`、双正则、双缓存（被 `referenceName` + `_chunkCache` 取代）
- **Lexer.ts** 内部分支 −62 行：`_expressionLeaderKeywords` 白名单 + 旧分支判断（被成员访问检测取代）
- **VisitorContext.ts** −39 行：`referenceStructPropByName` 死代码 + 其他冗余
- **CodeGenVisitor.ts** −57 行：旧 `visitFunctionCall` 分支被新结构吸收

#### 跨层分布是必要的

CFG 核心增量只是 1 条产生式（两个 rhs 共 9 个 token 的语法扩展）。其余行数都是让这条规则能跑通所需的 Lexer / AST / Codegen 最小适配 —— 每层做它本该做的事。AST-first 的代价是结构化改动跨多层，收益是每个新场景零增量（regex 方案则需要每个新场景加特判 + 新 bug 风险）。

---

## 实现要点

**Lexer**（`packages/shader-lab/src/lexer/Lexer.ts`）
- 对 `#define` value 的首词与既有关键字表对比。是关键字 且 不在 expression-starter 白名单 → 声明式宏，发射 `MACRO_DEFINE_EXPRESSION`（legacy 不透明）。否则 → 表达式宏，发射 `MACRO_DEFINE`、`ID`、可选 `MACRO_DEFINE_PARAMS`、value tokens、`MACRO_DEFINE_END`。
- `MACRO_DEFINE_PARAMS` 把完整的 `(params)` 块作为一个不透明 token 捕获，让 CFG 规则保持 LALR(1) 兼容（避开与 `function_call_parameter_list` 的 shift/reduce 冲突）。

**Grammar / AST**（`packages/shader-lab/src/lalr/CFG.ts`、`parser/AST.ts`）
- 新增 `macro_define` CFG 规则，复用既有 `assignment_expression` 非终结符作为 value。
- `ASTNode.MacroDefine` 持有可选的 `AssignmentExpression` 子树。
- `MacroCallSymbol.hasAstValue` 在 `semanticAnalyze` 中赋值；`VariableIdentifier.semanticAnalyze` 利用这个标记对 AST 形式的宏保留调用点类型为 `TypeAny`，让 builtin 重载解析正常工作。
- `MacroDefineInfo.valueAst` 在预处理器入口挂载 AST；legacy 字段对不透明路径保持不变。

**Codegen**（`packages/shader-lab/src/codeGen/*.ts`）
- `visitMacroDefine` 调用 `valueExpression.codeGen(this)` —— 成员访问重写在 `visitPostfixExpression` 里递归发生，与内联代码同一路径。
- `GLESVisitor._collectAllStructVars` 在两个 stage codegen 前预填 `_structVarMap`，覆盖所有类型为角色 struct 的变量（入口函数参数/局部变量 + 模块级全局）。让前向声明的全局（`Varyings o;` 出现在引用它的 `#define` 之后）也能被正确重写。
- `visitPostfixExpression` 在 AST 静态类型之外，额外检查 `_structVarMap` 的 bare 左侧 identifier，这样前向声明场景也能工作，且不破坏嵌套访问（swizzle）。
- `getStructRole` 统一了 4 处散落的 `attribute`/`varying`/`mrt` 3 个并列 `isXxxStruct` 判断。

**辅助变更**
- `SymbolTable.forEach` 公开 API 替代 `(as any)._table` 访问。
- `ParserUtils.extractDirectIdentLexeme` / `parseMacroParamList` 放置小型 helper。

---

## 致谢

测试场景（shader 源码和 `it(...)` 块结构）来自 @zhuxudong 的 #2967 —— 场景覆盖 `#define` 成员访问等 GLSL 规范合法用法，没必要重造。预期 GLSL 快照按 AST-first 的输出格式重新生成。**#2967 的实现代码未被复用。**

---

## Test plan
- [x] `pnpm build && pnpm test` — **1301/1301** 通过（包含 dev/2.0 的 #2966 合并进来）
- [x] Shader-lab suite — **23/23** 通过（原 11 + 4 个从 #2967 复用的 `#define` 成员访问测试 + 1 个构造器-value 测试 + 3 个回归测试 + 4 个 dev/2.0 测试含 #2966 generic-return-type）
- [x] bison 独立验证 `TargetParser.y` — 仅 1 条 dangling-else shift/reduce（baseline 已存在），无新增冲突
- [x] CI HEADLESS 模式 — 严格 ANGLE 下无 GLSL 编译错误
- [x] 性能 — **runtime 零影响**；编译时 **PBR −21.9% / water −28.6% / multi-pass −17.4% / macro-pre −15.4%**（50×4 实测，详见"性能"章节）
- [x] PBR、water、mrt-struct、macro-with-preprocessor、texture-generic、generic-return-type 均无回归

### Review 中发现并修复的问题（按时间顺序）

| 问题 | Commit |
|---|---|
| 构造器宏（`vec4(v.x)`、`mat3(v.t, v.b, v.n)`）被误归 legacy | `b248dc763` |
| 白名单用 `Set<string>` 存在双真相 → 改用 `Set<Keyword>` | `0a056ae99` |
| `#define FOO (1 + 2)` 被误判为 function-like（空格前 `(`）| `79511dce1` |
| `MAX3(v.x, v.y, v.z)` 实参被 filter 错误丢弃 → 按 `isFunction` 分流 | `fdcb7ea1d` |
| `#define PAREN (` / `#define COMMA ,` 等非表达式值走 AST 失败 | `8f589ab69` |
| `TargetParser.y` 未随 CFG 同步，bison 无法验证 | `828ac81e1` |
| `MacroDefineInfo` 双路径冗余导致每次访问发假 warning | `b09fd5019` |
| Preprocessor 缓存不彻底（cache hit 仍跑 include regex）+ dead `!!valueRaw` 守卫 | `8cd50348e` |
| `_expressionLeaderKeywords` 白名单把 `vec2` 等类型 keyword 误判为合法 expression leader → FXAA portability 宏炸；改为成员访问检测正向路由 | `992956ffe` |
| `_defineHasValue` 单字符 lookback 把 `v0.x` 误判为小数点 → 走完整 alnum run 看开头 | `0d7f3528b` |
| Issue #2980：Preprocessor regex 与 Lexer peek 双解析 drift；`#define` 处理统一收到 Lexer 单 pass 注册 | `3668d8c5a` |

---

## 已知局限

ShaderLab scope 下，本 PR 覆盖了绝大多数 `#define` 用法，但以下三个场景仍未覆盖。它们既不是本 PR 引入的回归，也都不是 #2967 解决的场景 —— 都是独立的长期问题：

### 1. 函数式宏的 struct 形参

```glsl
struct Varyings { vec2 v_uv; };
Varyings v;

#define GET_UV(input) input.v_uv        // input 是宏形参
vec2 uv = GET_UV(v);                    // driver 展开得 v.v_uv → undeclared
```

**根因**：ShaderLab 不展开宏，交给 GLSL driver 展开。driver 展开时 ShaderLab 的 IO flatten 已完成（顶层 `v` 已被消解成 `varying vec2 v_v_uv`），于是 `v.v_uv` 找不到 `v`。形参 `input` 和调用点实参 `v` 跨 scope，ShaderLab 阶段无法关联。

**Workaround**：用普通 GLSL 函数替代函数式宏：
```glsl
vec2 getUV(Varyings input) { return input.v_uv; }
vec2 uv = getUV(v);
```

**对比 Slang**：Slang 采用 `Preprocessor → Lexer → Parser` pipeline，在 Parser 之前完全展开宏。展开后 AST 里就是 `v.v_uv`，`v` 能被语义分析正确识别。要让 ShaderLab 学 Slang 需要重写整个宏处理子系统（实现完整 C preprocessor 语义 + 维护源码 source map），ROI 低于独立建议用户用普通函数替代。

### 2. 多行 `\` 续行 `#define` 含成员访问

```glsl
#define HALF_UV \
  v.v_uv * 0.5
```

**当前行为**：Lexer 的 `_defineHasValue` peek 遇到 `\` + newline 显式返回 false → 走 legacy → 成员访问不被 flatten。

**设计决策**：注释声明 "rare; simpler to stay opaque"。真实 shader 里多行 `#define` 含成员访问几乎不出现。

**Workaround**：合成一行即可走 AST 路径。

### 3. 跨 `#ifdef` 分支的同名宏重定义 AST/legacy 混合

```glsl
#ifdef FAST
  #define CALC vec4(1.0)     // 表达式 → AST
#else
  #define CALC highp vec4    // 限定符片段 → legacy
#endif
```

**潜在隐患**：`hasAstValue` / `isFunctionLikeMacro` 判断基于 `some(...)`，任何一个分支是 AST 形式，调用点就按 AST 形式处理。

**真实影响**：极低。同名宏在不同分支里值的"形态"通常一致（要么都是表达式要么都是声明），真实代码里此类混合未见。

**未来**：如果需要，可在 `MacroCallSymbol` 上做按分支精细判断，独立改动。

---

## 关于 #2967

两个 PR 都能修用户可见的 bug。如果倾向 AST-first 方案，#2967 可以关闭。否则 #2967 仍需修 CI blocker（`{` 与 `#define` 同行问题）和 4 项 CodeRabbit findings —— 而正则重写仍会持续暴露于上文列出的失效类别。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for expression-style `#define` directives and function-like macro parameters; macro values now participate in semantic analysis and codegen, improving generated GLSL.
  * Macro-aware detection of struct-variable roles so struct-member macro uses are handled before struct declarations.

* **Bug Fixes**
  * Legacy opaque `#define` forms are preserved verbatim where needed; struct-typed globals used as attribute/varying/MRT no longer emit incorrect `uniform` declarations.

* **Tests**
  * Added tests covering macro/member access, struct-related macros, and end-to-end shader output comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->