### PR TITLE
fix(core): invoke structured Signal listeners with runtime args before bound args

### DIFF
--- a/packages/core/src/Signal.ts
+++ b/packages/core/src/Signal.ts
@@ -20,9 +20,11 @@ export class Signal<T extends any[] = []> {
   on(fn: (...args: T) => void, target?: any): void;
   /**
    * Add a structured binding listener. Structured bindings support clone remapping.
+   * The target method will be invoked as `method(...signalArgs, ...args)` —
+   * runtime signal arguments come first, bound arguments are appended.
    * @param target - The target component
    * @param methodName - The method name to invoke on the target
-   * @param args - Pre-resolved arguments
+   * @param args - Pre-resolved arguments appended after the runtime signal arguments
    */
   on(target: Component, methodName: string, ...args: any[]): void;
   on(fnOrTarget: ((...args: T) => void) | Component, targetOrMethodName?: any, ...args: any[]): void {
@@ -37,9 +39,11 @@ export class Signal<T extends any[] = []> {
   once(fn: (...args: T) => void, target?: any): void;
   /**
    * Add a one-time structured binding listener.
+   * The target method will be invoked as `method(...signalArgs, ...args)` —
+   * runtime signal arguments come first, bound arguments are appended.
    * @param target - The target component
    * @param methodName - The method name to invoke on the target
-   * @param args - Pre-resolved arguments
+   * @param args - Pre-resolved arguments appended after the runtime signal arguments
    */
   once(target: Component, methodName: string, ...args: any[]): void;
   once(fnOrTarget: ((...args: T) => void) | Component, targetOrMethodName?: any, ...args: any[]): void {
@@ -171,7 +175,7 @@ export class Signal<T extends any[] = []> {
       const methodName = targetOrMethodName as string;
       const fn =
         args.length > 0
-          ? (...signalArgs: any[]) => (target as any)[methodName](...args, ...signalArgs)
+          ? (...signalArgs: any[]) => (target as any)[methodName](...signalArgs, ...args)
           : (...signalArgs: any[]) => (target as any)[methodName](...signalArgs);
       this._listeners.push({
         fn: fn as (...args: T) => void,

--- a/tests/src/core/CloneUtils.test.ts
+++ b/tests/src/core/CloneUtils.test.ts
@@ -1,12 +1,4 @@
-import {
-  Entity,
-  MeshRenderer,
-  Script,
-  Signal,
-  assignmentClone,
-  deepClone,
-  ignoreClone
-} from "@galacean/engine-core";
+import { Entity, MeshRenderer, Script, Signal, assignmentClone, deepClone, ignoreClone } from "@galacean/engine-core";
 import { WebGLEngine } from "@galacean/engine";
 import { describe, expect, it } from "vitest";
 
@@ -108,7 +100,7 @@ class ClickHandler extends Script {
     this.callCount++;
   }
 
-  handleClickWithPrefix(prefix: string): void {
+  handleClickWithPrefix(arg: number, prefix: string): void {
     this.callCount++;
     this.lastPrefix = prefix;
   }
@@ -553,7 +545,9 @@ describe("Clone remap", async () => {
       const parent = rootEntity.createChild("parent");
       const script = parent.addComponent(SignalScript);
       let called = false;
-      script.onFire.on(() => { called = true; });
+      script.onFire.on(() => {
+        called = true;
+      });
 
       const cloned = parent.clone();
       const cs = cloned.getComponent(SignalScript);

--- a/tests/src/core/Signal.test.ts
+++ b/tests/src/core/Signal.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 class TestHandler extends Script {
   callCount = 0;
   lastPrefix = "";
+  lastArgs: any[] = [];
 
   handleClick() {
     this.callCount++;
@@ -13,6 +14,11 @@ class TestHandler extends Script {
   handleClickWithPrefix(prefix: string) {
     this.callCount++;
     this.lastPrefix = prefix;
+  }
+
+  handleWithArgs(...args: any[]) {
+    this.callCount++;
+    this.lastArgs = args;
   }
 }
 
@@ -272,6 +278,56 @@ describe("Signal", async () => {
     signal.invoke();
     // fn2 fires, but destroyed handler's binding should not cause errors
     expect(fn2).toHaveBeenCalledOnce();
+  });
+
+  // ---- Structured binding arg order (runtime first, bound last) ----
+
+  it("structured binding: runtime args precede bound args", () => {
+    const signal = new Signal<[string, number]>();
+    const entity = root.createChild("sb-order");
+    const handler = entity.addComponent(TestHandler);
+
+    signal.on(handler, "handleWithArgs", "boundA", "boundB");
+    signal.invoke("event", 42);
+    expect(handler.lastArgs).toEqual(["event", 42, "boundA", "boundB"]);
+
+    entity.destroy();
+  });
+
+  it("structured binding: event object stays at index 0 regardless of bound args count", () => {
+    const event = { type: "click", x: 10, y: 20 };
+    const signal = new Signal<[typeof event]>();
+    const e1 = root.createChild("sb-evt-1");
+    const e2 = root.createChild("sb-evt-2");
+    const h1 = e1.addComponent(TestHandler);
+    const h2 = e2.addComponent(TestHandler);
+
+    signal.on(h1, "handleWithArgs");
+    signal.on(h2, "handleWithArgs", "ctx", 1, true);
+
+    signal.invoke(event);
+
+    expect(h1.lastArgs[0]).toBe(event);
+    expect(h2.lastArgs[0]).toBe(event);
+    expect(h2.lastArgs).toEqual([event, "ctx", 1, true]);
+
+    e1.destroy();
+    e2.destroy();
+  });
+
+  it("structured binding once: runtime + bound args order preserved", () => {
+    const signal = new Signal<[number]>();
+    const entity = root.createChild("sb-once-args");
+    const handler = entity.addComponent(TestHandler);
+
+    signal.once(handler, "handleWithArgs", "bound");
+    signal.invoke(99);
+    signal.invoke(100);
+
+    expect(handler.callCount).toBe(1);
+    expect(handler.lastArgs).toEqual([99, "bound"]);
+
+    entity.destroy();
   });
 
   // ---- Clone ----

--- a/tests/src/ui/UIInteractive.test.ts
+++ b/tests/src/ui/UIInteractive.test.ts
@@ -1,7 +1,16 @@
 import { Camera, PointerEventData, Script, SpriteDrawMode } from "@galacean/engine-core";
 import { Color, Vector3 } from "@galacean/engine-math";
 import { WebGLEngine } from "@galacean/engine";
-import { Button, ColorTransition, Image, ScaleTransition, Text, UICanvas, UIGroup, UITransform } from "@galacean/engine-ui";
+import {
+  Button,
+  ColorTransition,
+  Image,
+  ScaleTransition,
+  Text,
+  UICanvas,
+  UIGroup,
+  UITransform
+} from "@galacean/engine-ui";
 import { describe, expect, it, vi } from "vitest";
 
 class ClickHandler extends Script {
@@ -12,7 +21,7 @@ class ClickHandler extends Script {
     this.callCount++;
   }
 
-  handleClickWithPrefix(prefix: string) {
+  handleClickWithPrefix(event: PointerEventData, prefix: string) {
     this.callCount++;
     this.lastPrefix = prefix;
   }
@@ -40,7 +49,7 @@ describe("Button", async () => {
   const canvasEntity = root.createChild("canvas");
   canvasEntity.addComponent(UIGroup);
 
-  const commonTextEntity = canvasEntity.createChild("commonText")
+  const commonTextEntity = canvasEntity.createChild("commonText");
   const commonText = commonTextEntity.addComponent(Text);
 
   // Create button
@@ -54,7 +63,6 @@ describe("Button", async () => {
   text.text = "Button";
   text.color.set(0, 0, 0, 1);
   const button = buttonEntity.addComponent(Button);
-
 
   it("Set and Get", () => {
     // Click
@@ -135,7 +143,7 @@ describe("Button", async () => {
     const cloneButton = cloneButtonEntity.getComponent(Button);
     const cloneTransitions = cloneButton.transitions;
     const cloneTransition = cloneTransitions[0];
-    expect(cloneTransition.target).to.eq(cloneButtonEntity.getComponent(Image))
+    expect(cloneTransition.target).to.eq(cloneButtonEntity.getComponent(Image));
 
     const cloneTransitionOne = cloneTransitions[1];
     expect(cloneTransitionOne.target).to.eq(cloneButtonEntity.findByName("Text").getComponent(Text));


### PR DESCRIPTION
## Summary
- Flip structured-binding listener invocation order from `method(...boundArgs, ...signalArgs)` to `method(...signalArgs, ...boundArgs)`, so the event object always sits at index 0.
- Aligns with DOM `(event, customData)` convention.

## Background
Cherry-picked from `b16d8b5d7` on fix/shaderlab.

## Test plan
- [x] 3 new `Signal.test.ts` cases: arg ordering, event index 0 invariant, `once()` parity
- [x] All 29 Signal tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Signal structured binding invocation order so runtime signal arguments are passed before pre-resolved bound arguments. The event object continues to be the first argument, restoring consistent handler behavior.

* **Tests**
  * Expanded Signal tests to verify runtime vs bound argument ordering for both persistent and single-use listeners.

* **Chores**
  * Updated related test handler signatures and formatting to align with structured binding argument expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->