### PR TITLE
fix(camera): mark replacement shader fields as assignment clone

### DIFF
--- a/packages/core/src/Camera.ts
+++ b/packages/core/src/Camera.ts
@@ -9,7 +9,7 @@ import { Transform } from "./Transform";
 import { UpdateFlagManager } from "./UpdateFlagManager";
 import { VirtualCamera } from "./VirtualCamera";
 import { GLCapabilityType, Logger } from "./base";
-import { deepClone, ignoreClone } from "./clone/CloneManager";
+import { assignmentClone, deepClone, ignoreClone } from "./clone/CloneManager";
 import { AntiAliasing } from "./enums/AntiAliasing";
 import { CameraClearFlags } from "./enums/CameraClearFlags";
 import { CameraModifyFlags } from "./enums/CameraModifyFlags";
@@ -125,8 +125,10 @@ export class Camera extends Component {
   @deepClone
   _virtualCamera: VirtualCamera = new VirtualCamera();
   /** @internal */
+  @assignmentClone
   _replacementShader: Shader = null;
   /** @internal */
+  @assignmentClone
   _replacementSubShaderTag: ShaderTagKey = null;
   /** @internal */
   _replacementFailureStrategy: ReplacementFailureStrategy = null;

--- a/tests/src/core/Camera.test.ts
+++ b/tests/src/core/Camera.test.ts
@@ -118,7 +118,7 @@ describe("camera test", function () {
     // get enableHDR
     expect(camera.enableHDR).to.eq(false);
     // @ts-ignore
-    expect(camera._isIndependentCanvasEnabled()).to.eq(true);// Because sRGB pass
+    expect(camera._isIndependentCanvasEnabled()).to.eq(true); // Because sRGB pass
     // set enableHDR
     camera.enableHDR = true;
     expect(camera.enableHDR).to.eq(true);
@@ -420,14 +420,37 @@ describe("camera test", function () {
     camera.nearClipPlane = 1;
     camera.farClipPlane = 255;
     const cloneCamera = camera.entity.clone().getComponent(Camera);
-    expect(cloneCamera.isOrthographic).to.eq(camera.isOrthographic)
+    expect(cloneCamera.isOrthographic).to.eq(camera.isOrthographic);
     expect(cloneCamera.nearClipPlane).to.eq(camera.nearClipPlane);
     expect(cloneCamera.farClipPlane).to.eq(camera.farClipPlane);
     expect(cloneCamera.renderTarget).to.eq(camera.renderTarget);
     expect(cloneCamera.shaderData).to.not.eq(camera.shaderData);
     // @ts-ignore
     expect(cloneCamera._globalShaderMacro).to.not.eq(camera._globalShaderMacro);
-  })
+  });
+
+  it("clone preserves replacement shader by reference (assignmentClone)", () => {
+    const shader = Shader.create("TestCloneReplaceShader", [
+      new SubShader("Default", [new ShaderPass("Default", [], [], ShaderLanguage.GLSLES100)])
+    ]);
+
+    // @ts-ignore
+    camera._replacementShader = shader;
+    // @ts-ignore
+    camera._replacementSubShaderTag = "TestTag";
+
+    const cloneCamera = camera.entity.clone().getComponent(Camera);
+
+    // @ts-ignore - assignmentClone copies reference, not deep clone
+    expect(cloneCamera._replacementShader).to.eq(shader);
+    // @ts-ignore
+    expect(cloneCamera._replacementSubShaderTag).to.eq("TestTag");
+
+    // @ts-ignore - cleanup
+    camera._replacementShader = null;
+    // @ts-ignore
+    camera._replacementSubShaderTag = null;
+  });
 
   it("destroy test", () => {
     camera.destroy();


### PR DESCRIPTION
## Summary
- Add `@assignmentClone` to `_replacementShader` and `_replacementSubShaderTag` so cloned cameras share the same shader/tag reference instead of deep cloning them.

## Background
Extracted from `ca5252a9a` on fix/shaderlab. Without this, cloning a camera that has a replacement shader set would deep-clone the Shader object, creating an unnecessary duplicate.

## Test plan
- [x] New test case: clone preserves replacement shader by reference
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed camera component duplication to properly maintain shader state during cloning, ensuring consistent behavior when duplicating camera instances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/2988)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->