### PR TITLE
fix(core): disable cache for SceneLoader to avoid loadScene self-destroy

### DIFF
--- a/packages/core/src/SceneManager.ts
+++ b/packages/core/src/SceneManager.ts
@@ -94,9 +94,12 @@ export class SceneManager {
     const scenePromise = this.engine.resourceManager.load<Scene>({ url, type: AssetType.Scene });
     scenePromise.then((scene: Scene) => {
       if (destroyOldScene) {
-        const scenes = this._scenes.getArray();
+        // Use loop array because `destroy` removes the scene from `_scenes` during iteration,
+        // and skip `scene` itself because concurrent loads of the same url resolve to the same instance
+        const scenes = this._scenes.getLoopArray();
         for (let i = 0, n = scenes.length; i < n; i++) {
-          scenes[i].destroy();
+          const oldScene = scenes[i];
+          oldScene !== scene && oldScene.destroy();
         }
       }
       this.addScene(scene);

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -167,7 +167,7 @@ export function applySceneData(
   return Promise.all(promises).then(() => {});
 }
 
-@resourceLoader(AssetType.Scene, ["scene"], true)
+@resourceLoader(AssetType.Scene, ["scene"], false)
 class SceneLoader extends Loader<Scene> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Scene> {
     const { engine } = resourceManager;

--- a/tests/src/core/resource/SceneLoaderCache.test.ts
+++ b/tests/src/core/resource/SceneLoaderCache.test.ts
@@ -1,0 +1,30 @@
+import { AssetType, ResourceManager } from "@galacean/engine-core";
+import "@galacean/engine-loader";
+import { WebGLEngine } from "@galacean/engine";
+import { describe, beforeAll, expect, it } from "vitest";
+
+describe("SceneLoader cache policy", () => {
+  let engine: WebGLEngine;
+
+  beforeAll(async () => {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+  });
+
+  it("SceneLoader should have useCache disabled", () => {
+    const sceneLoader = ResourceManager._loaders[AssetType.Scene];
+    expect(sceneLoader).to.not.be.undefined;
+    expect(sceneLoader.useCache).to.eq(false);
+  });
+
+  it("PrimitiveMeshLoader should also have useCache disabled (existing convention)", () => {
+    const loader = ResourceManager._loaders[AssetType.PrimitiveMesh];
+    expect(loader).to.not.be.undefined;
+    expect(loader.useCache).to.eq(false);
+  });
+
+  it("Texture2D loader should still have useCache enabled (immutable asset)", () => {
+    const loader = ResourceManager._loaders[AssetType.Texture2D] || ResourceManager._loaders[AssetType.Texture];
+    expect(loader).to.not.be.undefined;
+    expect(loader.useCache).to.eq(true);
+  });
+});

--- a/tests/src/core/resource/SceneLoaderCache.test.ts
+++ b/tests/src/core/resource/SceneLoaderCache.test.ts
@@ -1,13 +1,21 @@
-import { AssetType, ResourceManager } from "@galacean/engine-core";
+import { AssetPromise, AssetType, ResourceManager, Scene } from "@galacean/engine-core";
 import "@galacean/engine-loader";
 import { WebGLEngine } from "@galacean/engine";
-import { describe, beforeAll, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 describe("SceneLoader cache policy", () => {
   let engine: WebGLEngine;
 
   beforeAll(async () => {
     engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    engine.destroy();
   });
 
   it("SceneLoader should have useCache disabled", () => {
@@ -22,9 +30,69 @@ describe("SceneLoader cache policy", () => {
     expect(loader.useCache).to.eq(false);
   });
 
-  it("Texture2D loader should still have useCache enabled (immutable asset)", () => {
-    const loader = ResourceManager._loaders[AssetType.Texture2D] || ResourceManager._loaders[AssetType.Texture];
+  it("Texture loader should still have useCache enabled (immutable asset)", () => {
+    const loader = ResourceManager._loaders[AssetType.Texture];
     expect(loader).to.not.be.undefined;
     expect(loader.useCache).to.eq(true);
+  });
+
+  describe("loadScene behavior", () => {
+    function mockSceneLoad() {
+      const loader = ResourceManager._loaders[AssetType.Scene];
+      return vi.spyOn(loader, "load").mockImplementation(
+        () =>
+          new AssetPromise<Scene>((resolve) => {
+            resolve(new Scene(engine, "mock"));
+          })
+      );
+    }
+
+    it("should activate a fresh Scene instance and destroy the old one on sequential loads of the same url", async () => {
+      mockSceneLoad();
+      const sceneManager = engine.sceneManager;
+
+      const first = await sceneManager.loadScene("/mock-sequential.scene");
+      const second = await sceneManager.loadScene("/mock-sequential.scene");
+
+      expect(second).not.toBe(first);
+      expect(first.destroyed).toBe(true);
+      expect(second.destroyed).toBe(false);
+      expect(sceneManager.scenes[0]).toBe(second);
+    });
+
+    it("should destroy every old scene when multiple scenes are active", async () => {
+      mockSceneLoad();
+      const sceneManager = engine.sceneManager;
+      sceneManager.addScene(new Scene(engine, "extra1"));
+      sceneManager.addScene(new Scene(engine, "extra2"));
+      const oldScenes = [...sceneManager.scenes];
+      expect(oldScenes.length).toBeGreaterThanOrEqual(2);
+
+      const scene = await sceneManager.loadScene("/mock-multi.scene");
+
+      for (const oldScene of oldScenes) {
+        expect(oldScene.destroyed).toBe(true);
+      }
+      expect(scene.destroyed).toBe(false);
+      expect(sceneManager.scenes.length).toBe(1);
+      expect(sceneManager.scenes[0]).toBe(scene);
+    });
+
+    it("should not destroy the activated scene when concurrent loads of the same url share one loading promise", async () => {
+      const loadSpy = mockSceneLoad();
+      const sceneManager = engine.sceneManager;
+
+      const [first, second] = await Promise.all([
+        sceneManager.loadScene("/mock-concurrent.scene"),
+        sceneManager.loadScene("/mock-concurrent.scene")
+      ]);
+
+      // The in-flight loading promise is shared regardless of useCache
+      expect(loadSpy).toHaveBeenCalledTimes(1);
+      expect(second).toBe(first);
+      expect(first.destroyed).toBe(false);
+      expect(sceneManager.scenes.length).toBe(1);
+      expect(sceneManager.scenes[0]).toBe(first);
+    });
   });
 });


### PR DESCRIPTION
Disable resource cache for SceneLoader so loadScene always produces a fresh Scene instance.

**Bug**: loadScene(url) with destroyOldScene=true, cached Scene is active scene -> resourceManager.load returns same instance -> then-handler destroys it -> rootEntities empty, PhysicsScene released, screen blank.

**Fix**: useCache true to false for SceneLoader. Consistent with PrimitiveMeshLoader and ProjectLoader.

Aligned with Unity/Unreal which all create fresh Scene instances.

**Origin**: Replaces evict workaround from commit 599a7e611 on fix/shaderlab (by @luzhuang) with root-cause fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted scene asset loader configuration
* **Tests**
  * Added validation tests for scene asset loader behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/2993)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->