### PR TITLE
feat(loader): support $class refs and numeric SpecularMode in v2 scene

### DIFF
--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -14,7 +14,7 @@ export class ReflectionParser {
 
   /**
    * Apply v2 props to a component/object instance.
-   * Each prop value is resolved recursively (handling $ref, $type, $entity, $component, $signal).
+   * Each prop value is resolved recursively (handling $ref, $type, $class, $entity, $component, $signal).
    */
   parseProps(instance: any, props?: Record<string, unknown>): Promise<any> {
     const promises: Promise<any>[] = [];
@@ -78,10 +78,11 @@ export class ReflectionParser {
    * 2. Array → recurse each element
    * 3. { $ref }       → asset reference
    * 4. { $type }      → polymorphic type construct
-   * 5. { $entity }    → entity reference by path (flat index + optional children descent)
-   * 6. { $component } → component reference
-   * 7. { $signal }    → signal binding
-   * 8. plain object   → recurse values (modify originValue in place if exists)
+   * 5. { $class }     → registered class constructor
+   * 6. { $entity }    → entity reference by path (flat index + optional children descent)
+   * 7. { $component } → component reference
+   * 8. { $signal }    → signal binding
+   * 9. plain object   → recurse values (modify originValue in place if exists)
    */
   private _resolveValue(value: unknown, originValue?: any): Promise<any> {
     if (value == null || typeof value !== "object") return Promise.resolve(value);
@@ -111,14 +112,26 @@ export class ReflectionParser {
     // $type — polymorphic type: construct instance and apply remaining props
     if ("$type" in obj) {
       const { $type, ...rest } = obj;
-      const typeName = $type as string;
-      const Class = Loader.getClass(typeName);
-      if (!Class) return Promise.reject(new Error(`Loader.getClass: class "${typeName}" is not registered`));
+      let Class: any;
+      try {
+        Class = this._getRegisteredClass($type, "$type");
+      } catch (error) {
+        return Promise.reject(error);
+      }
       const instance = new Class();
       if (Object.keys(rest).length > 0) {
         return this.parseProps(instance, rest);
       }
       return Promise.resolve(instance);
+    }
+
+    // $class — registered class constructor for factory-style methods.
+    if ("$class" in obj) {
+      try {
+        return Promise.resolve(this._getRegisteredClass(obj.$class, "$class"));
+      } catch (error) {
+        return Promise.reject(error);
+      }
     }
 
     // $entity — entity reference by path (first element = flat index, subsequent = children indices)
@@ -146,6 +159,16 @@ export class ReflectionParser {
       promises.push(this._resolveValue(obj[key], target[key]).then((v) => (target[key] = v)));
     }
     return Promise.all(promises).then(() => target);
+  }
+
+  private _getRegisteredClass(value: unknown, sentinel: "$type" | "$class"): any {
+    if (typeof value !== "string" || value.length === 0) {
+      throw new Error(`${sentinel} must be a non-empty registered class name string`);
+    }
+
+    const Class = Loader.getClass(value);
+    if (!Class) throw new Error(`Loader.getClass: class "${value}" is not registered`);
+    return Class;
   }
 
   private _resolveSignal(signal: any, listeners: SignalListener[]): Promise<any> {

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -112,26 +112,15 @@ export class ReflectionParser {
     // $type — polymorphic type: construct instance and apply remaining props
     if ("$type" in obj) {
       const { $type, ...rest } = obj;
-      let Class: any;
-      try {
-        Class = this._getRegisteredClass($type, "$type");
-      } catch (error) {
-        return Promise.reject(error);
-      }
-      const instance = new Class();
-      if (Object.keys(rest).length > 0) {
-        return this.parseProps(instance, rest);
-      }
-      return Promise.resolve(instance);
+      return this._resolveRegisteredClass($type, "$type").then((Class) => {
+        const instance = new Class();
+        return Object.keys(rest).length > 0 ? this.parseProps(instance, rest) : instance;
+      });
     }
 
     // $class — registered class constructor for factory-style methods.
     if ("$class" in obj) {
-      try {
-        return Promise.resolve(this._getRegisteredClass(obj.$class, "$class"));
-      } catch (error) {
-        return Promise.reject(error);
-      }
+      return this._resolveRegisteredClass(obj.$class, "$class");
     }
 
     // $entity — entity reference by path (first element = flat index, subsequent = children indices)
@@ -169,6 +158,15 @@ export class ReflectionParser {
     const Class = Loader.getClass(value);
     if (!Class) throw new Error(`Loader.getClass: class "${value}" is not registered`);
     return Class;
+  }
+
+  /** Promise-adapt {@link _getRegisteredClass} so $type/$class branches can fold into the resolver chain. */
+  private _resolveRegisteredClass(value: unknown, sentinel: "$type" | "$class"): Promise<any> {
+    try {
+      return Promise.resolve(this._getRegisteredClass(value, sentinel));
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   private _resolveSignal(signal: any, listeners: SignalListener[]): Promise<any> {

--- a/packages/loader/src/schema/CommonSchema.ts
+++ b/packages/loader/src/schema/CommonSchema.ts
@@ -15,6 +15,11 @@ export interface ComponentRef {
   index: number;
 }
 
+/** Reference to a registered runtime class constructor. */
+export interface ClassRef {
+  $class: string;
+}
+
 export interface SignalListener {
   target: { $component: ComponentRef };
   methodName: string;

--- a/packages/loader/src/schema/SceneSchema.ts
+++ b/packages/loader/src/schema/SceneSchema.ts
@@ -10,8 +10,8 @@ import type { HierarchyFile } from "./HierarchySchema";
 import type { Vec3Tuple, Vec4Tuple } from "./CommonSchema";
 
 export enum SpecularMode {
-  Sky = "Sky",
-  Custom = "Custom"
+  Sky = 0,
+  Custom = 1
 }
 
 export interface SceneFile extends HierarchyFile {

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -810,6 +810,67 @@ describe("ReflectionParser $type resolution", () => {
       })
     ).rejects.toThrow("NonExistentClass123");
   });
+
+  it("should throw a clear error when $type is not a non-empty string", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context, []);
+    const target: any = {};
+    await expect(
+      parser.parseProps(target, {
+        value: { $type: 123 } as any
+      })
+    ).rejects.toThrow("$type must be a non-empty registered class name string");
+  });
+});
+
+describe("ReflectionParser $class resolution", () => {
+  it("should resolve $class as the registered constructor through parseProps", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context, []);
+    const target: any = {};
+    await parser.parseProps(target, {
+      value: { $class: "TestValueType" }
+    });
+    expect(target.value).to.equal(TestValueType);
+  });
+
+  it("should throw a clear error when $class is an empty string", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context, []);
+    const target: any = {};
+    await expect(
+      parser.parseProps(target, {
+        value: { $class: "" }
+      })
+    ).rejects.toThrow("$class must be a non-empty registered class name string");
+  });
+
+  it("should throw a clear error when $class is not a string", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context, []);
+    const target: any = {};
+    await expect(
+      parser.parseProps(target, {
+        value: { $class: 123 } as any
+      })
+    ).rejects.toThrow("$class must be a non-empty registered class name string");
+  });
+
+  it("should throw a clear error when $class references an unregistered class", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context, []);
+    const target: any = {};
+    await expect(
+      parser.parseProps(target, {
+        value: { $class: "NonExistentClass123" }
+      })
+    ).rejects.toThrow("NonExistentClass123");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -72,6 +72,13 @@ Loader.registerClass("CallOrderComponent", CallOrderComponent);
 
 let engine: WebGLEngine;
 
+describe("SceneFile v2 schema enums", () => {
+  it("uses numeric enum values for ambient specularMode", () => {
+    expect(SpecularMode.Sky).to.equal(0);
+    expect(SpecularMode.Custom).to.equal(1);
+  });
+});
+
 beforeAll(async function () {
   const canvasDOM = document.createElement("canvas");
   canvasDOM.width = 100;

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -3,10 +3,12 @@ import {
   BackgroundTextureFillMode,
   BackgroundMode,
   Camera,
+  BloomEffect,
   DiffuseMode,
   Entity,
   FogMode,
   Loader,
+  PostProcess,
   Scene,
   Script,
   ShadowCascadesMode,
@@ -26,6 +28,8 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 Loader.registerClass("Transform", Transform);
 Loader.registerClass("Camera", Camera);
+Loader.registerClass("PostProcess", PostProcess);
+Loader.registerClass("BloomEffect", BloomEffect);
 
 class TestValueType {
   x = 0;
@@ -233,6 +237,34 @@ describe("ReflectionParser v2 props resolution", () => {
 // ---------------------------------------------------------------------------
 
 describe("ReflectionParser calls resolution", () => {
+  it("should resolve $class call args as constructors for factory-style methods", async () => {
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new ReflectionParser(context, []);
+    const entity = new Entity(engine, "post-process");
+    const postProcess = entity.addComponent(PostProcess);
+
+    await parser.parseCalls(postProcess, [
+      {
+        method: "addEffect",
+        args: [{ $class: "BloomEffect" }],
+        result: {
+          props: {
+            threshold: { value: 0.9 },
+            scatter: { value: 0.6 },
+            intensity: { value: 1.5 }
+          }
+        }
+      }
+    ]);
+
+    const effect = postProcess.getEffect(BloomEffect);
+    expect(effect).to.be.instanceOf(BloomEffect);
+    expect(effect.threshold.value).to.equal(0.9);
+    expect(effect.scatter.value).to.equal(0.6);
+    expect(effect.intensity.value).to.equal(1.5);
+  });
+
   it("should resolve special call args through v2 value rules", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
@@ -529,6 +561,44 @@ describe("SceneParser v2 entity tree", () => {
     expect(component).to.not.be.null;
     expect(component.value).to.equal("base");
     expect(component.receivedArgs).to.deep.equal(["after"]);
+  });
+
+  it("should apply component calls with $class args through scene parsing", async () => {
+    const data = createSceneData(
+      [{ name: "PostProcessEntity", components: [0] }],
+      [
+        {
+          type: "PostProcess",
+          props: { isGlobal: true, priority: 2 },
+          calls: [
+            {
+              method: "addEffect",
+              args: [{ $class: "BloomEffect" }],
+              result: {
+                props: {
+                  threshold: { value: 0.85 },
+                  intensity: { value: 1.25 }
+                }
+              }
+            }
+          ]
+        } as any
+      ],
+      [0]
+    );
+
+    const scene = new Scene(engine);
+    const context = new ParserContext(engine, ParserType.Scene, scene);
+    const parser = new SceneParser(data, context, scene);
+    parser.start();
+    await parser.promise;
+
+    const postProcess = scene.rootEntities[0].getComponent(PostProcess);
+    const effect = postProcess.getEffect(BloomEffect);
+    expect(postProcess.priority).to.equal(2);
+    expect(effect).to.be.instanceOf(BloomEffect);
+    expect(effect.threshold.value).to.equal(0.85);
+    expect(effect.intensity.value).to.equal(1.25);
   });
 
   it("should throw a clear error when component type is not registered", async () => {


### PR DESCRIPTION
## Summary

针对 v2 scene 格式的两处 loader 扩展，集中在 `packages/loader`。

### `$class` value sentinel（ReflectionParser）

- `ReflectionParser._resolveValue` 新增 `{ $class: "ClassName" }` 解析分支，通过 `Loader.getClass` 拿到已注册的构造函数本身（不实例化），用于 factory 风格的方法调用，例如：
  ```json
  { "method": "addEffect", "args": [{ "$class": "BloomEffect" }] }
  ```
- 把原本只服务 `$type` 的类查找逻辑抽成 `_getRegisteredClass(value, sentinel)`，统一加上「必须是非空字符串」和「类必须已注册」两层校验，`$type` 与 `$class` 共用同一份错误信息和兜底
- `CommonSchema.ts` 新增 `ClassRef` 接口与 `ComponentRef` 等其他 ref 形态对齐

### 数值化 `SpecularMode`（SceneSchema）

- `SpecularMode` 枚举从字符串 `"Sky"/"Custom"` 改为数字 `0/1`，与 v2 scene 中其他枚举（`FogMode`、`ShadowCascadesMode` 等）的数值化约定保持一致，序列化时体积更小、解析时无字符串比较

## Test plan

- [x] `tests/src/loader/SceneFormatV2.test.ts`：新增 `$class` 解析用例
  - parser 直接调用：`addEffect({ $class: "BloomEffect" })` 走 `parseCalls`，断言生成的 effect 是 `BloomEffect` 实例且 `result.props` 正确写回
  - 完整 scene 解析路径：通过 `SceneParser` 跑端到端，确认 component calls 中的 `$class` 参数能落到实际组件上
- [x] `tests/src/loader/SceneFormatV2.test.ts`：新增 `SpecularMode` 数值断言（`Sky === 0`、`Custom === 1`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene configs can reference registered class constructors via a `$class` property for direct component/effect instantiation.
  * Polymorphic value resolution improved with stricter validation and clearer, consistent error handling.

* **Schema Updates**
  * Added a class-reference schema type.
  * Specular mode values changed to numeric representation.

* **Tests**
  * Expanded tests for `$class` resolution, error cases, and scene parsing with effect instances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/2994)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->