### PR TITLE
refactor(loader): rename v2 scene.entities to scene.rootEntities

### DIFF
--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -54,7 +54,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       .catch(this._reject);
   }
 
-  /** Root entity indices for this hierarchy (scene.entities or [prefab.root]). */
+  /** Root entity indices for this hierarchy (scene.roots or [prefab.root]). */
   protected abstract _getRootIndices(): number[];
   protected abstract _handleRootEntity(index: number): void;
   protected abstract _clearAndResolve(): Scene | PrefabResource;

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -54,7 +54,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       .catch(this._reject);
   }
 
-  /** Root entity indices for this hierarchy (scene.roots or [prefab.root]). */
+  /** Root entity indices for this hierarchy (scene.rootEntities or [prefab.root]). */
   protected abstract _getRootIndices(): number[];
   protected abstract _handleRootEntity(index: number): void;
   protected abstract _clearAndResolve(): Scene | PrefabResource;

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -27,7 +27,7 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
   }
 
   protected override _getRootIndices(): number[] {
-    return (this.data as SceneFile).scene.entities;
+    return (this.data as SceneFile).scene.roots;
   }
 
   protected override _handleRootEntity(index: number): void {

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -27,7 +27,7 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
   }
 
   protected override _getRootIndices(): number[] {
-    return (this.data as SceneFile).scene.roots;
+    return (this.data as SceneFile).scene.rootEntities;
   }
 
   protected override _handleRootEntity(index: number): void {

--- a/packages/loader/src/schema/SceneSchema.ts
+++ b/packages/loader/src/schema/SceneSchema.ts
@@ -17,7 +17,7 @@ export enum SpecularMode {
 export interface SceneFile extends HierarchyFile {
   scene: {
     name?: string;
-    roots: number[];
+    rootEntities: number[];
     background: {
       mode: BackgroundMode;
       color: Vec4Tuple;

--- a/packages/loader/src/schema/SceneSchema.ts
+++ b/packages/loader/src/schema/SceneSchema.ts
@@ -17,7 +17,7 @@ export enum SpecularMode {
 export interface SceneFile extends HierarchyFile {
   scene: {
     name?: string;
-    entities: number[];
+    roots: number[];
     background: {
       mode: BackgroundMode;
       color: Vec4Tuple;

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -372,7 +372,7 @@ describe("SceneParser v2 entity tree", () => {
       entities,
       components,
       scene: {
-        roots: rootEntities,
+        rootEntities,
         background: {
           mode: 0,
           color: [0.25, 0.25, 0.25, 1]
@@ -392,7 +392,7 @@ describe("SceneParser v2 entity tree", () => {
       entities: [{ name: "Entity" }],
       components: [],
       scene: {
-        roots: [0],
+        rootEntities: [0],
         background: {
           mode: BackgroundMode.SolidColor,
           color: [0.25, 0.25, 0.25, 1]
@@ -630,7 +630,7 @@ describe("SceneParser v2 entity tree", () => {
       entities: [{ name: "Root", components: [0] }],
       components: [{ type: "CallOrderComponent" }],
       scene: {
-        roots: [0],
+        rootEntities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         ambient: {
           diffuseMode: DiffuseMode.SolidColor,
@@ -907,7 +907,7 @@ describe("applySceneData scene property parsing", () => {
       await applySceneData(
         scene,
         {
-          roots: [0],
+          rootEntities: [0],
           background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
           ambient: {
             diffuseMode: DiffuseMode.SphericalHarmonics,
@@ -952,7 +952,7 @@ describe("applySceneData scene property parsing", () => {
       await applySceneData(
         scene,
         {
-          roots: [0],
+          rootEntities: [0],
           background: {
             mode: BackgroundMode.Sky,
             color: [0, 0, 0, 1],
@@ -988,7 +988,7 @@ describe("applySceneData scene property parsing", () => {
       await applySceneData(
         scene,
         {
-          roots: [0],
+          rootEntities: [0],
           background: {
             mode: BackgroundMode.Texture,
             color: [0, 0, 0, 1],
@@ -1014,7 +1014,7 @@ describe("applySceneData scene property parsing", () => {
       applySceneData(
         scene,
         {
-          roots: [0],
+          rootEntities: [0],
           background: {
             mode: BackgroundMode.Texture,
             color: [0, 0, 0, 1],
@@ -1032,7 +1032,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        roots: [0],
+        rootEntities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         shadow: {
           castShadows: false,
@@ -1066,7 +1066,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        roots: [0],
+        rootEntities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         fog: {
           fogMode: FogMode.ExponentialSquared,
@@ -1095,7 +1095,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        roots: [0],
+        rootEntities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         ambientOcclusion: {
           enabledAmbientOcclusion: true,
@@ -1128,7 +1128,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        roots: [0],
+        rootEntities: [0],
         background: {
           mode: BackgroundMode.SolidColor,
           color: [0.5, 0.6, 0.7, 1]
@@ -1150,7 +1150,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        roots: [0],
+        rootEntities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] }
       },
       engine.resourceManager,

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -372,7 +372,7 @@ describe("SceneParser v2 entity tree", () => {
       entities,
       components,
       scene: {
-        entities: rootEntities,
+        roots: rootEntities,
         background: {
           mode: 0,
           color: [0.25, 0.25, 0.25, 1]
@@ -392,7 +392,7 @@ describe("SceneParser v2 entity tree", () => {
       entities: [{ name: "Entity" }],
       components: [],
       scene: {
-        entities: [0],
+        roots: [0],
         background: {
           mode: BackgroundMode.SolidColor,
           color: [0.25, 0.25, 0.25, 1]
@@ -630,7 +630,7 @@ describe("SceneParser v2 entity tree", () => {
       entities: [{ name: "Root", components: [0] }],
       components: [{ type: "CallOrderComponent" }],
       scene: {
-        entities: [0],
+        roots: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         ambient: {
           diffuseMode: DiffuseMode.SolidColor,
@@ -907,7 +907,7 @@ describe("applySceneData scene property parsing", () => {
       await applySceneData(
         scene,
         {
-          entities: [0],
+          roots: [0],
           background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
           ambient: {
             diffuseMode: DiffuseMode.SphericalHarmonics,
@@ -952,7 +952,7 @@ describe("applySceneData scene property parsing", () => {
       await applySceneData(
         scene,
         {
-          entities: [0],
+          roots: [0],
           background: {
             mode: BackgroundMode.Sky,
             color: [0, 0, 0, 1],
@@ -988,7 +988,7 @@ describe("applySceneData scene property parsing", () => {
       await applySceneData(
         scene,
         {
-          entities: [0],
+          roots: [0],
           background: {
             mode: BackgroundMode.Texture,
             color: [0, 0, 0, 1],
@@ -1014,7 +1014,7 @@ describe("applySceneData scene property parsing", () => {
       applySceneData(
         scene,
         {
-          entities: [0],
+          roots: [0],
           background: {
             mode: BackgroundMode.Texture,
             color: [0, 0, 0, 1],
@@ -1032,7 +1032,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        entities: [0],
+        roots: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         shadow: {
           castShadows: false,
@@ -1066,7 +1066,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        entities: [0],
+        roots: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         fog: {
           fogMode: FogMode.ExponentialSquared,
@@ -1095,7 +1095,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        entities: [0],
+        roots: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
         ambientOcclusion: {
           enabledAmbientOcclusion: true,
@@ -1128,7 +1128,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        entities: [0],
+        roots: [0],
         background: {
           mode: BackgroundMode.SolidColor,
           color: [0.5, 0.6, 0.7, 1]
@@ -1150,7 +1150,7 @@ describe("applySceneData scene property parsing", () => {
     await applySceneData(
       scene,
       {
-        entities: [0],
+        roots: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] }
       },
       engine.resourceManager,


### PR DESCRIPTION
## Summary

- Rename `scene.entities: number[]` to `scene.rootEntities: number[]` in the v2 `SceneFile` schema.
- The old name collided with the top-level `entities: EntitySchema[]` (flat node table) and read like "all entities in the scene", while it actually only stores root indices. `rootEntities` matches the engine API surface (`Scene._rootEntities`, `Scene.addRootEntity`) and makes the intent unambiguous.
- The v2 schema is still on `2.0.0-alpha`, so this is a low-cost rename now; deferring it past the stable release would make it a breaking change.
- Synced call sites: `SceneParser._getRootIndices`, `HierarchyParser` JSDoc, and v2 fixtures in `SceneFormatV2.test.ts`.

## Test plan

- [x] All v2 schema / `SceneParser` / `applySceneData` tests in `SceneFormatV2.test.ts` pass (47 cases).
- [x] Verified no remaining `scene.entities` / `scene.roots` reads/writes in the repo.
- [ ] Editor-side v2 serializer lives in another repo and needs a coordinated follow-up rename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scene parsing now correctly identifies root entities from the explicit roots field, ensuring proper hierarchy/root setup.

* **Refactor**
  * Scene file schema updated to replace the generic entities field with an explicit rootEntities field for clearer scene structure.

* **Tests**
  * Test fixtures updated to use the new rootEntities field across scene parsing and property-parsing tests.

* **Documentation**
  * Clarified comment describing source of root-entity indices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/2997)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->