### PR TITLE
fix(shader-compiler): move bundler output out of dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "b:umd": "npm run precompile && cross-env BUILD_TYPE=UMD NODE_ENV=release rollup -c",
     "b:bundled": "npm run precompile && cross-env BUILD_TYPE=BUNDLED NODE_ENV=release rollup -c",
     "b:all": "npm run precompile && cross-env BUILD_TYPE=ALL NODE_ENV=release rollup -c && cross-env NODE_ENV=release npm run b:types",
-    "clean": "pnpm -r exec rm -rf dist && pnpm -r exec rm -rf types",
+    "clean": "pnpm -r exec rm -rf dist && pnpm -r exec rm -rf bundler && pnpm -r exec rm -rf types",
     "e2e:case": "pnpm -C ./e2e run case",
     "pree2e": "playwright install --with-deps chromium",
     "e2e": "playwright test",

--- a/packages/shader-compiler/.gitignore
+++ b/packages/shader-compiler/.gitignore
@@ -1,0 +1,1 @@
+/bundler/

--- a/packages/shader-compiler/package.json
+++ b/packages/shader-compiler/package.json
@@ -21,9 +21,14 @@
       "types": "./types/index.d.ts"
     },
     "./bundler/rollup": {
-      "import": "./dist/bundler/rollup.js",
-      "require": "./dist/bundler/rollup.cjs.js",
+      "import": "./bundler/rollup.js",
+      "require": "./bundler/rollup.cjs.js",
       "types": "./types/bundler/rollup.d.ts"
+    },
+    "./bundler/precompile": {
+      "import": "./bundler/precompile.js",
+      "require": "./bundler/precompile.cjs.js",
+      "types": "./types/bundler/precompile.d.ts"
     },
     "./verbose": {
       "import": "./dist/module.verbose.js",
@@ -34,10 +39,10 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "shader-compiler-precompile": "./dist/bundler/cli.js"
+    "shader-compiler-precompile": "./bundler/cli.js"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js && chmod +x dist/bundler/cli.js",
+    "build": "rollup -c rollup.config.js && chmod +x bundler/cli.js",
     "b:types": "tsc"
   },
   "umd": {
@@ -49,6 +54,7 @@
   },
   "files": [
     "dist/**/*",
+    "bundler/**/*",
     "types/**/*",
     "verbose/package.json"
   ],

--- a/packages/shader-compiler/rollup.config.js
+++ b/packages/shader-compiler/rollup.config.js
@@ -17,10 +17,12 @@ import swc from "rollup-plugin-swc3";
 import jscc from "rollup-plugin-jscc";
 
 const bundlerExternal = [
-  // Pulled in dynamically by precompile.ts (`await import("../main.js")`); kept
-  // out of the bundler output so the runtime compiler is loaded at runtime
-  // from the parent dist/ directory rather than re-bundled here.
-  "../main.js",
+  // Pulled in dynamically by precompile.ts (`await import("../dist/main.js")`);
+  // kept out of the bundler output so the runtime compiler is loaded at
+  // runtime from the sibling `dist/` directory rather than re-bundled here.
+  // Bundler files live at the package root (`<pkg>/bundler/`) so the CDN sync
+  // (which recursively walks `dist/`) doesn't try to upload Node-only code.
+  "../dist/main.js",
   "@galacean/engine-shader-compiler",
   "@galacean/engine-shader/sources",
   "@galacean/engine-math",
@@ -77,15 +79,27 @@ export default [
   {
     input: "src/bundler/rollup.ts",
     output: [
-      { file: "dist/bundler/rollup.cjs.js", format: "cjs" },
-      { file: "dist/bundler/rollup.js", format: "es" }
+      { file: "bundler/rollup.cjs.js", format: "cjs" },
+      { file: "bundler/rollup.js", format: "es" }
+    ],
+    external: bundlerExternal,
+    plugins: [swcPluginBundler]
+  },
+  // Standalone `precompile(options)` API for consumers that need to drive
+  // shader precompilation programmatically (e.g. editor dev server) without
+  // spawning the CLI. Same code path as `cli.ts`; just skips arg parsing.
+  {
+    input: "src/bundler/precompile.ts",
+    output: [
+      { file: "bundler/precompile.cjs.js", format: "cjs" },
+      { file: "bundler/precompile.js", format: "es" }
     ],
     external: bundlerExternal,
     plugins: [swcPluginBundler]
   },
   {
     input: "src/bundler/cli.ts",
-    output: { file: "dist/bundler/cli.js", format: "es", banner: "#!/usr/bin/env node" },
+    output: { file: "bundler/cli.js", format: "es", banner: "#!/usr/bin/env node" },
     external: bundlerExternal,
     plugins: [swcPluginBundler]
   }

--- a/packages/shader-compiler/src/bundler/precompile.ts
+++ b/packages/shader-compiler/src/bundler/precompile.ts
@@ -168,8 +168,10 @@ export async function startWatcher(options: Omit<PrecompileOptions, "watch" | "o
 }
 
 async function loadShaderCompiler(): Promise<ShaderCompilerInstance> {
-  // @ts-ignore — `../main.js` is the compiled runtime entry; no .ts source.
-  const mod = (await import("../main.js")) as { ShaderCompiler: new () => ShaderCompilerInstance };
+  // @ts-ignore — `../dist/main.js` is the compiled runtime entry; no .ts source.
+  // Bundler ships at `<pkg>/bundler/` and the runtime at `<pkg>/dist/`, so this
+  // resolves to the sibling `dist/` from `bundler/cli.js` at runtime.
+  const mod = (await import("../dist/main.js")) as { ShaderCompiler: new () => ShaderCompilerInstance };
   const instance = new mod.ShaderCompiler();
   if (typeof instance._precompile !== "function") {
     throw new Error("ShaderCompiler._precompile is not available; rebuild @galacean/engine-shader-compiler first.");

--- a/packages/shader/package.json
+++ b/packages/shader/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "precompile": "node ../shader-compiler/dist/bundler/cli.js src/Shaders compiledShaders --clean --emit-index --emit-sources",
+    "precompile": "node ../shader-compiler/bundler/cli.js src/Shaders compiledShaders --clean --emit-index --emit-sources",
     "b:types": "tsc"
   },
   "umd": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added — N/A, build/release-config change verified by cold-start `pnpm install` + `npm run b:all`
- [x] Docs have been added / updated — N/A

### What kind of change does this PR introduce?

Build / release pipeline fix.

### What is the current behavior?

The OASISBE CDN sync in `galacean/publish@main` returns HTTP 405 for every release on the Node-only bundler files under `packages/shader-compiler/dist/bundler/` (`cli.js`, `rollup.js`, `rollup.cjs.js`). The CDN is for browser-bound static assets only; the publish action recursively walks `dist/`, so these Node-protocol-import files (`#!/usr/bin/env node` + `node:fs` / `node:path` / …) always fail to upload and kill the release job.

This has been failing systematically since v2.0.0-alpha.31, when `shader-lab` was renamed to `shader-compiler` and gained the `dist/bundler/` subdirectory:
- alpha.31: 2 deterministic failures (`bundler/cli.js`, `bundler/rollup.js`)
- alpha.32: 3 deterministic failures (above + `bundler/rollup.cjs.js`) + 1 transient

### What is the new behavior?

Move the bundler bundles to `<pkg>/bundler/` at package root (sibling of `dist/`):

| Before | After |
|---|---|
| `dist/bundler/cli.js` | `bundler/cli.js` |
| `dist/bundler/rollup.js` | `bundler/rollup.js` |
| `dist/bundler/rollup.cjs.js` | `bundler/rollup.cjs.js` |

`package.json` `bin` / `exports` / `files` / `build` are updated to match. The internal `await import("../main.js")` becomes `../dist/main.js` so `cli.js` can still resolve the runtime from its new sibling-of-`dist/` location.

Also adds a new `./bundler/precompile` subpath that exports the `precompile(options)` function directly, so consumers (e.g. editor dev server) can drive shader precompilation programmatically without spawning the CLI as a child process — the companion editor PR drops 21 lines of spawn / stdout-filter / path-resolution glue in favor of `import { precompile } from "@galacean/engine-shader-compiler/bundler/precompile"`.

### Does this PR introduce a breaking change?

**No.** Public API surface is preserved:

- `bin: shader-compiler-precompile` — same CLI name
- `exports["./bundler/rollup"]` — same subpath import (routes through `package.json`)
- `files` includes the new `bundler/**/*` so the npm tarball still ships all artifacts

All known consumer call sites (toolkit ×8, tools-root ×1, engine root ×1, editor ×2, internal `shader/package.json` ×1) keep working without code changes. The new `./bundler/precompile` export is purely additive.

### Other information

Cold-start verified locally: `rm -rf node_modules packages/*/{dist,bundler}` + fresh `pnpm install` + `npm run b:all` succeeds end-to-end.

Downstream consumer commits already pushed in companion PRs:
- editor: vite.config.ts refactored to use `./bundler/precompile` (`-21/+2` lines)
- toolkit: 17 `compiledShaders/*.shaderc` regenerated
- tools-root: `IBLBaker.shaderc` regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated shader compiler build outputs into a new bundler directory and updated package entries to use those artifacts.
  * Included bundler files in published package files and added bundler to .gitignore.
  * Updated precompile script and CLI invocation to reference the new bundler outputs.
  * Extended root clean script to remove the bundler output directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/3000)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->