### PR TITLE
fix(shader-compiler): make LALR shift/reduce resolution explicit + sync TargetParser.y

### DIFF
--- a/packages/shader-compiler/src/lalr/LALR1.ts
+++ b/packages/shader-compiler/src/lalr/LALR1.ts
@@ -2,6 +2,7 @@ import { ETokenType } from "../common";
 import { Keyword } from "../common/enums/Keyword";
 import { Grammar } from "../parser/Grammar";
 import { GrammarSymbol, NoneTerminal, Terminal } from "../parser/GrammarSymbol";
+import Production from "./Production";
 import State from "./State";
 import StateItem from "./StateItem";
 import { default as GrammarUtils, default as Utils } from "./Utils";
@@ -157,9 +158,14 @@ export class LALR1 {
   private _addAction(table: ActionTable, terminal: Terminal, action: ActionInfo) {
     const exist = table.get(terminal);
     if (exist && !Utils.isActionEqual(exist, action)) {
-      // Resolve dangling else ambiguity
-      if (terminal === Keyword.ELSE && exist.action === EAction.Shift && action.action === EAction.Reduce) {
-        return;
+      // Known shift-preferred conflicts (see TargetParser.y `%expect 2`).
+      // Enforce shift regardless of the order `_inferNextState` registers
+      // actions: when `exist` is already Shift and `action` is Reduce, keep
+      // `exist` (early-return); the reverse order (`exist` Reduce, `action`
+      // Shift) falls through to `table.set` below and Shift overwrites
+      // Reduce. Order-independent by construction.
+      if (LALR1._isKnownShiftPreferred(terminal, exist, action)) {
+        if (exist.action === EAction.Shift && action.action === EAction.Reduce) return;
       } else {
         // #if _VERBOSE
         console.warn(
@@ -172,6 +178,28 @@ export class LALR1 {
       }
     }
     table.set(terminal, action);
+  }
+
+  // Catalog of expected shift/reduce conflicts. Each entry must correspond to
+  // one of TargetParser.y's `%expect`-ed conflicts; any new conflict not in
+  // this list falls through to the verbose `conflict detect` warning so the
+  // grammar/runtime drift is loud rather than silent.
+  //   - ELSE: dangling-else, bind to nearest `if`
+  //   - '(' + `type_specifier_nonarray → macro_call_symbol`: macro-as-type-alias
+  //     (#2974), prefer the expression-position `macro_call_function` over the
+  //     type-position reduce
+  private static _isKnownShiftPreferred(terminal: Terminal, exist: ActionInfo, action: ActionInfo): boolean {
+    if (terminal === Keyword.ELSE) return true;
+    if (terminal !== ETokenType.LEFT_PAREN) return false;
+    const reduce = exist.action === EAction.Reduce ? exist : action.action === EAction.Reduce ? action : null;
+    if (!reduce) return false;
+    const prod = Production.pool.get(reduce.target!);
+    return (
+      !!prod &&
+      prod.goal === NoneTerminal.type_specifier_nonarray &&
+      prod.derivation.length === 1 &&
+      prod.derivation[0] === NoneTerminal.macro_call_symbol
+    );
   }
 
   // https://people.cs.pitt.edu/~jmisurda/teaching/cs1622/handouts/cs1622-first_and_follow.pdf

--- a/packages/shader-compiler/src/parser/TargetParser.y
+++ b/packages/shader-compiler/src/parser/TargetParser.y
@@ -10,6 +10,20 @@
 // *set* of productions per non-terminal and the symbol *structure* of each
 // alternative must match.
 
+// Two expected shift/reduce conflicts — bison errors if the count diverges,
+// catching new unintended ambiguity at grammar-change time:
+//   1. `ELSE` in `selection_statement` — classic dangling-else, shift binds
+//      the `else` to the nearest `if`. Standard C/GLSL resolution.
+//   2. `(` in `type_specifier_nonarray → macro_call_symbol` (since #2974) —
+//      at a `macro_call_symbol .` item with `(` lookahead, shift forms a
+//      `macro_call_function` (expression-position macro call) rather than
+//      reducing to `type_specifier_nonarray`. Matches the AST node identity
+//      design intent of #2974.
+// Both are handled deterministically by `LALR1._isKnownShiftPreferred`
+// (lalr/LALR1.ts) — runtime resolution is order-independent, not reliant on
+// bison's implicit shift-wins default.
+%expect 2
+
 %token id
 %token INT_CONSTANT
 %token FLOAT_CONSTANT

--- a/packages/shader-compiler/src/parser/TargetParser.y
+++ b/packages/shader-compiler/src/parser/TargetParser.y
@@ -1,4 +1,14 @@
-// For cfg conflict test, used by bison
+// Bison-format mirror of the runtime grammar in `lalr/CFG.ts`.
+//
+// This file is consumed *only* by `bison -r all TargetParser.y` to produce a
+// human-readable LALR(1) state report — it does NOT generate runtime parser
+// code. The runtime grammar lives in `lalr/CFG.ts` and is the source of truth.
+//
+// Keep this file in sync with `CFG.ts` so the bison conflict report reflects
+// the actual state machine the runtime LALR1 builder produces. Naming
+// differences are tolerated (e.g. `eq` here ↔ `EQ_OP` in CFG.ts), but the
+// *set* of productions per non-terminal and the symbol *structure* of each
+// alternative must match.
 
 %token id
 %token INT_CONSTANT
@@ -8,11 +18,48 @@
 
 %token void
 %token float
+%token bool
 %token int
+%token uint
+%token vec2
+%token vec3
+%token vec4
+%token bvec2
+%token bvec3
+%token bvec4
+%token ivec2
+%token ivec3
+%token ivec4
+%token uvec2
+%token uvec3
+%token uvec4
+%token mat2
+%token mat3
 %token mat4
+%token mat2x3
+%token mat2x4
+%token mat3x2
+%token mat3x4
+%token mat4x2
+%token mat4x3
+%token sampler2D
+%token sampler3D
+%token samplerCube
+%token sampler2DShadow
+%token samplerCubeShadow
+%token sampler2DArray
+%token sampler2DArrayShadow
+%token isampler2D
+%token isampler3D
+%token isamplerCube
+%token isampler2DArray
+%token usampler2D
+%token usampler3D
+%token usamplerCube
+%token usampler2DArray
 %token struct
 %token highp
-%token mediemp
+%token mediump
 %token lowp
 
 %token const
@@ -168,8 +215,45 @@ precision_specifier:
 ext_builtin_type_specifier_nonarray:
     void
     | float
-    | int 
+    | bool
+    | int
+    | uint
+    | vec2
+    | vec3
+    | vec4
+    | bvec2
+    | bvec3
+    | bvec4
+    | ivec2
+    | ivec3
+    | ivec4
+    | uvec2
+    | uvec3
+    | uvec4
+    | mat2
+    | mat3
     | mat4
+    | mat2x3
+    | mat2x4
+    | mat3x2
+    | mat3x4
+    | mat4x2
+    | mat4x3
+    | sampler2D
+    | sampler3D
+    | samplerCube
+    | sampler2DShadow
+    | samplerCubeShadow
+    | sampler2DArray
+    | sampler2DArrayShadow
+    | isampler2D
+    | isampler3D
+    | isamplerCube
+    | isampler2DArray
+    | usampler2D
+    | usampler3D
+    | usamplerCube
+    | usampler2DArray
     ;
 
 type_specifier_nonarray:
@@ -185,8 +269,8 @@ type_specifier_nonarray:
     ;
 
 struct_specifier:
-    struct id '{' struct_declaration_list '}' ;
-    | struct '{' struct_declaration_list '}' ;
+    struct id '{' struct_declaration_list '}' ';'
+    | struct '{' struct_declaration_list '}' ';'
     ;
 
 struct_declaration_list:
@@ -216,7 +300,7 @@ macro_struct_branch:
 
 layout_qualifier:
     layout '(' location '=' INT_CONSTANT ')'
-    | layout '(' location '=' id ')'
+    ;
 
 
 struct_declarator_list:
@@ -241,7 +325,7 @@ type_specifier:
 
 precision_qualifier:
     highp
-    | mediemp
+    | mediump
     | lowp
     ;
 
@@ -421,7 +505,11 @@ function_call:
 function_call_generic:
     function_identifier '(' function_call_parameter_list ')'
     | function_identifier '(' ')'
-    | function_identifier '(' void ')'
+    // Mirrors CFG.ts:681 verbatim. This alt is unreachable from any legal
+    // GLSL token stream (lexer never produces `f VOID )` without `(` between)
+    // — present since the LALR refactor (#2113, 2024-07). Tracked as latent
+    // bug; fix belongs in a separate PR with a `f(void)` regression test.
+    | function_identifier void ')'
     ;
 
 function_call_parameter_list:
@@ -555,9 +643,9 @@ simple_statement:
 declaration:
     function_prototype ';'
     | init_declarator_list ';'
+    | PRECISION precision_qualifier ext_builtin_type_specifier_nonarray ';'
     | type_qualifier id ';'
     | type_qualifier id identifier_list ';'
-    | precision_specifier
     ;
 
 identifier_list:


### PR DESCRIPTION
## Summary

Two coupled changes to the LALR pipeline, paired so the grammar-level assertion and the runtime-level resolution land together:

1. **Grammar-level: `TargetParser.y` now mirrors `lalr/CFG.ts` and asserts the conflict count via `%expect 2`.**

   `.y` is the bison-format mirror used for human-readable LALR(1) state reports; `CFG.ts` is the runtime grammar (source of truth). The two had drifted across 7 categories (37 missing builtin types, missing struct `;`, an extra `layout_qualifier` form, missing `mediump`, `precision_specifier` inline vs reference, comments). After this PR every non-terminal has identical alt count and symbol structure across both files; remaining differences are pure terminal-naming aliases (`eq ↔ EQ_OP`, `sampler2DArray ↔ SAMPLER2D_ARRAY`, etc).

   `%expect 2` turns bison into an automatic gate: any future grammar change that introduces a 3rd conflict or eliminates an existing one fails `bison -r all` immediately, before LALR table construction ever runs.

2. **Runtime-level: `LALR1._addAction` resolves both expected conflicts via an explicit whitelist, not via the `_inferNextState` registration order.**

   Before this PR, only the dangling-else conflict had an explicit handler. The `(` + `type_specifier_nonarray → macro_call_symbol` conflict (introduced by #2974) was resolved by whichever action got written last to the action table. That's currently Shift (because reduce-loop runs before shift-loop in `_inferNextState`), but the dependency is implicit — any future refactor flipping the order would silently route every `MacroCall(args)` to a type-position reduce, breaking macro-as-type shaders without warning.

   Promote the ELSE-only handler into `_isKnownShiftPreferred`, matching both expected conflicts. Resolution is order-independent by construction:
   - `exist=Shift, action=Reduce` → early-return keeps Shift
   - `exist=Reduce, action=Shift` → falls through to `table.set`, Shift overwrites

   Anything not in the whitelist still triggers the verbose `conflict detect` warning, so grammar/runtime drift stays loud.

## Why these two land in one PR

They are the two sides of the same fact: "there are exactly 2 known shift/reduce conflicts in this grammar, both resolved by shift-preference". `%expect 2` is the spec; `_isKnownShiftPreferred` is the implementation. Splitting them would let one half be merged without the other — at which point either the spec is unenforced or the implementation is undocumented at the grammar level.

## Conflict invariance

```
$ bison -r all TargetParser.y
# exits 0 silently — %expect 2 matches
```

| State | Terminal | Conflict | Resolution |
|---|---|---|---|
| 154 | `(` | shift `macro_call_function` vs reduce `type_specifier_nonarray → macro_call_symbol` | shift (expression-position macro call, per #2974 intent) |
| 480 | `ELSE` | shift `IF (…) stmt ELSE stmt` vs reduce `IF (…) stmt` | shift (dangling-else, bind to nearest `if`) |

Both terminals + production targets match the `_isKnownShiftPreferred` whitelist exactly. No other state has a competing reduce on `(` that targets `type_specifier_nonarray → macro_call_symbol`; no other state has an `ELSE` conflict. Verified via full bison state dump.

## Risk

- **CFG.ts:** unchanged. Runtime parser behavior on dev/2.0 is preserved; this PR only makes the previously-implicit resolution explicit. Any divergence would surface as a verbose `conflict detect` warning, not silent wrong behavior.
- **TargetParser.y:** consumed only by bison; never compiled into runtime code.
- **No new test:** the regression behavior (macro-as-type-alias shaders compiling correctly) is already covered by every existing shader test that uses `#define FxaaFloat float; FxaaFloat x;` patterns. Adding a unit test on `_isKnownShiftPreferred` itself would duplicate what the whitelist's explicit form already shows in review.

## Test plan

- [x] `pnpm -C packages/shader-compiler build` passes
- [x] `pnpm run b:types` passes (full monorepo)
- [x] `bison -r all TargetParser.y` exits 0 silently (matches `%expect 2`)
- [x] Modifying `%expect 2` to `%expect 1` causes bison to exit 1 with "expected 1 shift/reduce conflict" — confirms the assertion is active
- [x] Production set diff (`.y` vs `CFG.ts`): zero structural differences, only terminal-naming aliases remain
- [ ] CI: full shader test suite passes (validates runtime behavior on dev/2.0 baseline)

## Relationship to PR #3001

PR #3001 (`fix/lalr-macro-as-type-shift`) independently arrived at the same `_isKnownShiftPreferred` design, plus a second commit routing `MacroCallFunction` codegen by `calleeKind`. The two PRs are non-conflicting:

- If #3001 merges first: this PR's runtime change becomes a no-op rebase (identical `_isKnownShiftPreferred`), the `.y` sync + `%expect 2` parts remain
- If this PR merges first: #3001's first commit becomes a no-op rebase, its second commit (calleeKind routing) is unaffected

Either order works; this PR is not blocked by #3001.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parsing of function-call and declaration forms, fixed precision qualifier, enforced trailing-semicolon for structs, and narrowed layout-qualifier handling.

* **Refactor**
  * Expanded support for GLSL built-in types (bool, int/uint, scalar/vector/matrix, sampler variants) and improved parser conflict resolution to prefer expected parse cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/3003)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->