### PR TITLE
fix(shader-compiler): silence spurious form-param warnings + createGSError release-mode regression

### DIFF
--- a/packages/shader-compiler/src/parser/AST.ts
+++ b/packages/shader-compiler/src/parser/AST.ts
@@ -1434,23 +1434,37 @@ export namespace ASTNode {
       // single-arm case — no warning, no type inference. Grammar half of the
       // cross-arm fix is in 87cb2b5f0.
       if (!(child instanceof BaseToken)) {
-        const macroName = child.macroName;
-        if (
-          macroName &&
-          needFindNames.indexOf(macroName) === -1 &&
-          !BuiltinFunction.isExist(macroName) &&
-          !BuiltinVariable.getVar(macroName)
-        ) {
-          VariableIdentifier._lookupAndMarkGlobalReference(sa, macroName, symbols, referenceGlobalSymbolNames, null);
-        }
+        VariableIdentifier._probeCrossArmShadowing(sa, child, needFindNames, symbols, referenceGlobalSymbolNames);
       }
+    }
+
+    /** Run the cross-arm shadowing probe for a MACRO_CALL site. No-op when the
+     *  probe isn't meaningful: no macro name, name already resolved as a real
+     *  reference, or name is a builtin (builtins can't be shadowed by a
+     *  sibling-arm decl). */
+    private static _probeCrossArmShadowing(
+      sa: SemanticAnalyzer,
+      child: MacroCallSymbol | MacroCallFunction,
+      needFindNames: string[],
+      symbols: (VarSymbol | FnSymbol)[],
+      referenceGlobalSymbolNames: string[]
+    ): void {
+      const macroName = child.macroName;
+      if (!macroName) return;
+      if (needFindNames.indexOf(macroName) !== -1) return; // already looked up as a real reference
+      if (BuiltinFunction.isExist(macroName) || BuiltinVariable.getVar(macroName)) return; // builtins can't be shadowed
+      VariableIdentifier._lookupAndMarkGlobalReference(sa, macroName, symbols, referenceGlobalSymbolNames, null);
     }
 
     /** Look up `name` in the symbol stack and, if a global var/fn declaration
      *  exists, push it into `referenceGlobalSymbolNames`. Returns `true` iff
      *  the lookup hit (caller can then derive type info). When `missWarnLoc`
      *  is non-null, a miss reports a "declared before used" warning; pass
-     *  `null` for silent probes (e.g. FXAA-style cross-arm shadowing). */
+     *  `null` for silent probes (e.g. FXAA-style cross-arm shadowing).
+     *
+     *  Mutation contract: `symbols` is used as scratch storage — `lookupAll`
+     *  clears and refills it. On hit, the caller may read `symbols[0]` for
+     *  type info before the next call overwrites the contents. */
     private static _lookupAndMarkGlobalReference(
       sa: SemanticAnalyzer,
       name: string,

--- a/packages/shader-compiler/src/parser/AST.ts
+++ b/packages/shader-compiler/src/parser/AST.ts
@@ -1874,6 +1874,14 @@ export namespace ASTNode {
         if (entries) entries.push(info);
         else list[this.macroName] = [info];
       }
+
+      // Close the form-param scope pushed at `MACRO_DEFINE_PARAMS` shift. By
+      // the time this reduce fires, every `VariableIdentifier` inside the
+      // value expression has already resolved against the params. Object-like
+      // macros never pushed a scope, so nothing to pop.
+      if (this.isFunction) {
+        sa.popScope();
+      }
     }
 
     override codeGen(visitor: CodeGenVisitor): string {

--- a/packages/shader-compiler/src/parser/AST.ts
+++ b/packages/shader-compiler/src/parser/AST.ts
@@ -1438,6 +1438,11 @@ export namespace ASTNode {
         sa.symbolTableStack.lookupAll(lookupSymbol, true, symbols);
 
         if (!symbols.length) {
+          // Skip macro-name-as-var lookup miss — the lookup is a cross-arm
+          // shadowing probe, a missing sibling var is the common single-arm case.
+          if (name === macroNameAsVarLookup) {
+            continue;
+          }
           // #if _VERBOSE
           sa.reportWarning(this.location, `Please sure the identifier "${name}" will be declared before used.`);
           // #endif

--- a/packages/shader-compiler/src/parser/AST.ts
+++ b/packages/shader-compiler/src/parser/AST.ts
@@ -1392,7 +1392,6 @@ export namespace ASTNode {
       const child = this.children[0] as BaseToken | MacroCallSymbol | MacroCallFunction;
       const referenceGlobalSymbolNames = this.referenceGlobalSymbolNames;
       const symbols = this._symbols;
-      const lookupSymbol = SemanticAnalyzer._lookupSymbol;
 
       // Real references — every name must resolve; miss is an authoring error.
       const needFindNames = child instanceof BaseToken ? [child.lexeme] : child.referenceSymbolNames;
@@ -1413,35 +1412,19 @@ export namespace ASTNode {
           continue;
         }
 
-        lookupSymbol.set(name, ESymbolType.Any);
-        sa.symbolTableStack.lookupAll(lookupSymbol, true, symbols);
-
-        if (!symbols.length) {
-          // #if _VERBOSE
-          sa.reportWarning(this.location, `Please sure the identifier "${name}" will be declared before used.`);
-          // #endif
-        } else {
-          // Expression-style macros have their own value AST; its real type isn't
-          // the type of any single `referenceSymbolNames` entry (`v` in `v.v_uv`
-          // is a `Varyings` struct but the macro call site's type should be the
-          // member type). Skip type inference for those and keep TypeAny.
-          if (child instanceof BaseToken || !child.hasAstValue) {
-            this.typeInfo = symbols[0].dataType?.type;
-          }
-          const currentScopeSymbol = <VarSymbol | FnSymbol>sa.symbolTableStack.scope.getSymbol(lookupSymbol, true);
-          if (currentScopeSymbol) {
-            if (
-              (currentScopeSymbol instanceof FnSymbol || currentScopeSymbol.isGlobalVariable) &&
-              referenceGlobalSymbolNames.indexOf(name) === -1
-            ) {
-              referenceGlobalSymbolNames.push(name);
-            }
-          } else if (
-            symbols.some((s) => s instanceof FnSymbol || s.isGlobalVariable) &&
-            referenceGlobalSymbolNames.indexOf(name) === -1
-          ) {
-            referenceGlobalSymbolNames.push(name);
-          }
+        const hit = VariableIdentifier._lookupAndMarkGlobalReference(
+          sa,
+          name,
+          symbols,
+          referenceGlobalSymbolNames,
+          this.location
+        );
+        // Expression-style macros have their own value AST; its real type isn't
+        // the type of any single `referenceSymbolNames` entry (`v` in `v.v_uv`
+        // is a `Varyings` struct but the macro call site's type should be the
+        // member type). Skip type inference for those and keep TypeAny.
+        if (hit && (child instanceof BaseToken || !child.hasAstValue)) {
+          this.typeInfo = symbols[0].dataType?.type;
         }
       }
 
@@ -1452,42 +1435,49 @@ export namespace ASTNode {
       // cross-arm fix is in 87cb2b5f0.
       if (!(child instanceof BaseToken)) {
         const macroName = child.macroName;
-        if (macroName && needFindNames.indexOf(macroName) === -1) {
-          VariableIdentifier._probeAndMarkSiblingArm(sa, macroName, symbols, referenceGlobalSymbolNames);
+        if (
+          macroName &&
+          needFindNames.indexOf(macroName) === -1 &&
+          !BuiltinFunction.isExist(macroName) &&
+          !BuiltinVariable.getVar(macroName)
+        ) {
+          VariableIdentifier._lookupAndMarkGlobalReference(sa, macroName, symbols, referenceGlobalSymbolNames, null);
         }
       }
     }
 
-    /** Cross-arm shadowing probe: lookup `name` and, if a sibling-arm var/fn
-     *  exists, push it into `referenceGlobalSymbolNames` so codegen retains
-     *  the declaration. Miss is silent — this is a probe, not a reference. */
-    private static _probeAndMarkSiblingArm(
+    /** Look up `name` in the symbol stack and, if a global var/fn declaration
+     *  exists, push it into `referenceGlobalSymbolNames`. Returns `true` iff
+     *  the lookup hit (caller can then derive type info). When `missWarnLoc`
+     *  is non-null, a miss reports a "declared before used" warning; pass
+     *  `null` for silent probes (e.g. FXAA-style cross-arm shadowing). */
+    private static _lookupAndMarkGlobalReference(
       sa: SemanticAnalyzer,
       name: string,
       symbols: (VarSymbol | FnSymbol)[],
-      referenceGlobalSymbolNames: string[]
-    ): void {
-      // Builtin names can't be shadowed by a sibling-arm declaration in any
-      // meaningful way — skip the lookup entirely.
-      if (BuiltinFunction.isExist(name) || BuiltinVariable.getVar(name)) return;
+      referenceGlobalSymbolNames: string[],
+      missWarnLoc: ShaderRange | null
+    ): boolean {
       const lookupSymbol = SemanticAnalyzer._lookupSymbol;
       lookupSymbol.set(name, ESymbolType.Any);
       sa.symbolTableStack.lookupAll(lookupSymbol, true, symbols);
-      if (!symbols.length) return;
-      const currentScopeSymbol = <VarSymbol | FnSymbol>sa.symbolTableStack.scope.getSymbol(lookupSymbol, true);
-      if (currentScopeSymbol) {
-        if (
-          (currentScopeSymbol instanceof FnSymbol || currentScopeSymbol.isGlobalVariable) &&
-          referenceGlobalSymbolNames.indexOf(name) === -1
-        ) {
-          referenceGlobalSymbolNames.push(name);
+
+      if (!symbols.length) {
+        // #if _VERBOSE
+        if (missWarnLoc) {
+          sa.reportWarning(missWarnLoc, `Please sure the identifier "${name}" will be declared before used.`);
         }
-      } else if (
-        symbols.some((s) => s instanceof FnSymbol || s.isGlobalVariable) &&
-        referenceGlobalSymbolNames.indexOf(name) === -1
-      ) {
+        // #endif
+        return false;
+      }
+      const currentScopeSymbol = <VarSymbol | FnSymbol>sa.symbolTableStack.scope.getSymbol(lookupSymbol, true);
+      const isGlobal = currentScopeSymbol
+        ? currentScopeSymbol instanceof FnSymbol || currentScopeSymbol.isGlobalVariable
+        : symbols.some((s) => s instanceof FnSymbol || s.isGlobalVariable);
+      if (isGlobal && referenceGlobalSymbolNames.indexOf(name) === -1) {
         referenceGlobalSymbolNames.push(name);
       }
+      return true;
     }
 
     override codeGen(visitor: CodeGenVisitor): string {

--- a/packages/shader-compiler/src/parser/AST.ts
+++ b/packages/shader-compiler/src/parser/AST.ts
@@ -1393,35 +1393,14 @@ export namespace ASTNode {
       const referenceGlobalSymbolNames = this.referenceGlobalSymbolNames;
       const symbols = this._symbols;
       const lookupSymbol = SemanticAnalyzer._lookupSymbol;
-      let needFindNames: string[];
 
-      // FXAA-style cross-arm shadowing: same name is a macro in one
-      // preprocessor arm and a variable in the mutually-exclusive arm.
-      // At a MACRO_CALL use site, also probe the macro name itself so
-      // the sibling-arm declaration is marked as referenced and codegen
-      // keeps it. Grammar half of the fix is in 87cb2b5f0.
-      let macroNameAsVarLookup: string | null = null;
-
-      if (child instanceof BaseToken) {
-        needFindNames = [child.lexeme];
-      } else {
-        const callSymbol = child as MacroCallSymbol | MacroCallFunction;
-        needFindNames = callSymbol.referenceSymbolNames;
-        const macroName = callSymbol.macroName;
-        if (macroName && needFindNames.indexOf(macroName) === -1) {
-          needFindNames = needFindNames.concat(macroName);
-          macroNameAsVarLookup = macroName;
-        }
-      }
+      // Real references — every name must resolve; miss is an authoring error.
+      const needFindNames = child instanceof BaseToken ? [child.lexeme] : child.referenceSymbolNames;
 
       for (let i = 0; i < needFindNames.length; i++) {
         const name = needFindNames[i];
 
-        // `macroDefineList` short-circuit; bypass for the macro name itself
-        // so cross-arm shadowing can resolve the sibling-arm declaration.
-        if (sa.macroDefineList[name] && name !== macroNameAsVarLookup) {
-          continue;
-        }
+        if (sa.macroDefineList[name]) continue;
 
         // only `macro_call` CFG can reference fnSymbols, others fnSymbols are referenced in `function_call_generic` CFG
         if (!(child instanceof BaseToken) && BuiltinFunction.isExist(name)) {
@@ -1438,11 +1417,6 @@ export namespace ASTNode {
         sa.symbolTableStack.lookupAll(lookupSymbol, true, symbols);
 
         if (!symbols.length) {
-          // Skip macro-name-as-var lookup miss — the lookup is a cross-arm
-          // shadowing probe, a missing sibling var is the common single-arm case.
-          if (name === macroNameAsVarLookup) {
-            continue;
-          }
           // #if _VERBOSE
           sa.reportWarning(this.location, `Please sure the identifier "${name}" will be declared before used.`);
           // #endif
@@ -1469,6 +1443,50 @@ export namespace ASTNode {
             referenceGlobalSymbolNames.push(name);
           }
         }
+      }
+
+      // FXAA-style cross-arm shadowing: at a MACRO_CALL use site, silently
+      // probe the macro name itself so any sibling-arm `var` declaration is
+      // marked as referenced and codegen keeps it. Miss is the common
+      // single-arm case — no warning, no type inference. Grammar half of the
+      // cross-arm fix is in 87cb2b5f0.
+      if (!(child instanceof BaseToken)) {
+        const macroName = child.macroName;
+        if (macroName && needFindNames.indexOf(macroName) === -1) {
+          VariableIdentifier._probeAndMarkSiblingArm(sa, macroName, symbols, referenceGlobalSymbolNames);
+        }
+      }
+    }
+
+    /** Cross-arm shadowing probe: lookup `name` and, if a sibling-arm var/fn
+     *  exists, push it into `referenceGlobalSymbolNames` so codegen retains
+     *  the declaration. Miss is silent — this is a probe, not a reference. */
+    private static _probeAndMarkSiblingArm(
+      sa: SemanticAnalyzer,
+      name: string,
+      symbols: (VarSymbol | FnSymbol)[],
+      referenceGlobalSymbolNames: string[]
+    ): void {
+      // Builtin names can't be shadowed by a sibling-arm declaration in any
+      // meaningful way — skip the lookup entirely.
+      if (BuiltinFunction.isExist(name) || BuiltinVariable.getVar(name)) return;
+      const lookupSymbol = SemanticAnalyzer._lookupSymbol;
+      lookupSymbol.set(name, ESymbolType.Any);
+      sa.symbolTableStack.lookupAll(lookupSymbol, true, symbols);
+      if (!symbols.length) return;
+      const currentScopeSymbol = <VarSymbol | FnSymbol>sa.symbolTableStack.scope.getSymbol(lookupSymbol, true);
+      if (currentScopeSymbol) {
+        if (
+          (currentScopeSymbol instanceof FnSymbol || currentScopeSymbol.isGlobalVariable) &&
+          referenceGlobalSymbolNames.indexOf(name) === -1
+        ) {
+          referenceGlobalSymbolNames.push(name);
+        }
+      } else if (
+        symbols.some((s) => s instanceof FnSymbol || s.isGlobalVariable) &&
+        referenceGlobalSymbolNames.indexOf(name) === -1
+      ) {
+        referenceGlobalSymbolNames.push(name);
       }
     }
 

--- a/packages/shader-compiler/src/parser/ShaderTargetParser.ts
+++ b/packages/shader-compiler/src/parser/ShaderTargetParser.ts
@@ -69,7 +69,6 @@ export class ShaderTargetParser {
     const { _traceBackStack: traceBackStack, sematicAnalyzer } = this;
     traceBackStack.push(0);
 
-    let macroParamScopeOpen = false;
     let nextToken = tokens.next();
     while (true) {
       const token = nextToken.value;
@@ -79,18 +78,15 @@ export class ShaderTargetParser {
         traceBackStack.push(token, actionInfo.target!);
         // Function-like `#define` form params live in a scope wrapping the
         // value AST, mirroring how `function_header` opens a scope for GLSL
-        // function parameters. Push on shift of `MACRO_DEFINE_PARAMS`, pop on
-        // `MACRO_DEFINE_END`. Object-like `#define` has neither token, so
-        // there's nothing to do.
+        // function parameters. Push on shift of `MACRO_DEFINE_PARAMS`; the
+        // matching `popScope` runs when `MacroDefine.semanticAnalyze` reduces
+        // the production (only the function-like alternative needs it, and
+        // it knows that from its own children).
         if (token.type === Keyword.MACRO_DEFINE_PARAMS) {
           sematicAnalyzer.pushScope();
-          macroParamScopeOpen = true;
           for (const p of ParserUtils.parseMacroParamList(token.lexeme)) {
             sematicAnalyzer.symbolTableStack.insert(new SymbolInfo(p, ESymbolType.VAR));
           }
-        } else if (token.type === Keyword.MACRO_DEFINE_END && macroParamScopeOpen) {
-          sematicAnalyzer.popScope();
-          macroParamScopeOpen = false;
         }
         nextToken = tokens.next();
       } else if (actionInfo?.action === EAction.Accept) {

--- a/packages/shader-compiler/src/parser/ShaderTargetParser.ts
+++ b/packages/shader-compiler/src/parser/ShaderTargetParser.ts
@@ -1,5 +1,6 @@
 import { ETokenType } from "../common";
 import { BaseToken } from "../common/BaseToken";
+import { Keyword } from "../common/enums/Keyword";
 import { GSError, GSErrorName } from "../GSError";
 import { LALR1 } from "../lalr";
 import { addTranslationRule, createGrammar } from "../lalr/CFG";
@@ -12,6 +13,7 @@ import { ASTNode, TreeNode } from "./AST";
 import { Grammar } from "./Grammar";
 import { GrammarSymbol, NoneTerminal } from "./GrammarSymbol";
 import SematicAnalyzer from "./SemanticAnalyzer";
+import { ESymbolType, SymbolInfo } from "./symbolTable";
 import { TraceStackItem } from "./types";
 
 /**
@@ -67,6 +69,7 @@ export class ShaderTargetParser {
     const { _traceBackStack: traceBackStack, sematicAnalyzer } = this;
     traceBackStack.push(0);
 
+    let macroParamScopeOpen = false;
     let nextToken = tokens.next();
     while (true) {
       const token = nextToken.value;
@@ -74,6 +77,21 @@ export class ShaderTargetParser {
       const actionInfo = this.stateActionTable.get(token.type);
       if (actionInfo?.action === EAction.Shift) {
         traceBackStack.push(token, actionInfo.target!);
+        // Function-like `#define` form params live in a scope wrapping the
+        // value AST, mirroring how `function_header` opens a scope for GLSL
+        // function parameters. Push on shift of `MACRO_DEFINE_PARAMS`, pop on
+        // `MACRO_DEFINE_END`. Object-like `#define` has neither token, so
+        // there's nothing to do.
+        if (token.type === Keyword.MACRO_DEFINE_PARAMS) {
+          sematicAnalyzer.pushScope();
+          macroParamScopeOpen = true;
+          for (const p of ParserUtils.parseMacroParamList(token.lexeme)) {
+            sematicAnalyzer.symbolTableStack.insert(new SymbolInfo(p, ESymbolType.VAR));
+          }
+        } else if (token.type === Keyword.MACRO_DEFINE_END && macroParamScopeOpen) {
+          sematicAnalyzer.popScope();
+          macroParamScopeOpen = false;
+        }
         nextToken = tokens.next();
       } else if (actionInfo?.action === EAction.Accept) {
         sematicAnalyzer.acceptRule?.(sematicAnalyzer);

--- a/tests/src/shader-compiler/ShaderCompiler.test.ts
+++ b/tests/src/shader-compiler/ShaderCompiler.test.ts
@@ -248,6 +248,22 @@ describe("ShaderCompiler", async () => {
     glslValidate(engine, shaderSource, shaderCompilerRelease);
   });
 
+  // Regression: function-like macro form params and macro-name-as-var cross-arm
+  // probes used to emit spurious "declared before used" warnings.
+  it("function-like macro form params and macro names don't warn as undeclared", async () => {
+    const src = await readFile("./shaders/macro-form-params-no-warn.shader");
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: any[]) => warns.push(args.join(" "));
+    try {
+      glslValidate(engine, src, shaderCompilerVerbose);
+    } finally {
+      console.warn = origWarn;
+    }
+    const undeclared = warns.filter((w) => /will be declared before used/.test(w));
+    expect(undeclared, `unexpected undeclared warnings:\n${undeclared.join("\n")}`).to.deep.equal([]);
+  });
+
   it("macro-negate-number (!0, !1 in #if expressions)", async () => {
     const shaderSource = await readFile("./shaders/macro-negate-number.shader");
     glslValidate(engine, shaderSource, shaderCompilerVerbose);

--- a/tests/src/shader-compiler/shaders/macro-form-params-no-warn.shader
+++ b/tests/src/shader-compiler/shaders/macro-form-params-no-warn.shader
@@ -1,0 +1,19 @@
+Shader "macro-form-params-no-warn" {
+  SubShader "Default" {
+    Pass "test" {
+      // Form params `a` / `mat` ref'd inside the value AST: must not warn.
+      #define saturate( a ) clamp( a, 0.0, 1.0 )
+      #define INVERSE_MAT(mat) inverseMat(mat)
+      // Object-like macro used as a value: cross-arm probe must not warn.
+      #define HALF_MIN 6.103515625e-5
+      mat2 inverseMat(mat2 m) { return m; }
+      void vert() { gl_Position = vec4(saturate(0.5)); }
+      void frag() {
+        float dp3 = max(float(HALF_MIN), 1.0);
+        gl_FragColor = vec4(dp3);
+      }
+      VertexShader = vert;
+      FragmentShader = frag;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

After #2996 routed function-like `#define` values through the AST path, real `VariableIdentifier` nodes inside macro values began emitting `Please sure the identifier "X" will be declared before used.` for two patterns that aren't user errors:

1. **Macro form params** — `a` in `#define saturate( a ) clamp( a, 0.0, 1.0 )`. The param is macro-local but isn't registered in any symbol table.
2. **Macro name as cross-arm var probe** — `HALF_MIN` in `float(HALF_MIN)`. `VariableIdentifier.semanticAnalyze` adds the macro name itself to `needFindNames` for FXAA-style cross-arm shadowing support; for single-arm macros (the common case) that lookup misses and the same warning fires.

Plus a release-mode regression also from #2996: `createGSError` had no `return` outside its `#if _VERBOSE` block, so `throwError` executed `throw undefined`. PR #2996's `macro-author-error: *` tests therefore failed on `codecov` (caught after merge, since codecov isn't a required check).

## Fix

**`ShaderTargetParser.ts` — scope-push for macro form params.**
On shift of `MACRO_DEFINE_PARAMS`, open a scope and insert each form param as a plain `SymbolInfo`. Close the scope on `MACRO_DEFINE_END`. Mirrors how `function_header` opens a scope for GLSL function parameters — `VariableIdentifier` is now macro-agnostic.

The shift-time hook (instead of an AST `semanticAnalyze`) is required because `MACRO_DEFINE_PARAMS` is an opaque lexer token, not an AST subtree — lexer keeps the `(…)` block atomic to avoid an LALR(1) conflict between a hypothetical `macro_define_param_list` and `function_call_parameter_list`.

**`AST.ts` — skip macro-name-as-var lookup miss.**
The cross-arm shadowing probe stays (still marks sibling-arm decls as referenced when present), but a miss is the single-arm common case, not user error — don't warn on it.

**`ShaderCompilerUtils.ts` — `createGSError` returns `Error` in release.**
Return a plain `Error` with `name = errorName` outside the `#if _VERBOSE` block. `throwError` now throws a real Error in both builds.

## Tests

`tests/.../shaders/macro-form-params-no-warn.shader` exercises:
- Function-like macro with form-param refs (`saturate(a)`, `INVERSE_MAT(mat)`)
- Object-like macro used in expression position (`HALF_MIN`)

Test asserts no `will be declared before used` warning fires for either.

The `createGSError` fix is reverse-falsifiable via PR #2996's existing `macro-author-error: *` tests (revert the change → tests fail with `expected undefined to be an instance of Error`).

192/192 tests pass on `dev/2.0` base.

## Test plan

- [x] `pnpm test` passes (192/192 on dev/2.0 baseline)
- [x] No `will be declared before used` warnings for form-param refs or single-arm object-like macros in expression position
- [x] PR #2996's `macro-author-error: *` tests pass under release build
- [x] `bison ./TargetParser.y -r all` still reports exactly 2 expected shift/reduce conflicts (unchanged by this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppresses spurious "declared before used" warnings involving function-like macro parameters and macro-name lookups by improving scope handling and lookup behavior.

* **Tests**
  * Added a regression test to ensure no incorrect "declared before used" warnings occur with function-like macro parameters.

* **Refactor**
  * Internal lookup and reference-marking logic streamlined to ensure consistent resolution and warning suppression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/3005)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->