### PR TITLE
feat(loader): audioLoader recognize .m4a extension

### DIFF
--- a/packages/core/src/asset/AssetType.ts
+++ b/packages/core/src/asset/AssetType.ts
@@ -44,7 +44,7 @@ export enum AssetType {
   Font = "Font",
   /** Source Font, include ttf, otf and woff. */
   SourceFont = "SourceFont",
-  /** AudioClip, include ogg, wav and mp3. */
+  /** AudioClip, include ogg, wav, mp3 and m4a. */
   Audio = "Audio",
   /** Project asset. */
   Project = "project",

--- a/packages/loader/src/AudioLoader.ts
+++ b/packages/loader/src/AudioLoader.ts
@@ -9,7 +9,7 @@ import {
   ResourceManager,
   resourceLoader
 } from "@galacean/engine-core";
-@resourceLoader(AssetType.Audio, ["mp3", "ogg", "wav"])
+@resourceLoader(AssetType.Audio, ["mp3", "ogg", "wav", "m4a"])
 class AudioLoader extends Loader<AudioClip> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<AudioClip> {
     return new AssetPromise((resolve, reject) => {


### PR DESCRIPTION
## Summary

`AudioLoader` 的 `@resourceLoader` 装饰器扩展名数组只含 `["mp3", "ogg", "wav"]`，未包含 `.m4a`。这导致用户用 url 加载 m4a 音频时（不显式传 type）会被 `ResourceManager` 拒绝。

```ts
// before
engine.resourceManager.load("sfx.m4a")
// throws: "asset type should be specified: sfx.m4a"

// after
engine.resourceManager.load("sfx.m4a")
// resolves AudioClip
```

## Why m4a, why not change anything else

- `.m4a` 本质是 MP4 容器装纯音频（通常 AAC 编码），MIME 为 `audio/mp4`（RFC 4337）。
- 浏览器 `AudioContext.decodeAudioData` 在 Chromium / WebKit / Gecko 上**原生支持**该容器/编码，无需 polyfill 或额外解码逻辑。
- `AudioLoader.load` 走 `arraybuffer → decodeAudioData` 路径，对容器格式完全透明，零业务改动。
- 因此这条只是把白名单补全，让 `_extTypeMapping` 反查命中 `AssetType.Audio`。

## Editor 侧对应改动

Editor (galacean/editor#3731) 已经在 dev/2.0 同步打开 m4a：
- 上传面板 accept
- audio.create / vfs.create 工具 MIME map（`.m4a → audio/mp4`）
- cli-preview 静态资源 MIME

两边并行 land 之后，整个链路（editor 上传 → 序列化引用 → 运行时按 url 加载）就全通了。

## Test plan

- [ ] 浏览器里 `engine.resourceManager.load("/assets/sfx.m4a")` 不再抛错，返回 AudioClip
- [ ] `AudioSource` 播放 m4a 资产无回归
- [ ] `mp3 / ogg / wav` 原有路径无回归

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added M4A audio support alongside MP3, OGG, and WAV so playback and asset loading now recognize .m4a files.

* **Documentation**
  * Updated public documentation/comments to list M4A as a supported audio format and clarify supported audio extensions for users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/3008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->