### PR TITLE
feat(loader): recognize .aac and .flac extensions for audioClip loader

### DIFF
--- a/packages/core/src/asset/AssetType.ts
+++ b/packages/core/src/asset/AssetType.ts
@@ -44,7 +44,7 @@ export enum AssetType {
   Font = "Font",
   /** Source Font, include ttf, otf and woff. */
   SourceFont = "SourceFont",
-  /** AudioClip, include ogg, wav, mp3 and m4a. */
+  /** AudioClip, include ogg, wav, mp3, m4a, aac and flac. */
   Audio = "Audio",
   /** Project asset. */
   Project = "project",

--- a/packages/loader/src/AudioLoader.ts
+++ b/packages/loader/src/AudioLoader.ts
@@ -9,7 +9,7 @@ import {
   ResourceManager,
   resourceLoader
 } from "@galacean/engine-core";
-@resourceLoader(AssetType.Audio, ["mp3", "ogg", "wav", "m4a"])
+@resourceLoader(AssetType.Audio, ["mp3", "ogg", "wav", "m4a", "aac", "flac"])
 class AudioLoader extends Loader<AudioClip> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<AudioClip> {
     return new AssetPromise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Follow-up to #3008 (which opened `.m4a`). Add `.aac` **and** `.flac` to `AudioLoader`'s `@resourceLoader` extension list so that loading audio via url without explicit type resolves to `AssetType.Audio`.

```ts
// before
engine.resourceManager.load("sfx.aac")  // throws: "asset type should be specified"
engine.resourceManager.load("bgm.flac") // throws: "asset type should be specified"

// after
engine.resourceManager.load("sfx.aac")  // resolves AudioClip
engine.resourceManager.load("bgm.flac") // resolves AudioClip
```

## Browser native decode support

| Format | Container | Encoding | MIME | Browser native `decodeAudioData` |
| --- | --- | --- | --- | --- |
| `.aac` | ADTS | AAC | `audio/aac` | Chromium 9+ / Safari 3.1+ / Firefox 90+ (2021-07, stable by 2022) |
| `.flac` | FLAC | FLAC | `audio/flac` | Chromium 56+ (2017-01) / Safari 11+ (2017-09) / Firefox 51+ (2017-01) |

Both formats use `AudioContext.decodeAudioData`'s standard decode pipeline — no polyfill / no extra encode path.

## Editor companion PR

galacean/editor#3731 opens `.m4a` / `.aac` / `.flac` on the editor side in lockstep:
- upload panel accept (derived from `AUDIO_EXT_LIST`)
- `audio.create` / `vfs.create` MIME maps (via shared `AUDIO_EXT_MIME` constant)
- cli-preview static resource MIME
- ResourcePackageExporter MIME
- WeChat mini-game whitelist (`.flac` newly added; `.m4a` / `.aac` already present)

## Test plan

- [ ] Manual: `engine.resourceManager.load("/path/sfx.aac")` returns AudioClip
- [ ] Manual: `engine.resourceManager.load("/path/bgm.flac")` returns AudioClip
- [ ] Manual: `AudioSource.clip = clip` plays correctly
- [ ] Regression: existing `mp3 / ogg / wav / m4a` paths unaffected (see `AudioSource.test.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AAC and FLAC audio formats alongside MP3, OGG, WAV, and M4A.
* **Documentation**
  * Updated audio format documentation to reflect the newly supported AAC format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/3009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->