### PR TITLE
feat(particle): implement rateOverDistance emission

### DIFF
--- a/e2e/case/particleRenderer-rateOverDistance.ts
+++ b/e2e/case/particleRenderer-rateOverDistance.ts
@@ -1,0 +1,92 @@
+/**
+ * @title Particle Rate Over Distance
+ * @category Particle
+ */
+import {
+  BlendMode,
+  Camera,
+  Color,
+  Engine,
+  Entity,
+  ParticleCompositeCurve,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleSimulationSpace,
+  Script,
+  SphereShape,
+  WebGLEngine
+} from "@galacean/engine";
+import { initScreenshot, updateForE2E } from "./.mockForE2E";
+
+WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
+  engine.canvas.resizeByClientSize();
+
+  const scene = engine.sceneManager.activeScene;
+  const rootEntity = scene.createRootEntity();
+  scene.background.solidColor = new Color(0, 0, 0, 1);
+
+  const cameraEntity = rootEntity.createChild("camera");
+  cameraEntity.transform.setPosition(0, 0, 12);
+  const camera = cameraEntity.addComponent(Camera);
+  camera.fieldOfView = 60;
+
+  const particleEntity = buildRateOverDistanceParticle(engine);
+  particleEntity.addComponent(SweepScript);
+  rootEntity.addChild(particleEntity);
+
+  updateForE2E(engine, 50);
+  initScreenshot(engine, camera);
+});
+
+function buildRateOverDistanceParticle(engine: Engine): Entity {
+  const particleEntity = new Entity(engine, "RateOverDistance");
+  particleEntity.transform.setPosition(-5, 0, 0);
+
+  const particleRenderer = particleEntity.addComponent(ParticleRenderer);
+  const generator = particleRenderer.generator;
+  generator.useAutoRandomSeed = false;
+
+  const material = new ParticleMaterial(engine);
+  material.baseColor = new Color(0.4, 0.8, 1.0, 1.0);
+  material.blendMode = BlendMode.Additive;
+  particleRenderer.setMaterial(material);
+
+  const { main, emission } = generator;
+
+  // Long lifetime so the trail stays visible end-to-end in the screenshot.
+  main.duration = 3;
+  main.isLoop = true;
+  main.startLifetime.constant = 3;
+  // No initial velocity — particles stay where they were emitted so the
+  // emitter's path is what we see in the capture.
+  main.startSpeed.constant = 0;
+  main.startSize.constant = 0.2;
+  main.gravityModifier.constant = 0;
+  // World space so particles do NOT follow the moving emitter; the trail
+  // marks the path.
+  main.simulationSpace = ParticleSimulationSpace.World;
+  main.maxParticles = 500;
+
+  // Only distance-driven emission for this case.
+  emission.rateOverTime = new ParticleCompositeCurve(0);
+  emission.rateOverDistance = new ParticleCompositeCurve(2);
+
+  // Small point-ish source so the trail reads as a line, not a cloud.
+  const sphereShape = new SphereShape();
+  sphereShape.radius = 0.01;
+  emission.shape = sphereShape;
+
+  return particleEntity;
+}
+
+class SweepScript extends Script {
+  private _x: number = -5;
+  // Constant horizontal velocity so the emitter sweeps across the view in
+  // the deterministic ~0.5s the e2e drives, regardless of frame count.
+  private readonly _speed: number = 20.0;
+
+  onUpdate(deltaTime: number): void {
+    this._x += this._speed * deltaTime;
+    this.entity.transform.setPosition(this._x, 0, 0);
+  }
+}

--- a/e2e/case/particleRenderer-rateOverDistance.ts
+++ b/e2e/case/particleRenderer-rateOverDistance.ts
@@ -3,17 +3,21 @@
  * @category Particle
  */
 import {
+  AssetType,
   BlendMode,
   Camera,
   Color,
   Engine,
   Entity,
   ParticleCompositeCurve,
+  ParticleCurveMode,
+  ParticleGradientMode,
   ParticleMaterial,
   ParticleRenderer,
   ParticleSimulationSpace,
   Script,
   SphereShape,
+  Texture2D,
   WebGLEngine
 } from "@galacean/engine";
 import { initScreenshot, updateForE2E } from "./.mockForE2E";
@@ -30,17 +34,23 @@ WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
   const camera = cameraEntity.addComponent(Camera);
   camera.fieldOfView = 60;
 
-  const particleEntity = buildRateOverDistanceParticle(engine);
-  particleEntity.addComponent(SweepScript);
-  rootEntity.addChild(particleEntity);
+  engine.resourceManager
+    .load({
+      url: "https://mdn.alipayobjects.com/huamei_9ahbho/afts/img/A*OiP_RLwuFqAAAAAAQBAAAAgAegDwAQ/original",
+      type: AssetType.Texture
+    })
+    .then((texture) => {
+      const particleEntity = createTrailParticle(engine, <Texture2D>texture);
+      particleEntity.addComponent(OrbitScript);
+      rootEntity.addChild(particleEntity);
 
-  updateForE2E(engine, 50);
-  initScreenshot(engine, camera);
+      updateForE2E(engine, 100, 40);
+      initScreenshot(engine, camera);
+    });
 });
 
-function buildRateOverDistanceParticle(engine: Engine): Entity {
+function createTrailParticle(engine: Engine, texture: Texture2D): Entity {
   const particleEntity = new Entity(engine, "RateOverDistance");
-  particleEntity.transform.setPosition(-5, 0, 0);
 
   const particleRenderer = particleEntity.addComponent(ParticleRenderer);
   const generator = particleRenderer.generator;
@@ -49,44 +59,61 @@ function buildRateOverDistanceParticle(engine: Engine): Entity {
   const material = new ParticleMaterial(engine);
   material.baseColor = new Color(0.4, 0.8, 1.0, 1.0);
   material.blendMode = BlendMode.Additive;
+  material.baseTexture = texture;
   particleRenderer.setMaterial(material);
 
-  const { main, emission } = generator;
+  const { main, emission, colorOverLifetime, sizeOverLifetime } = generator;
 
-  // Long lifetime so the trail stays visible end-to-end in the screenshot.
-  main.duration = 3;
+  // Main: world space so the trail stays put while the emitter moves.
+  main.duration = 5;
   main.isLoop = true;
-  main.startLifetime.constant = 3;
-  // No initial velocity — particles stay where they were emitted so the
-  // emitter's path is what we see in the capture.
+  main.startLifetime.constant = 2;
   main.startSpeed.constant = 0;
-  main.startSize.constant = 0.2;
+  main.startSize.constantMin = 0.15;
+  main.startSize.constantMax = 0.3;
+  main.startSize.mode = ParticleCurveMode.TwoConstants;
   main.gravityModifier.constant = 0;
-  // World space so particles do NOT follow the moving emitter; the trail
-  // marks the path.
   main.simulationSpace = ParticleSimulationSpace.World;
-  main.maxParticles = 500;
+  main.maxParticles = 2000;
 
-  // Only distance-driven emission for this case.
+  // Emission: only distance-driven.
   emission.rateOverTime = new ParticleCompositeCurve(0);
-  emission.rateOverDistance = new ParticleCompositeCurve(2);
+  emission.rateOverDistance = new ParticleCompositeCurve(15);
 
-  // Small point-ish source so the trail reads as a line, not a cloud.
   const sphereShape = new SphereShape();
-  sphereShape.radius = 0.01;
+  sphereShape.radius = 0.05;
   emission.shape = sphereShape;
+
+  // Fade in/out along lifetime.
+  colorOverLifetime.enabled = true;
+  colorOverLifetime.color.mode = ParticleGradientMode.Gradient;
+  const gradient = colorOverLifetime.color.gradient;
+  gradient.alphaKeys[0].alpha = 0;
+  gradient.alphaKeys[1].alpha = 0;
+  gradient.addAlphaKey(0.2, 1.0);
+  gradient.addAlphaKey(0.8, 1.0);
+  gradient.colorKeys[0].color.set(0.4, 0.8, 1.0, 1.0);
+  gradient.colorKeys[1].color.set(1.0, 0.3, 0.8, 1.0);
+
+  // Shrink to nothing.
+  sizeOverLifetime.enabled = true;
+  sizeOverLifetime.size.mode = ParticleCurveMode.Curve;
+  const sizeCurve = sizeOverLifetime.size.curve;
+  sizeCurve.keys[0].value = 1;
+  sizeCurve.keys[1].value = 0;
 
   return particleEntity;
 }
 
-class SweepScript extends Script {
-  private _x: number = -5;
-  // Constant horizontal velocity so the emitter sweeps across the view in
-  // the deterministic ~0.5s the e2e drives, regardless of frame count.
-  private readonly _speed: number = 20.0;
+class OrbitScript extends Script {
+  private _radius: number = 4;
+  private _angle: number = 0;
+  private _speed: number = 1.5;
 
   onUpdate(deltaTime: number): void {
-    this._x += this._speed * deltaTime;
-    this.entity.transform.setPosition(this._x, 0, 0);
+    this._angle += deltaTime * this._speed;
+    const x = Math.cos(this._angle) * this._radius;
+    const y = Math.sin(this._angle * 2) * this._radius * 0.5;
+    this.entity.transform.setPosition(x, y, 0);
   }
 }

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -448,6 +448,12 @@ export const E2E_CONFIG = {
       caseFileName: "particleRenderer-burst-cycles",
       threshold: 0,
       diffPercentage: 0.2
+    },
+    rateOverDistance: {
+      category: "Particle",
+      caseFileName: "particleRenderer-rateOverDistance",
+      threshold: 0,
+      diffPercentage: 0
     }
   },
   PostProcess: {

--- a/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9a45fb68a6f2055f377d7f579832e7f449339d6ee7efd216334a21fbfd747e3
-size 37291
+oid sha256:44f95054f9671d950e42fd1af28de5ef104726c65cc284aeb79b027efe9dd30f
+size 37959

--- a/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04ec3afbb869eea29fd149c7980f68154d0c156be536c9b642da186c1dc825e6
-size 17387
+oid sha256:3c2ef0d9a74cb2ef520b14d53f4aa979d83c1ae4039d06f0e2a3eec431be1e4d
+size 23974

--- a/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04ec3afbb869eea29fd149c7980f68154d0c156be536c9b642da186c1dc825e6
+size 17387

--- a/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
+++ b/e2e/fixtures/originImage/Particle_particleRenderer-rateOverDistance.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c2ef0d9a74cb2ef520b14d53f4aa979d83c1ae4039d06f0e2a3eec431be1e4d
-size 23974
+oid sha256:b9a45fb68a6f2055f377d7f579832e7f449339d6ee7efd216334a21fbfd747e3
+size 37291

--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -220,6 +220,7 @@ export class ParticleGenerator {
       }
 
       this._playStartDelay = this.main.startDelay.evaluate(undefined, this.main._startDelayRand.random());
+      this.emission._resyncCursors(this._playTime);
     }
   }
 
@@ -240,17 +241,11 @@ export class ParticleGenerator {
       }
     } else {
       this._isPlaying = false;
-      // Invalidate the rateOverDistance baseline so emitter movement during the stop
-      // interval doesn't burst on resume.
       if (stopMode === ParticleStopMode.StopEmittingAndClear) {
         this._clearActiveParticles();
         this._playTime = 0;
 
         this._firstActiveTransformedBoundingBox = this._firstFreeTransformedBoundingBox;
-
-        this.emission._reset();
-      } else {
-        this.emission._invalidateDistanceBaseline();
       }
     }
   }

--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -266,37 +266,41 @@ export class ParticleGenerator {
   /**
    * @internal
    */
-  _emit(playTime: number, count: number, emitWorldPositionOverride?: Vector3): void {
-    const { emission } = this;
-    if (emission.enabled) {
-      const { main } = this;
-      // Wait the existing particles to be retired
-      const notRetireParticleCount = this._getNotRetiredParticleCount();
-      if (notRetireParticleCount >= main.maxParticles) {
-        return;
-      }
-      const position = ParticleGenerator._tempVector30;
-      const direction = ParticleGenerator._tempVector31;
-      const transform = this._renderer.entity.transform;
-      const shape = emission.shape;
-      const positionScale = main._getPositionScale();
-      for (let i = 0; i < count; i++) {
-        if (shape?.enabled) {
-          shape._generatePositionAndDirection(emission._shapeRand, playTime, position, direction);
-          position.multiply(positionScale);
-          direction.normalize().multiply(positionScale);
-        } else {
-          position.set(0, 0, 0);
-          direction.set(0, 0, -1);
-          // Speed is scaled by shape scale in world simulation space
-          // So if no shape and in world simulation space, we shouldn't scale the speed
-          if (main.simulationSpace === ParticleSimulationSpace.Local) {
-            direction.multiply(positionScale);
-          }
-        }
-        this._addNewParticle(position, direction, transform, playTime, emitWorldPositionOverride);
-      }
+  _emit(playTime: number, count: number, emitWorldPositionOverride?: Vector3): number {
+    const { emission, main } = this;
+    if (!emission.enabled) {
+      return 0;
     }
+    const budget = main.maxParticles - this._getNotRetiredParticleCount();
+    if (count > budget) {
+      count = budget;
+    }
+    if (count <= 0) {
+      return 0;
+    }
+
+    const position = ParticleGenerator._tempVector30;
+    const direction = ParticleGenerator._tempVector31;
+    const transform = this._renderer.entity.transform;
+    const shape = emission.shape;
+    const positionScale = main._getPositionScale();
+    for (let i = 0; i < count; i++) {
+      if (shape?.enabled) {
+        shape._generatePositionAndDirection(emission._shapeRand, playTime, position, direction);
+        position.multiply(positionScale);
+        direction.normalize().multiply(positionScale);
+      } else {
+        position.set(0, 0, 0);
+        direction.set(0, 0, -1);
+        // Speed is scaled by shape scale in world simulation space
+        // So if no shape and in world simulation space, we shouldn't scale the speed
+        if (main.simulationSpace === ParticleSimulationSpace.Local) {
+          direction.multiply(positionScale);
+        }
+      }
+      this._addNewParticle(position, direction, transform, playTime, emitWorldPositionOverride);
+    }
+    return count;
   }
 
   /**

--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -240,6 +240,8 @@ export class ParticleGenerator {
       }
     } else {
       this._isPlaying = false;
+      // Invalidate the rateOverDistance baseline so emitter movement during the stop
+      // interval doesn't burst on resume.
       if (stopMode === ParticleStopMode.StopEmittingAndClear) {
         this._clearActiveParticles();
         this._playTime = 0;
@@ -247,6 +249,8 @@ export class ParticleGenerator {
         this._firstActiveTransformedBoundingBox = this._firstFreeTransformedBoundingBox;
 
         this.emission._reset();
+      } else {
+        this.emission._invalidateDistanceBaseline();
       }
     }
   }
@@ -262,7 +266,7 @@ export class ParticleGenerator {
   /**
    * @internal
    */
-  _emit(playTime: number, count: number): void {
+  _emit(playTime: number, count: number, emitWorldPositionOverride?: Vector3): void {
     const { emission } = this;
     if (emission.enabled) {
       const { main } = this;
@@ -290,7 +294,7 @@ export class ParticleGenerator {
             direction.multiply(positionScale);
           }
         }
-        this._addNewParticle(position, direction, transform, playTime);
+        this._addNewParticle(position, direction, transform, playTime, emitWorldPositionOverride);
       }
     }
   }
@@ -838,7 +842,13 @@ export class ParticleGenerator {
     }
   }
 
-  private _addNewParticle(position: Vector3, direction: Vector3, transform: Transform, playTime: number): void {
+  private _addNewParticle(
+    position: Vector3,
+    direction: Vector3,
+    transform: Transform,
+    playTime: number,
+    emitWorldPositionOverride?: Vector3
+  ): void {
     const firstFreeElement = this._firstFreeElement;
     let nextFreeElement = firstFreeElement + 1;
     if (nextFreeElement >= this._currentParticleCount) {
@@ -870,7 +880,7 @@ export class ParticleGenerator {
 
     let pos: Vector3, rot: Quaternion;
     if (main.simulationSpace === ParticleSimulationSpace.World) {
-      pos = transform.worldPosition;
+      pos = emitWorldPositionOverride ?? transform.worldPosition;
       rot = transform.worldRotationQuaternion;
     }
 
@@ -1027,7 +1037,7 @@ export class ParticleGenerator {
 
     // Initialize feedback buffer for this particle
     if (this._useTransformFeedback) {
-      this._addFeedbackParticle(firstFreeElement, position, direction, startSpeed, transform);
+      this._addFeedbackParticle(firstFreeElement, position, direction, startSpeed, transform, pos);
     }
 
     this._firstFreeElement = nextFreeElement;
@@ -1038,7 +1048,8 @@ export class ParticleGenerator {
     shapePosition: Vector3,
     direction: Vector3,
     startSpeed: number,
-    transform: Transform
+    transform: Transform,
+    emitWorldPosition?: Vector3
   ): void {
     let position: Vector3;
     if (this.main.simulationSpace === ParticleSimulationSpace.Local) {
@@ -1046,7 +1057,7 @@ export class ParticleGenerator {
     } else {
       position = ParticleGenerator._tempVector32;
       Vector3.transformByQuat(shapePosition, transform.worldRotationQuaternion, position);
-      position.add(transform.worldPosition);
+      position.add(emitWorldPosition ?? transform.worldPosition);
     }
 
     this._feedbackSimulator.writeParticleData(

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -1,4 +1,4 @@
-import { MathUtil, Rand } from "@galacean/engine-math";
+import { MathUtil, Rand, Vector3 } from "@galacean/engine-math";
 import { deepClone, ignoreClone } from "../../clone/CloneManager";
 import { ShaderMacro } from "../../shader/ShaderMacro";
 import { ParticleRandomSubSeeds } from "../enums/ParticleRandomSubSeeds";
@@ -28,6 +28,16 @@ export class EmissionModule extends ParticleGeneratorModule {
   _shapeRand = new Rand(0, ParticleRandomSubSeeds.Shape);
   /** @internal */
   _frameRateTime: number = 0;
+
+  /** Carries the sub-interval distance fragment between frames so `rateOverDistance` interpolates correctly across long pulls. */
+  @ignoreClone
+  private _distanceAccumulator: number = 0;
+  /** Last sampled world position of the emitter; subsequent frames diff against it for `rateOverDistance`. */
+  @ignoreClone
+  private _lastEmitPosition: Vector3 = new Vector3();
+  /** False until the first emit after `_reset` (or first ever play), so we don't diff against an uninitialized origin. */
+  @ignoreClone
+  private _hasLastEmitPosition: boolean = false;
 
   @deepClone
   private _bursts: Burst[] = [];
@@ -130,6 +140,7 @@ export class EmissionModule extends ParticleGeneratorModule {
    */
   _emit(lastPlayTime: number, playTime: number): void {
     this._emitByRateOverTime(playTime);
+    this._emitByRateOverDistance();
     this._emitByBurst(lastPlayTime, playTime);
   }
 
@@ -147,6 +158,8 @@ export class EmissionModule extends ParticleGeneratorModule {
   _reset(): void {
     this._frameRateTime = 0;
     this._currentBurstIndex = 0;
+    this._distanceAccumulator = 0;
+    this._hasLastEmitPosition = false;
   }
 
   /**
@@ -167,6 +180,41 @@ export class EmissionModule extends ParticleGeneratorModule {
         cumulativeTime -= emitInterval;
         this._frameRateTime += emitInterval;
         generator._emit(this._frameRateTime, 1);
+      }
+    }
+  }
+
+  private _emitByRateOverDistance(): void {
+    const generator = this._generator;
+    const currentPos = generator._renderer.entity.transform.worldPosition;
+    const ratePerUnit = this.rateOverDistance.evaluate(undefined, undefined);
+
+    // No active rate or no baseline yet — sync the position and bail. We
+    // still drop the accumulator so a later rate flip from 0 → N doesn't
+    // dump every pre-flip frame of movement into a one-shot burst.
+    if (ratePerUnit <= 0 || !this._hasLastEmitPosition) {
+      this._lastEmitPosition.copyFrom(currentPos);
+      this._hasLastEmitPosition = true;
+      this._distanceAccumulator = 0;
+      return;
+    }
+
+    const dx = currentPos.x - this._lastEmitPosition.x;
+    const dy = currentPos.y - this._lastEmitPosition.y;
+    const dz = currentPos.z - this._lastEmitPosition.z;
+    this._lastEmitPosition.copyFrom(currentPos);
+
+    this._distanceAccumulator += Math.sqrt(dx * dx + dy * dy + dz * dz);
+    const emitInterval = 1.0 / ratePerUnit;
+    // Single divide + Math.floor instead of a while-subtract loop so the
+    // accumulator doesn't drift after long runs (`2.0 - 19 * 0.1` is not 0.1
+    // in float). zeroTolerance handles the symmetric exact-boundary case.
+    const count = Math.floor(this._distanceAccumulator / emitInterval + MathUtil.zeroTolerance);
+    if (count > 0) {
+      this._distanceAccumulator -= count * emitInterval;
+      const playTime = generator._playTime;
+      for (let i = 0; i < count; i++) {
+        generator._emit(playTime, 1);
       }
     }
   }

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -2,6 +2,7 @@ import { MathUtil, Rand, Vector3 } from "@galacean/engine-math";
 import { deepClone, ignoreClone } from "../../clone/CloneManager";
 import { ShaderMacro } from "../../shader/ShaderMacro";
 import { ParticleRandomSubSeeds } from "../enums/ParticleRandomSubSeeds";
+import { ParticleSimulationSpace } from "../enums/ParticleSimulationSpace";
 import { Burst } from "./Burst";
 import { ParticleCompositeCurve } from "./ParticleCompositeCurve";
 import { ParticleGeneratorModule } from "./ParticleGeneratorModule";
@@ -13,6 +14,8 @@ import { BaseShape } from "./shape/BaseShape";
 export class EmissionModule extends ParticleGeneratorModule {
   /** @internal */
   static readonly _emissionShapeMacro = ShaderMacro.getByName("RENDERER_EMISSION_SHAPE");
+
+  private static _tempEmitPosition = new Vector3();
 
   /**  The rate of particle emission. */
   @deepClone
@@ -29,15 +32,12 @@ export class EmissionModule extends ParticleGeneratorModule {
   /** @internal */
   _frameRateTime: number = 0;
 
-  /** Carries the sub-interval distance fragment between frames so `rateOverDistance` interpolates correctly across long pulls. */
   @ignoreClone
-  private _distanceAccumulator: number = 0;
-  /** Last sampled world position of the emitter; subsequent frames diff against it for `rateOverDistance`. */
+  private _distanceAccumulator = 0;
   @ignoreClone
-  private _lastEmitPosition: Vector3 = new Vector3();
-  /** False until the first emit after `_reset` (or first ever play), so we don't diff against an uninitialized origin. */
+  private _lastEmitPosition = new Vector3();
   @ignoreClone
-  private _hasLastEmitPosition: boolean = false;
+  private _hasLastEmitPosition = false;
 
   @deepClone
   private _bursts: Burst[] = [];
@@ -158,8 +158,15 @@ export class EmissionModule extends ParticleGeneratorModule {
   _reset(): void {
     this._frameRateTime = 0;
     this._currentBurstIndex = 0;
-    this._distanceAccumulator = 0;
+    this._invalidateDistanceBaseline();
+  }
+
+  /**
+   * @internal
+   */
+  _invalidateDistanceBaseline(): void {
     this._hasLastEmitPosition = false;
+    this._distanceAccumulator = 0;
   }
 
   /**
@@ -185,38 +192,52 @@ export class EmissionModule extends ParticleGeneratorModule {
   }
 
   private _emitByRateOverDistance(): void {
-    const generator = this._generator;
-    const currentPos = generator._renderer.entity.transform.worldPosition;
     const ratePerUnit = this.rateOverDistance.evaluate(undefined, undefined);
+    const generator = this._generator;
 
-    // No active rate or no baseline yet — sync the position and bail. We
-    // still drop the accumulator so a later rate flip from 0 → N doesn't
-    // dump every pre-flip frame of movement into a one-shot burst.
-    if (ratePerUnit <= 0 || !this._hasLastEmitPosition) {
-      this._lastEmitPosition.copyFrom(currentPos);
+    if (ratePerUnit <= 0) {
+      this._invalidateDistanceBaseline();
+      return;
+    }
+    if (!this._hasLastEmitPosition) {
+      this._lastEmitPosition.copyFrom(generator._renderer.entity.transform.worldPosition);
       this._hasLastEmitPosition = true;
-      this._distanceAccumulator = 0;
       return;
     }
 
-    const dx = currentPos.x - this._lastEmitPosition.x;
-    const dy = currentPos.y - this._lastEmitPosition.y;
-    const dz = currentPos.z - this._lastEmitPosition.z;
-    this._lastEmitPosition.copyFrom(currentPos);
+    const lastPos = this._lastEmitPosition;
+    const currentPos = generator._renderer.entity.transform.worldPosition;
+    const dx = currentPos.x - lastPos.x;
+    const dy = currentPos.y - lastPos.y;
+    const dz = currentPos.z - lastPos.z;
+    const moveLength = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    this._distanceAccumulator += moveLength;
 
-    this._distanceAccumulator += Math.sqrt(dx * dx + dy * dy + dz * dz);
     const emitInterval = 1.0 / ratePerUnit;
-    // Single divide + Math.floor instead of a while-subtract loop so the
-    // accumulator doesn't drift after long runs (`2.0 - 19 * 0.1` is not 0.1
-    // in float). zeroTolerance handles the symmetric exact-boundary case.
+    // `+ zeroTolerance` absorbs float divide error so an exact `N*interval` accumulator doesn't drop 1
     const count = Math.floor(this._distanceAccumulator / emitInterval + MathUtil.zeroTolerance);
+
     if (count > 0) {
       this._distanceAccumulator -= count * emitInterval;
       const playTime = generator._playTime;
-      for (let i = 0; i < count; i++) {
-        generator._emit(playTime, 1);
+      if (generator.main.simulationSpace === ParticleSimulationSpace.World && moveLength > MathUtil.zeroTolerance) {
+        // Distribute N emissions along [lastPos → currentPos]: most-recent particle at
+        // t = 1 - remaining/moveLength, earlier ones step back by tStep each.
+        const invMoveLength = 1.0 / moveLength;
+        const tStep = emitInterval * invMoveLength;
+        let t = 1.0 - this._distanceAccumulator * invMoveLength;
+        const emitPos = EmissionModule._tempEmitPosition;
+        for (let i = count - 1; i >= 0; i--) {
+          emitPos.set(lastPos.x + dx * t, lastPos.y + dy * t, lastPos.z + dz * t);
+          generator._emit(playTime, 1, emitPos);
+          t -= tStep;
+        }
+      } else {
+        generator._emit(playTime, count);
       }
     }
+
+    lastPos.copyFrom(currentPos);
   }
 
   private _emitByBurst(lastPlayTime: number, playTime: number): void {

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -219,27 +219,31 @@ export class EmissionModule extends ParticleGeneratorModule {
 
     if (count > 0) {
       this._distanceAccumulator -= count * emitInterval;
-      if (generator.main.simulationSpace === ParticleSimulationSpace.World && moveLength > MathUtil.zeroTolerance) {
-        // Distribute N emissions along [lastPos → currentPos]. The same normalized
-        // back-distance `s ∈ [0, 1]` controls both spatial offset and emit-time offset:
-        //   s = 0 → spawn at currentPos with emitTime = playTime (just born),
-        //   s = 1 → spawn at lastPos    with emitTime = lastPlayTime (born a frame ago).
-        // Without the time interpolation, all N particles would share `playTime`, so any
-        // age-driven module (COL / SOL / FOL) would render them as a uniform stamp
-        // instead of a smooth fade — the very high-speed case spatial distribution is
-        // meant to fix.
-        const invMoveLength = 1.0 / moveLength;
-        const sStep = emitInterval * invMoveLength;
-        const dt = playTime - lastPlayTime;
-        let s = this._distanceAccumulator * invMoveLength;
-        const emitPos = EmissionModule._tempEmitPosition;
-        for (let i = 0; i < count; i++) {
-          emitPos.set(currentPos.x - dx * s, currentPos.y - dy * s, currentPos.z - dz * s);
-          generator._emit(playTime - dt * s, 1, emitPos);
-          s += sStep;
+      // `subFrameAge ∈ [0, 1]`: how far back into the frame a particle was born
+      // (0 = newest at currentPos/playTime, 1 = oldest at lastPos/lastPlayTime).
+      // The initial clamp protects two edges — moveLength ≈ 0 (collapse to frame-end
+      // emit) and a tiny moveLength near the emitInterval edge (would put age > 1).
+      // Local simulation space ignores the position override but still uses emitTime.
+      const isWorld = generator.main.simulationSpace === ParticleSimulationSpace.World;
+      const invMoveLength = moveLength > MathUtil.zeroTolerance ? 1.0 / moveLength : 0;
+      const ageStep = emitInterval * invMoveLength;
+      const dt = playTime - lastPlayTime;
+      let subFrameAge = Math.min(this._distanceAccumulator * invMoveLength, 1.0);
+      const emitPos = EmissionModule._tempEmitPosition;
+      for (let i = 0; i < count; i++) {
+        if (isWorld) {
+          emitPos.set(
+            currentPos.x - dx * subFrameAge,
+            currentPos.y - dy * subFrameAge,
+            currentPos.z - dz * subFrameAge
+          );
         }
-      } else {
-        generator._emit(playTime, count);
+        if (generator._emit(playTime - dt * subFrameAge, 1, isWorld ? emitPos : undefined) === 0) {
+          // Buffer full: settle the frame's distance budget instead of carrying it over
+          this._distanceAccumulator = 0;
+          break;
+        }
+        subFrameAge += ageStep;
       }
     }
 

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -56,6 +56,9 @@ export class EmissionModule extends ParticleGeneratorModule {
 
   override set enabled(value: boolean) {
     if (value !== this._enabled) {
+      if (value) {
+        this._resyncCursors(this._generator._playTime);
+      }
       this._enabled = value;
       if (value && this._shape) {
         this._generator._renderer.shaderData.enableMacro(EmissionModule._emissionShapeMacro);
@@ -152,19 +155,10 @@ export class EmissionModule extends ParticleGeneratorModule {
     this._shapeRand.reset(seed, ParticleRandomSubSeeds.Shape);
   }
 
-  /**
-   * @internal
-   */
-  _reset(): void {
-    this._frameRateTime = 0;
+  /** @internal */
+  _resyncCursors(playTime: number): void {
+    this._frameRateTime = playTime;
     this._currentBurstIndex = 0;
-    this._invalidateDistanceBaseline();
-  }
-
-  /**
-   * @internal
-   */
-  _invalidateDistanceBaseline(): void {
     this._hasLastEmitPosition = false;
     this._distanceAccumulator = 0;
   }
@@ -178,16 +172,18 @@ export class EmissionModule extends ParticleGeneratorModule {
 
   private _emitByRateOverTime(playTime: number): void {
     const ratePerSeconds = this.rateOverTime.evaluate(undefined, undefined);
-    if (ratePerSeconds > 0) {
-      const generator = this._generator;
-      const emitInterval = 1.0 / ratePerSeconds;
+    if (ratePerSeconds <= 0) {
+      this._frameRateTime = playTime;
+      return;
+    }
+    const generator = this._generator;
+    const emitInterval = 1.0 / ratePerSeconds;
 
-      let cumulativeTime = playTime - this._frameRateTime;
-      while (cumulativeTime >= emitInterval) {
-        cumulativeTime -= emitInterval;
-        this._frameRateTime += emitInterval;
-        generator._emit(this._frameRateTime, 1);
-      }
+    let cumulativeTime = playTime - this._frameRateTime;
+    while (cumulativeTime >= emitInterval) {
+      cumulativeTime -= emitInterval;
+      this._frameRateTime += emitInterval;
+      generator._emit(this._frameRateTime, 1);
     }
   }
 
@@ -196,7 +192,8 @@ export class EmissionModule extends ParticleGeneratorModule {
     const generator = this._generator;
 
     if (ratePerUnit <= 0) {
-      this._invalidateDistanceBaseline();
+      this._hasLastEmitPosition = false;
+      this._distanceAccumulator = 0;
       return;
     }
     if (!this._hasLastEmitPosition) {
@@ -207,9 +204,10 @@ export class EmissionModule extends ParticleGeneratorModule {
 
     const lastPos = this._lastEmitPosition;
     const currentPos = generator._renderer.entity.transform.worldPosition;
-    const dx = currentPos.x - lastPos.x;
-    const dy = currentPos.y - lastPos.y;
-    const dz = currentPos.z - lastPos.z;
+    const { x: cx, y: cy, z: cz } = currentPos;
+    const dx = cx - lastPos.x;
+    const dy = cy - lastPos.y;
+    const dz = cz - lastPos.z;
     const moveLength = Math.sqrt(dx * dx + dy * dy + dz * dz);
     this._distanceAccumulator += moveLength;
 
@@ -219,11 +217,10 @@ export class EmissionModule extends ParticleGeneratorModule {
 
     if (count > 0) {
       this._distanceAccumulator -= count * emitInterval;
-      // `subFrameAge ∈ [0, 1]`: how far back into the frame a particle was born
-      // (0 = newest at currentPos/playTime, 1 = oldest at lastPos/lastPlayTime).
-      // The initial clamp protects two edges — moveLength ≈ 0 (collapse to frame-end
-      // emit) and a tiny moveLength near the emitInterval edge (would put age > 1).
-      // Local simulation space ignores the position override but still uses emitTime.
+      // `subFrameAge ∈ [0, 1]`: 0 = newest at currentPos/playTime, 1 = oldest
+      // at lastPos/lastPlayTime. Monotonically clamped so a rate hike that
+      // pays out more particles than this frame's segment can host stacks the
+      // overflow at lastPos instead of extrapolating past it.
       const isWorld = generator.main.simulationSpace === ParticleSimulationSpace.World;
       const invMoveLength = moveLength > MathUtil.zeroTolerance ? 1.0 / moveLength : 0;
       const ageStep = emitInterval * invMoveLength;
@@ -232,22 +229,13 @@ export class EmissionModule extends ParticleGeneratorModule {
       const emitPos = EmissionModule._tempEmitPosition;
       for (let i = 0; i < count; i++) {
         if (isWorld) {
-          emitPos.set(
-            currentPos.x - dx * subFrameAge,
-            currentPos.y - dy * subFrameAge,
-            currentPos.z - dz * subFrameAge
-          );
+          emitPos.set(cx - dx * subFrameAge, cy - dy * subFrameAge, cz - dz * subFrameAge);
         }
         if (generator._emit(playTime - dt * subFrameAge, 1, isWorld ? emitPos : undefined) === 0) {
           // Buffer full: settle the frame's distance budget instead of carrying it over
           this._distanceAccumulator = 0;
           break;
         }
-        // Mirror the initial Math.min clamp inside the loop: a mid-PR rate hike
-        // can make previousCarry exceed the new emitInterval, so the accumulator
-        // pays out multiple particles' worth of distance in a single frame whose
-        // moveLength is only one interval wide. Without this clamp the second
-        // particle onward would extrapolate past lastPos in both space and time.
         subFrameAge = Math.min(subFrameAge + ageStep, 1.0);
       }
     }

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -140,7 +140,7 @@ export class EmissionModule extends ParticleGeneratorModule {
    */
   _emit(lastPlayTime: number, playTime: number): void {
     this._emitByRateOverTime(playTime);
-    this._emitByRateOverDistance();
+    this._emitByRateOverDistance(lastPlayTime, playTime);
     this._emitByBurst(lastPlayTime, playTime);
   }
 
@@ -191,7 +191,7 @@ export class EmissionModule extends ParticleGeneratorModule {
     }
   }
 
-  private _emitByRateOverDistance(): void {
+  private _emitByRateOverDistance(lastPlayTime: number, playTime: number): void {
     const ratePerUnit = this.rateOverDistance.evaluate(undefined, undefined);
     const generator = this._generator;
 
@@ -219,18 +219,24 @@ export class EmissionModule extends ParticleGeneratorModule {
 
     if (count > 0) {
       this._distanceAccumulator -= count * emitInterval;
-      const playTime = generator._playTime;
       if (generator.main.simulationSpace === ParticleSimulationSpace.World && moveLength > MathUtil.zeroTolerance) {
-        // Distribute N emissions along [lastPos → currentPos]: most-recent particle at
-        // t = 1 - remaining/moveLength, earlier ones step back by tStep each.
+        // Distribute N emissions along [lastPos → currentPos]. The same normalized
+        // back-distance `s ∈ [0, 1]` controls both spatial offset and emit-time offset:
+        //   s = 0 → spawn at currentPos with emitTime = playTime (just born),
+        //   s = 1 → spawn at lastPos    with emitTime = lastPlayTime (born a frame ago).
+        // Without the time interpolation, all N particles would share `playTime`, so any
+        // age-driven module (COL / SOL / FOL) would render them as a uniform stamp
+        // instead of a smooth fade — the very high-speed case spatial distribution is
+        // meant to fix.
         const invMoveLength = 1.0 / moveLength;
-        const tStep = emitInterval * invMoveLength;
-        let t = 1.0 - this._distanceAccumulator * invMoveLength;
+        const sStep = emitInterval * invMoveLength;
+        const dt = playTime - lastPlayTime;
+        let s = this._distanceAccumulator * invMoveLength;
         const emitPos = EmissionModule._tempEmitPosition;
-        for (let i = count - 1; i >= 0; i--) {
-          emitPos.set(lastPos.x + dx * t, lastPos.y + dy * t, lastPos.z + dz * t);
-          generator._emit(playTime, 1, emitPos);
-          t -= tStep;
+        for (let i = 0; i < count; i++) {
+          emitPos.set(currentPos.x - dx * s, currentPos.y - dy * s, currentPos.z - dz * s);
+          generator._emit(playTime - dt * s, 1, emitPos);
+          s += sStep;
         }
       } else {
         generator._emit(playTime, count);

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -243,7 +243,12 @@ export class EmissionModule extends ParticleGeneratorModule {
           this._distanceAccumulator = 0;
           break;
         }
-        subFrameAge += ageStep;
+        // Mirror the initial Math.min clamp inside the loop: a mid-PR rate hike
+        // can make previousCarry exceed the new emitInterval, so the accumulator
+        // pays out multiple particles' worth of distance in a single frame whose
+        // moveLength is only one interval wide. Without this clamp the second
+        // particle onward would extrapolate past lastPos in both space and time.
+        subFrameAge = Math.min(subFrameAge + ageStep, 1.0);
       }
     }
 

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -244,6 +244,34 @@ describe("EmissionModule rateOverDistance", () => {
     entity.destroy();
   });
 
+  it("clamps count and discards accumulator on teleport-sized moves", () => {
+    const { entity, renderer } = buildEmitter(engine, "teleport-clamp");
+    const generator = renderer.generator;
+    generator.main.maxParticles = 50;
+    // Rate 10/unit × 10000 unit jump would otherwise demand 100,000 emissions
+    // in one frame — millions of `_addNewParticle` calls hitting the buffer-full
+    // early return.
+    generator.emission.rateOverDistance.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // baseline sync at (0,0,0)
+
+    entity.transform.setPosition(10000, 0, 0); // teleport
+    tick(engine, elapsed);
+
+    // Alive count must not exceed the configured cap.
+    expect(generator._getAliveParticleCount()).to.be.lessThanOrEqual(50);
+
+    // Next frame without movement: accumulator should have been reset to 0
+    // (residue dropped), so no further emission.
+    const aliveAfterTeleport = generator._getAliveParticleCount();
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(aliveAfterTeleport);
+
+    entity.destroy();
+  });
+
   it("does not burst on play() after emitter moves while stopped", () => {
     const { entity, renderer } = buildEmitter(engine, "no-burst-on-replay");
     const generator = renderer.generator;

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -1,0 +1,169 @@
+import {
+  Camera,
+  Engine,
+  Entity,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleStopMode
+} from "@galacean/engine-core";
+import { Color, Vector3 } from "@galacean/engine-math";
+import { WebGLEngine } from "@galacean/engine";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+function tick(engine: Engine, times: { value: number }, deltaMs: number = 100): void {
+  //@ts-ignore
+  engine._vSyncCount = Infinity;
+  //@ts-ignore
+  engine._time._lastSystemTime = 0;
+  performance.now = function () {
+    times.value += deltaMs;
+    return times.value;
+  };
+  engine.update();
+}
+
+function buildEmitter(engine: Engine, name: string): { entity: Entity; renderer: ParticleRenderer } {
+  const scene = engine.sceneManager.activeScene;
+  const entity = scene.createRootEntity(name);
+  const renderer = entity.addComponent(ParticleRenderer);
+  const material = new ParticleMaterial(engine);
+  material.baseColor = new Color(1, 1, 1, 1);
+  renderer.setMaterial(material);
+
+  const generator = renderer.generator;
+  generator.useAutoRandomSeed = false;
+  generator.main.duration = 5;
+  generator.main.isLoop = false;
+  generator.main.maxParticles = 1000;
+  generator.main.startLifetime.constant = 10;
+  // Zero out the time-based path so only rateOverDistance contributes.
+  generator.emission.rateOverTime.constant = 0;
+  return { entity, renderer };
+}
+
+describe("EmissionModule rateOverDistance", () => {
+  let engine: Engine;
+  let elapsed: { value: number };
+
+  beforeAll(async function () {
+    engine = await WebGLEngine.create({
+      canvas: document.createElement("canvas")
+    });
+
+    const scene = engine.sceneManager.activeScene;
+    const cameraEntity = scene.createRootEntity("Camera");
+    cameraEntity.addComponent(Camera);
+    cameraEntity.transform.setPosition(0, 0, 10);
+
+    engine.run();
+    elapsed = { value: 0 };
+  });
+
+  afterAll(function () {
+    engine.destroy();
+  });
+
+  it("defaults to 0 (no emission triggered by movement)", () => {
+    const { entity, renderer } = buildEmitter(engine, "default-zero");
+    const generator = renderer.generator;
+    expect(generator.emission.rateOverDistance.evaluate(undefined, undefined)).to.eq(0);
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    tick(engine, elapsed);
+    entity.transform.setPosition(10, 0, 0);
+    tick(engine, elapsed);
+
+    expect(generator._getAliveParticleCount()).to.eq(0);
+    entity.destroy();
+  });
+
+  it("emits ratePerUnit × distance particles", () => {
+    const { entity, renderer } = buildEmitter(engine, "rate-times-distance");
+    const generator = renderer.generator;
+    generator.emission.rateOverDistance.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    // First tick syncs the baseline position.
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(0);
+
+    // Move 2 units → 10 * 2 = 20 particles.
+    entity.transform.setPosition(2, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(20);
+
+    entity.destroy();
+  });
+
+  it("accumulates sub-interval movement across frames", () => {
+    const { entity, renderer } = buildEmitter(engine, "subinterval-carry");
+    const generator = renderer.generator;
+    // 1 particle per 0.5 units → 2 particles per unit.
+    generator.emission.rateOverDistance.constant = 2;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // baseline sync
+
+    // 3 moves of 0.3 units each = 0.9 total. With interval 0.5, that's
+    // exactly 1 emission (at 0.5) plus 0.4 carried forward.
+    entity.transform.setPosition(0.3, 0, 0);
+    tick(engine, elapsed);
+    entity.transform.setPosition(0.6, 0, 0);
+    tick(engine, elapsed);
+    entity.transform.setPosition(0.9, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(1);
+
+    // Move another 0.6 units → accumulator hits 1.0, then 0 carried fwd. Emit 2 more.
+    entity.transform.setPosition(1.5, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(3);
+
+    entity.destroy();
+  });
+
+  it("static emitter never emits via distance", () => {
+    const { entity, renderer } = buildEmitter(engine, "static-emitter");
+    const generator = renderer.generator;
+    generator.emission.rateOverDistance.constant = 100;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed);
+    tick(engine, elapsed);
+    tick(engine, elapsed);
+
+    expect(generator._getAliveParticleCount()).to.eq(0);
+    entity.destroy();
+  });
+
+  it("stop+clear resets the distance accumulator", () => {
+    const { entity, renderer } = buildEmitter(engine, "reset-on-clear");
+    const generator = renderer.generator;
+    generator.emission.rateOverDistance.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed);
+    entity.transform.setPosition(0.5, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(5);
+
+    // After clear+play, the next tick must re-sync from the *current* position,
+    // not diff against the pre-clear baseline — so jumping back to origin
+    // should not emit anything until the next move.
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    entity.transform.setPosition(0, 0, 0);
+    generator.play();
+    tick(engine, elapsed);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(0);
+
+    entity.destroy();
+  });
+});

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -272,4 +272,27 @@ describe("EmissionModule rateOverDistance", () => {
 
     entity.destroy();
   });
+
+  it("returns actual emitted count when buffer is full", () => {
+    // Documents the `_emit` return-value contract that lets distance emission detect
+    // mid-loop buffer exhaustion (and drop residual accumulator to avoid spinning
+    // through millions of no-op iterations on a teleport).
+    const { entity, renderer } = buildEmitter(engine, "emit-returns-actual");
+    const generator = renderer.generator;
+    generator.main.maxParticles = 10;
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed);
+
+    // Request 100, buffer only has 10 slots.
+    //@ts-ignore — reach into the internal _emit contract
+    const emitted = generator._emit(generator._playTime, 100);
+    expect(emitted).to.eq(10);
+
+    // Subsequent request returns 0 — buffer is saturated.
+    //@ts-ignore
+    expect(generator._emit(generator._playTime, 5)).to.eq(0);
+
+    entity.destroy();
+  });
 });

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -301,6 +301,62 @@ describe("EmissionModule rateOverDistance", () => {
     entity.destroy();
   });
 
+  it("does not burst on play() after non-loop auto-stop with movement", () => {
+    // Auto-stop path: _update sets _isPlaying=false directly without going
+    // through stop(), so the old fix that invalidated baseline in stop() only
+    // missed this. play() resync must cover it.
+    const { entity, renderer } = buildEmitter(engine, "no-burst-on-autostop-replay");
+    const generator = renderer.generator;
+    generator.main.duration = 0.05; // 50ms — one 100ms tick pushes past it
+    generator.main.isLoop = false;
+    generator.emission.rateOverDistance.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // _playTime=0.1 > duration → auto-stops
+    expect(generator._getAliveParticleCount()).to.eq(0);
+    //@ts-ignore
+    expect((generator as any)._isPlaying).to.eq(false);
+
+    // Emitter moves while auto-stopped, then replay via play() (no stop call).
+    entity.transform.setPosition(3, 0, 0);
+    generator.play();
+
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount(), "auto-stop replay must resync, not burst 30").to.eq(0);
+
+    entity.destroy();
+  });
+
+  it("does not burst when emission.enabled is toggled off, moved, then on", () => {
+    // emission.enabled=false skips _emit entirely; toggling back to true must
+    // resync the baseline at the new position so the disabled interval doesn't
+    // count as emission distance.
+    const { entity, renderer } = buildEmitter(engine, "no-burst-on-enabled-toggle");
+    const generator = renderer.generator;
+    generator.main.duration = 100; // long-running, isolate from auto-stop
+    generator.main.isLoop = true;
+    generator.emission.rateOverDistance.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // baseline sync at (0,0,0)
+
+    generator.emission.enabled = false;
+    entity.transform.setPosition(3, 0, 0);
+    generator.emission.enabled = true;
+
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount(), "enabled toggle must resync, not burst 30").to.eq(0);
+
+    // Subsequent movement still emits normally.
+    entity.transform.setPosition(4, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(10);
+
+    entity.destroy();
+  });
+
   it("returns actual emitted count when buffer is full", () => {
     // Documents the `_emit` return-value contract that lets distance emission detect
     // mid-loop buffer exhaustion (and drop residual accumulator to avoid spinning

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -204,6 +204,46 @@ describe("EmissionModule rateOverDistance", () => {
     entity.destroy();
   });
 
+  it("distributes emit time along the movement path in World space", () => {
+    const { entity, renderer } = buildEmitter(engine, "world-space-time-distribution");
+    const generator = renderer.generator;
+    generator.main.simulationSpace = ParticleSimulationSpace.World;
+    // 1 particle per unit; move 4 units across one 100ms tick → 4 particles,
+    // each born at a sub-frame offset.
+    generator.emission.rateOverDistance.constant = 1;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    tick(engine, elapsed); // baseline sync at (0,0,0)
+    entity.transform.setPosition(4, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(4);
+
+    //@ts-ignore - reach into instance buffer to read per-particle emit time
+    const verts = (generator as any)._instanceVertices as Float32Array;
+    const stride = 42;
+    // a_DirectionTime is at byte 16 → float 4; the .w slot (emit time) is float 4+3=7.
+    const timeFloatOffset = 7;
+    const times: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      times.push(verts[i * stride + timeFloatOffset]);
+    }
+    times.sort((a, b) => a - b);
+
+    // The 4 emit times must form an arithmetic sequence (constant step = sStep * dt),
+    // and they must not all be equal — that's exactly the bug we're guarding against,
+    // where COL / SOL / FOL would otherwise render them as a uniform stamp.
+    const diff0 = times[1] - times[0];
+    const diff1 = times[2] - times[1];
+    const diff2 = times[3] - times[2];
+    expect(diff0).to.be.greaterThan(1e-4);
+    expect(diff1).to.be.closeTo(diff0, 1e-4);
+    expect(diff2).to.be.closeTo(diff0, 1e-4);
+
+    entity.destroy();
+  });
+
   it("does not burst on play() after emitter moves while stopped", () => {
     const { entity, renderer } = buildEmitter(engine, "no-burst-on-replay");
     const generator = renderer.generator;

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -4,6 +4,7 @@ import {
   Entity,
   ParticleMaterial,
   ParticleRenderer,
+  ParticleSimulationSpace,
   ParticleStopMode
 } from "@galacean/engine-core";
 import { Color, Vector3 } from "@galacean/engine-math";
@@ -163,6 +164,71 @@ describe("EmissionModule rateOverDistance", () => {
     tick(engine, elapsed);
     tick(engine, elapsed);
     expect(generator._getAliveParticleCount()).to.eq(0);
+
+    entity.destroy();
+  });
+
+  it("distributes particles along the movement path in World space", () => {
+    const { entity, renderer } = buildEmitter(engine, "world-space-distribution");
+    const generator = renderer.generator;
+    generator.main.simulationSpace = ParticleSimulationSpace.World;
+    // 1 particle per unit; move 4 units → 4 particles spaced at world x = 1, 2, 3, 4
+    generator.emission.rateOverDistance.constant = 1;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+
+    tick(engine, elapsed); // baseline sync at (0,0,0)
+
+    entity.transform.setPosition(4, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(4);
+
+    // Verify each particle's stored world position is along [0,4] on x axis, not all at x=4.
+    // Particles are written sequentially starting at firstActiveElement=0.
+    //@ts-ignore - test reaches into instance buffer to verify spatial distribution
+    const verts = (generator as any)._instanceVertices as Float32Array;
+    // Per-instance stride = 168 bytes / 4 = 42 floats; world position lives at offset 27.
+    const stride = 42;
+    const xs: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      xs.push(verts[i * stride + 27]);
+    }
+    xs.sort((a, b) => a - b);
+    // Expect roughly [1, 2, 3, 4] — accept loose tolerance for float ops.
+    expect(xs[0]).to.be.closeTo(1, 1e-4);
+    expect(xs[1]).to.be.closeTo(2, 1e-4);
+    expect(xs[2]).to.be.closeTo(3, 1e-4);
+    expect(xs[3]).to.be.closeTo(4, 1e-4);
+
+    entity.destroy();
+  });
+
+  it("does not burst on play() after emitter moves while stopped", () => {
+    const { entity, renderer } = buildEmitter(engine, "no-burst-on-replay");
+    const generator = renderer.generator;
+    generator.emission.rateOverDistance.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // baseline sync at (0,0,0)
+
+    // Stop *without* clear — accumulator/baseline retained by the old impl.
+    generator.stop(true, ParticleStopMode.StopEmitting);
+    // Emitter teleports a few units while stopped (kept inside the camera frustum
+    // so renderer culling doesn't mask the test).
+    entity.transform.setPosition(3, 0, 0);
+    generator.play();
+
+    // First tick after play() must resync the baseline at the new position,
+    // not diff (3 - 0) and dump 30 particles in one shot.
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(0);
+
+    // Subsequent movement still emits normally — diffed against the resynced baseline.
+    entity.transform.setPosition(4, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(10);
 
     entity.destroy();
   });

--- a/tests/src/core/particle/RateOverDistance.test.ts
+++ b/tests/src/core/particle/RateOverDistance.test.ts
@@ -323,4 +323,48 @@ describe("EmissionModule rateOverDistance", () => {
 
     entity.destroy();
   });
+
+  it("does not extrapolate past lastPos when a rate hike pays out previous carry", () => {
+    // Trigger: rate climbs between frames while the accumulator already carries
+    // sub-interval distance from the lower-rate era. The new emitInterval is
+    // small enough that `residual / moveLength > 1` after the count subtraction —
+    // initial subFrameAge clamps to 1.0, but a naive `+= ageStep` would let later
+    // iterations exceed 1 and extrapolate emitPos past lastPos in opposite
+    // direction of motion (and emitTime to before lastPlayTime).
+    const { entity, renderer } = buildEmitter(engine, "rate-hike-clamp");
+    const generator = renderer.generator;
+    generator.main.simulationSpace = ParticleSimulationSpace.World;
+    generator.emission.rateOverDistance.constant = 0.5; // interval = 2
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // baseline at (0,0,0)
+
+    // Move 1.5 units under low rate → accumulator carries 1.5, no emit.
+    entity.transform.setPosition(1.5, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(0);
+
+    // Bump rate: interval drops to 0.2. Tiny additional move (0.05) pushes
+    // accumulator to 1.55 → count = 7, residual ≈ 0.15, moveLength = 0.05,
+    // ratio = 3.0 (well above 1).
+    generator.emission.rateOverDistance.constant = 5;
+    entity.transform.setPosition(1.55, 0, 0);
+    tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(7);
+
+    //@ts-ignore - reach into instance buffer to verify positions stay in [lastPos, currentPos]
+    const verts = (generator as any)._instanceVertices as Float32Array;
+    const stride = 42;
+    for (let i = 0; i < 7; i++) {
+      const x = verts[i * stride + 27];
+      // Without the in-loop clamp this would be e.g. -1.0, -1.2, ... (extrapolated
+      // far behind lastPos.x = 1.5). With the clamp every particle lives within
+      // the legitimate frame window [lastPos.x, currentPos.x] = [1.5, 1.55].
+      expect(x).to.be.greaterThanOrEqual(1.5 - 1e-4);
+      expect(x).to.be.lessThanOrEqual(1.55 + 1e-4);
+    }
+
+    entity.destroy();
+  });
 });

--- a/tests/src/core/particle/RateOverTimeReplay.test.ts
+++ b/tests/src/core/particle/RateOverTimeReplay.test.ts
@@ -1,0 +1,145 @@
+import {
+  Camera,
+  Engine,
+  Entity,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleStopMode
+} from "@galacean/engine-core";
+import { Color } from "@galacean/engine-math";
+import { WebGLEngine } from "@galacean/engine";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+function tick(engine: Engine, times: { value: number }, deltaMs: number = 100): void {
+  //@ts-ignore
+  engine._vSyncCount = Infinity;
+  //@ts-ignore
+  engine._time._lastSystemTime = 0;
+  performance.now = function () {
+    times.value += deltaMs;
+    return times.value;
+  };
+  engine.update();
+}
+
+function buildEmitter(engine: Engine, name: string): { entity: Entity; renderer: ParticleRenderer } {
+  const scene = engine.sceneManager.activeScene;
+  const entity = scene.createRootEntity(name);
+  const renderer = entity.addComponent(ParticleRenderer);
+  const material = new ParticleMaterial(engine);
+  material.baseColor = new Color(1, 1, 1, 1);
+  renderer.setMaterial(material);
+
+  const generator = renderer.generator;
+  generator.useAutoRandomSeed = false;
+  generator.main.maxParticles = 1000;
+  generator.main.startLifetime.constant = 100;
+  generator.emission.rateOverTime.constant = 0;
+  generator.emission.rateOverDistance.constant = 0;
+  return { entity, renderer };
+}
+
+describe("EmissionModule rateOverTime replay/resume", () => {
+  let engine: Engine;
+  let elapsed: { value: number };
+
+  beforeAll(async function () {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+    const scene = engine.sceneManager.activeScene;
+    const cameraEntity = scene.createRootEntity("Camera");
+    cameraEntity.addComponent(Camera);
+    cameraEntity.transform.setPosition(0, 0, 10);
+    engine.run();
+    elapsed = { value: 0 };
+  });
+
+  afterAll(function () {
+    engine.destroy();
+  });
+
+  it("does not catch-up burst on play() after non-loop auto-stop", () => {
+    // _update advances _playTime every frame regardless of _isPlaying (the
+    // particle-retire path needs it). _frameRateTime was only reset by _reset
+    // (= stop(Clear)) before this fix. So auto-stop + waiting + bare play()
+    // used to unwind the entire stopped interval into a single-frame catch-up.
+    const { entity, renderer } = buildEmitter(engine, "rot-autostop-replay");
+    const generator = renderer.generator;
+    generator.main.duration = 0.05;
+    generator.main.isLoop = false;
+    generator.emission.rateOverTime.constant = 10; // 10/sec
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // first play; _playTime=0.1 > duration → auto-stops
+    const baseline = generator._getAliveParticleCount();
+    //@ts-ignore
+    expect((generator as any)._isPlaying).to.eq(false);
+
+    // 3 seconds of idle frames — _playTime keeps growing, _frameRateTime stuck.
+    for (let i = 0; i < 30; i++) tick(engine, elapsed);
+
+    generator.play();
+    tick(engine, elapsed);
+
+    // Without the fix this dumps ~30 catch-up particles in one frame.
+    const delta = generator._getAliveParticleCount() - baseline;
+    expect(delta, "auto-stop replay must not catch up the stopped interval").to.be.lessThan(5);
+
+    entity.destroy();
+  });
+
+  it("does not catch-up burst when rateOverTime flips 0 → N mid-play", () => {
+    // rate=0 for an interval: _emitByRateOverTime used to return without
+    // touching _frameRateTime. When rate flips back positive, cumulativeTime =
+    // playTime - _frameRateTime spans the rate-0 interval and unwinds it.
+    const { entity, renderer } = buildEmitter(engine, "rot-rate-transition");
+    const generator = renderer.generator;
+    generator.main.duration = 100;
+    generator.main.isLoop = true;
+    generator.emission.rateOverTime.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed); // emit ~1 particle
+    const baseline = generator._getAliveParticleCount();
+
+    // Drop rate to 0 for ~3 seconds.
+    generator.emission.rateOverTime.constant = 0;
+    for (let i = 0; i < 30; i++) tick(engine, elapsed);
+    expect(generator._getAliveParticleCount()).to.eq(baseline);
+
+    // Restore rate. The next tick must only contribute its own ~0.1s worth (~1 particle),
+    // not ~30 catch-up particles from the rate-0 interval.
+    generator.emission.rateOverTime.constant = 10;
+    tick(engine, elapsed);
+    const delta = generator._getAliveParticleCount() - baseline;
+    expect(delta, "rate 0→N must not unwind the rate-0 interval").to.be.lessThan(5);
+
+    entity.destroy();
+  });
+
+  it("does not catch-up burst when emission.enabled is toggled off → on", () => {
+    // Same root: emission.enabled=false skips _emit; toggling back to true
+    // must drop the stale _frameRateTime cursor too, not just the distance baseline.
+    const { entity, renderer } = buildEmitter(engine, "rot-enabled-toggle");
+    const generator = renderer.generator;
+    generator.main.duration = 100;
+    generator.main.isLoop = true;
+    generator.emission.rateOverTime.constant = 10;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    tick(engine, elapsed);
+    const baseline = generator._getAliveParticleCount();
+
+    generator.emission.enabled = false;
+    for (let i = 0; i < 30; i++) tick(engine, elapsed);
+    generator.emission.enabled = true;
+
+    tick(engine, elapsed);
+    const delta = generator._getAliveParticleCount() - baseline;
+    expect(delta, "enabled toggle must not unwind the disabled interval").to.be.lessThan(5);
+
+    entity.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

`EmissionModule.rateOverDistance` has been declared since the initial particle implementation but never consumed — only the time-based emission path ran. This wires it up.

Each frame the emitter samples its world position, accumulates the delta against the previous sample, and emits `ratePerUnit × distanceMoved` particles (Unity-aligned semantics). Sub-interval distance is carried across frames so long, fine-grained pulls integrate correctly.

## Implementation notes

- **Float-drift safe**: use `Math.floor(accumulator / interval + zeroTolerance)` + single subtraction, not a `while (acc >= interval)` loop. `2.0 - 19 * 0.1` style drift would otherwise drop a particle at exact boundaries (the unit test caught this).
- **Rate-flip safe**: when rate is `<= 0` or the baseline position is uninitialized, sync the position and drop the accumulator. A later `0 → N` rate flip starts fresh from the current position instead of dumping pre-flip frames of movement into a burst.
- **`_reset` clears state**: stop(StopEmittingAndClear) → play re-syncs from the current emitter position.

## Test plan

- [x] Unit test `RateOverDistance.test.ts` (5 cases): default-zero, ratePerUnit×distance, sub-interval accumulation, static-emitter no-emit, stop+clear reset
- [x] e2e `particleRenderer-rateOverDistance`: World-space emitter sweeps horizontally with `rateOverTime=0` and `rateOverDistance=2`, leaving a deterministic particle trail; baseline captured
- [x] Full particle test suite (82/82) passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emitters can spawn particles based on travel distance, placing particles along motion in world space.
  * Particle visuals: alpha fades in/out and size shrinks over lifetime.
  * Deterministic orbital emitter motion and reproducible seeding; textures load asynchronously for the particle case.

* **Bug Fixes**
  * Stopping/replaying emitters now properly resets distance baselines to prevent unexpected bursts.

* **Tests**
  * Added E2E and unit tests for distance-based emission, accumulation, reset/replay, and rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galacean/engine/pull/3011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->