### PR TITLE
fix(particle): stop CustomDataModule from false-rejecting stream names by prefix

### DIFF
--- a/packages/core/src/particle/modules/CustomDataModule.ts
+++ b/packages/core/src/particle/modules/CustomDataModule.ts
@@ -47,7 +47,6 @@ interface GradientStream {
  */
 export class CustomDataModule extends ParticleGeneratorModule {
   private static readonly _streamNamePattern = /^[A-Za-z0-9_]+$/;
-  private static readonly _reservedPrefixPattern = /^(?:VOL|FOL|SOL|COL|ROL|TSA|LVL)/;
   private static readonly _zeroCurveArray = new Float32Array(8);
   private static readonly _zeroGradientColorArray = new Float32Array(16);
   private static readonly _zeroGradientAlphaArray = new Float32Array(8);
@@ -302,13 +301,6 @@ export class CustomDataModule extends ParticleGeneratorModule {
     if (!CustomDataModule._streamNamePattern.test(name)) {
       Logger.error(
         `CustomDataModule.${method}: "${name}" must contain only letters, digits, or underscores; call ignored.`
-      );
-      return false;
-    }
-    if (CustomDataModule._reservedPrefixPattern.test(name)) {
-      Logger.error(
-        `CustomDataModule.${method}: "${name}" starts with a reserved engine particle module prefix ` +
-          `(VOL/FOL/SOL/COL/ROL/TSA/LVL) and would collide with built-in uniforms; call ignored.`
       );
       return false;
     }

--- a/tests/src/core/particle/CustomData.test.ts
+++ b/tests/src/core/particle/CustomData.test.ts
@@ -122,20 +122,18 @@ describe("CustomDataModule", function () {
     expect(customData.curves.size).to.eq(2);
   });
 
-  it("addCurve / addGradient reject names that collide with engine particle module namespaces", function () {
+  it("accepts names that merely start with an engine module prefix (no false rejection)", function () {
+    // Validation only checks the character set and duplicate names — it does NOT
+    // reject by prefix. Names like "COLOR" / "VOLUME" generate `renderer_COLOR...` /
+    // `renderer_VOLUME...`, which never equal an engine uniform (`renderer_COL...` /
+    // `renderer_VOL...`), so they must be accepted.
     const customData = particleRenderer.generator.customData;
-    Logger.enable();
-    // Bare prefixes (exact collision with module's MaxConst/MaxGradient*…)
-    customData.addCurve("VOL", new ParticleCompositeCurve(0));
-    customData.addGradient("COL", new ParticleCompositeGradient(new Color()));
-    // Suffix-extended also rejected (`FOLSpeedMaxConst` collides with FOL's existing uniform space)
+    customData.addCurve("COLOR", new ParticleCompositeCurve(0));
+    customData.addCurve("VOLUME", new ParticleCompositeCurve(0));
+    customData.addCurve("SOLID", new ParticleCompositeCurve(0));
+    customData.addCurve("ROLL", new ParticleCompositeCurve(0));
     customData.addCurve("FOLSpeed", new ParticleCompositeCurve(0));
-    customData.addGradient("TSAFrame", new ParticleCompositeGradient(new Color()));
-    expect(customData.curves.size).to.eq(0);
-    expect(customData.gradients.size).to.eq(0);
-    // Names that merely happen to contain the substring are NOT rejected — only the leading prefix matters.
-    customData.addCurve("MyVOL", new ParticleCompositeCurve(0));
-    expect(customData.curves.size).to.eq(1);
+    expect(customData.curves.size).to.eq(5);
   });
 
   it("addCurve rejects duplicate name (cross with gradients)", function () {
@@ -208,10 +206,7 @@ describe("CustomDataModule", function () {
     customData.enabled = true;
     customData.addCurve("C1", new ParticleCompositeCurve(1));
     customData.addCurve("C2", new ParticleCompositeCurve(1, 5));
-    customData.addCurve(
-      "C3",
-      new ParticleCompositeCurve(new ParticleCurve(new CurveKey(0, 0), new CurveKey(1, 1)))
-    );
+    customData.addCurve("C3", new ParticleCompositeCurve(new ParticleCurve(new CurveKey(0, 0), new CurveKey(1, 1))));
     customData.addCurve(
       "C4",
       new ParticleCompositeCurve(
@@ -231,10 +226,7 @@ describe("CustomDataModule", function () {
     const customData = particleRenderer.generator.customData;
     customData.enabled = true;
     customData.addGradient("G1", new ParticleCompositeGradient(new Color(1, 0.5, 0.25, 1)));
-    customData.addGradient(
-      "G2",
-      new ParticleCompositeGradient(new Color(0, 0, 0, 1), new Color(1, 1, 1, 1))
-    );
+    customData.addGradient("G2", new ParticleCompositeGradient(new Color(0, 0, 0, 1), new Color(1, 1, 1, 1)));
     expect(customData.gradients.get("G2")!.mode).to.eq(ParticleGradientMode.TwoConstants);
     expect(() => {
       //@ts-ignore


### PR DESCRIPTION
## Summary

Follow-up to #3004. `CustomDataModule._validateName` rejected any stream name that **starts with** an engine particle module prefix (`VOL` / `FOL` / `SOL` / `COL` / `ROL` / `TSA` / `LVL`) via a `_reservedPrefixPattern` regex. But the real collision condition is that the **generated** uniform name `renderer_<name><suffix>` is character-for-character equal to an existing engine uniform — not that the name merely begins with those letters.

A user adding a color stream named `"COLOR"`:

```ts
customData.addGradient("COLOR", myGradient);
```

generates `renderer_COLORMaxGradientColor` etc., which never equal the engine's `renderer_COLMaxGradientColor` (`COLOR…` vs `COL…`, zero overlap). Yet the old check matched `"COLOR"` against `/^COL/`, rejected it, and the stream was **never created** — the custom shader then read all-zero uniforms with no exception thrown, only a `Logger.error`. Same false rejection for `VOLUME`, `SOLID`, `ROLL`, `FOLSpeed`, and any other natural name starting with those three letters.

## Fix

Drop the prefix blacklist entirely. It was both:
- **too wide** — false-rejecting common names like `COLOR` / `VOLUME`, and
- **a second source of truth** that drifts whenever engine particle uniforms change.

`_validateName` now checks only the GLSL character set and duplicate names. The handful of names that genuinely collide are exact whole-name matches of a module prefix (literally `"VOL"` / `"COL"` / …), which are unnatural stream names; that's left to documentation rather than an over-broad runtime guard.

## Test plan

- [x] `tests/src/core/particle/` — 112/112 pass
- [x] Reworked the collision test: it now asserts `COLOR` / `VOLUME` / `SOLID` / `ROLL` / `FOLSpeed` are all **accepted** (was previously asserting they're rejected)
- [x] `npm run b:module` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Simplified custom data name validation to be more permissive. Naming patterns previously rejected are now accepted, provided entries use valid characters and remain unique within their collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->