### PR TITLE
fix(particle): mesh not applied via setter when cloning ParticleRenderer

### DIFF
--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -623,6 +623,7 @@ export class ParticleGenerator {
    */
   _updateShaderData(shaderData: ShaderData): void {
     this.main._updateShaderData(shaderData);
+    this.emission._updateShaderData(shaderData);
     this.velocityOverLifetime._updateShaderData(shaderData);
     this.forceOverLifetime._updateShaderData(shaderData);
     this.limitVelocityOverLifetime._updateShaderData(shaderData);

--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -93,6 +93,7 @@ export class ParticleGenerator {
   readonly customData: CustomDataModule;
 
   /** @internal */
+  @ignoreClone
   _currentParticleCount = 0;
   /** @internal */
   @ignoreClone

--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -623,7 +623,6 @@ export class ParticleGenerator {
    */
   _updateShaderData(shaderData: ShaderData): void {
     this.main._updateShaderData(shaderData);
-    this.emission._updateShaderData(shaderData);
     this.velocityOverLifetime._updateShaderData(shaderData);
     this.forceOverLifetime._updateShaderData(shaderData);
     this.limitVelocityOverLifetime._updateShaderData(shaderData);

--- a/packages/core/src/particle/ParticleGenerator.ts
+++ b/packages/core/src/particle/ParticleGenerator.ts
@@ -412,6 +412,9 @@ export class ParticleGenerator {
 
     if (renderer.renderMode === ParticleRenderMode.Mesh) {
       const { mesh } = renderer;
+      if (!mesh) {
+        return;
+      }
       const positionElement = mesh.getVertexElement(VertexAttribute.Position);
       const colorElement = mesh.getVertexElement(VertexAttribute.Color);
       const uvElement = mesh.getVertexElement(VertexAttribute.UV);

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -272,8 +272,8 @@ export class ParticleRenderer extends Renderer {
    */
   override _cloneTo(target: ParticleRenderer): void {
     super._cloneTo(target);
-    target.renderMode = this._renderMode;
     target.mesh = this._mesh;
+    target.renderMode = this._renderMode;
     target.generator.emission._updateShapeMacro();
   }
 

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -49,7 +49,9 @@ export class ParticleRenderer extends Renderer {
   @ignoreClone
   private _mesh: ModelMesh;
 
+  @ignoreClone
   private _renderMode: ParticleRenderMode = ParticleRenderMode.Billboard;
+  @ignoreClone
   private _currentRenderModeMacro: ShaderMacro;
   private _supportInstancedArrays: boolean;
 
@@ -95,9 +97,7 @@ export class ParticleRenderer extends Renderer {
       const wasMeshMode = lastRenderMode === ParticleRenderMode.Mesh;
       const isMeshMode = value === ParticleRenderMode.Mesh;
       if (wasMeshMode !== isMeshMode) {
-        if (!isMeshMode || this.mesh) {
-          this.generator._reorganizeGeometryBuffers();
-        }
+        this.generator._reorganizeGeometryBuffers();
       }
     }
   }
@@ -272,6 +272,7 @@ export class ParticleRenderer extends Renderer {
    */
   override _cloneTo(target: ParticleRenderer): void {
     super._cloneTo(target);
+    target.renderMode = this._renderMode;
     target.mesh = this._mesh;
   }
 

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -274,6 +274,7 @@ export class ParticleRenderer extends Renderer {
     super._cloneTo(target);
     target.renderMode = this._renderMode;
     target.mesh = this._mesh;
+    target.generator.emission._updateShapeMacro();
   }
 
   /**

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -46,10 +46,11 @@ export class ParticleRenderer extends Renderer {
   /** @internal */
   @ignoreClone
   _transformedBounds = new BoundingBox();
+  @ignoreClone
+  private _mesh: ModelMesh;
 
   private _renderMode: ParticleRenderMode = ParticleRenderMode.Billboard;
   private _currentRenderModeMacro: ShaderMacro;
-  private _mesh: ModelMesh;
   private _supportInstancedArrays: boolean;
 
   /**
@@ -264,6 +265,14 @@ export class ParticleRenderer extends Renderer {
     }
     super._onDestroy();
     this.generator._destroy();
+  }
+
+  /**
+   * @internal
+   */
+  override _cloneTo(target: ParticleRenderer): void {
+    super._cloneTo(target);
+    target.mesh = this._mesh;
   }
 
   /**

--- a/packages/core/src/particle/ParticleRenderer.ts
+++ b/packages/core/src/particle/ParticleRenderer.ts
@@ -274,7 +274,6 @@ export class ParticleRenderer extends Renderer {
     super._cloneTo(target);
     target.mesh = this._mesh;
     target.renderMode = this._renderMode;
-    target.generator.emission._updateShapeMacro();
   }
 
   /**

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -1,6 +1,6 @@
 import { MathUtil, Rand, Vector3 } from "@galacean/engine-math";
 import { deepClone, ignoreClone } from "../../clone/CloneManager";
-import { ShaderMacro } from "../../shader/ShaderMacro";
+import { ShaderData, ShaderMacro } from "../../shader";
 import { ParticleRandomSubSeeds } from "../enums/ParticleRandomSubSeeds";
 import { ParticleSimulationSpace } from "../enums/ParticleSimulationSpace";
 import { Burst } from "./Burst";
@@ -29,6 +29,9 @@ export class EmissionModule extends ParticleGeneratorModule {
   /** @internal */
   @ignoreClone
   _shapeRand = new Rand(0, ParticleRandomSubSeeds.Shape);
+
+  @ignoreClone
+  private _shapeMacro: ShaderMacro;
   /** @internal */
   _frameRateTime: number = 0;
 
@@ -60,11 +63,6 @@ export class EmissionModule extends ParticleGeneratorModule {
         this._resyncCursors(this._generator._playTime);
       }
       this._enabled = value;
-      if (value && this._shape) {
-        this._generator._renderer.shaderData.enableMacro(EmissionModule._emissionShapeMacro);
-      } else {
-        this._generator._renderer.shaderData.disableMacro(EmissionModule._emissionShapeMacro);
-      }
     }
   }
 
@@ -82,13 +80,7 @@ export class EmissionModule extends ParticleGeneratorModule {
 
       const renderer = this._generator._renderer;
       lastShape?._unRegisterOnValueChanged(renderer._onGeneratorParamsChanged);
-
-      if (value) {
-        value._registerOnValueChanged(renderer._onGeneratorParamsChanged);
-        this.enabled && renderer.shaderData.enableMacro(EmissionModule._emissionShapeMacro);
-      } else {
-        renderer.shaderData.disableMacro(EmissionModule._emissionShapeMacro);
-      }
+      value?._registerOnValueChanged(renderer._onGeneratorParamsChanged);
 
       renderer._onGeneratorParamsChanged();
     }
@@ -145,6 +137,14 @@ export class EmissionModule extends ParticleGeneratorModule {
     this._emitByRateOverTime(playTime);
     this._emitByRateOverDistance(lastPlayTime, playTime);
     this._emitByBurst(lastPlayTime, playTime);
+  }
+
+  /**
+   * @internal
+   */
+  _updateShaderData(shaderData: ShaderData): void {
+    const shapeMacro = this._enabled && this._shape ? EmissionModule._emissionShapeMacro : null;
+    this._shapeMacro = this._enableMacro(shaderData, this._shapeMacro, shapeMacro);
   }
 
   /**

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -1,6 +1,6 @@
 import { MathUtil, Rand, Vector3 } from "@galacean/engine-math";
 import { deepClone, ignoreClone } from "../../clone/CloneManager";
-import { ShaderMacro } from "../../shader";
+import { ShaderData, ShaderMacro } from "../../shader";
 import { ParticleRandomSubSeeds } from "../enums/ParticleRandomSubSeeds";
 import { ParticleSimulationSpace } from "../enums/ParticleSimulationSpace";
 import { Burst } from "./Burst";
@@ -63,7 +63,6 @@ export class EmissionModule extends ParticleGeneratorModule {
         this._resyncCursors(this._generator._playTime);
       }
       this._enabled = value;
-      this._updateShapeMacro();
     }
   }
 
@@ -83,7 +82,6 @@ export class EmissionModule extends ParticleGeneratorModule {
       lastShape?._unRegisterOnValueChanged(renderer._onGeneratorParamsChanged);
       value?._registerOnValueChanged(renderer._onGeneratorParamsChanged);
 
-      this._updateShapeMacro();
       renderer._onGeneratorParamsChanged();
     }
   }
@@ -144,17 +142,9 @@ export class EmissionModule extends ParticleGeneratorModule {
   /**
    * @internal
    */
-  _updateShapeMacro(): void {
-    const shaderData = this._generator._renderer.shaderData;
+  _updateShaderData(shaderData: ShaderData): void {
     const shapeMacro = this._enabled && this._shape ? EmissionModule._emissionShapeMacro : null;
     this._shapeMacro = this._enableMacro(shaderData, this._shapeMacro, shapeMacro);
-  }
-
-  /**
-   * @internal
-   */
-  _cloneTo(target: EmissionModule): void {
-    target._updateShapeMacro();
   }
 
   /**

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -153,6 +153,13 @@ export class EmissionModule extends ParticleGeneratorModule {
   /**
    * @internal
    */
+  _cloneTo(target: EmissionModule): void {
+    target._updateShapeMacro();
+  }
+
+  /**
+   * @internal
+   */
   _resetRandomSeed(seed: number): void {
     this._burstRand.reset(seed, ParticleRandomSubSeeds.Burst);
     this._shapeRand.reset(seed, ParticleRandomSubSeeds.Shape);

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -1,6 +1,6 @@
 import { MathUtil, Rand, Vector3 } from "@galacean/engine-math";
 import { deepClone, ignoreClone } from "../../clone/CloneManager";
-import { ShaderData, ShaderMacro } from "../../shader";
+import { ShaderMacro } from "../../shader";
 import { ParticleRandomSubSeeds } from "../enums/ParticleRandomSubSeeds";
 import { ParticleSimulationSpace } from "../enums/ParticleSimulationSpace";
 import { Burst } from "./Burst";
@@ -63,6 +63,7 @@ export class EmissionModule extends ParticleGeneratorModule {
         this._resyncCursors(this._generator._playTime);
       }
       this._enabled = value;
+      this._updateShapeMacro();
     }
   }
 
@@ -82,6 +83,7 @@ export class EmissionModule extends ParticleGeneratorModule {
       lastShape?._unRegisterOnValueChanged(renderer._onGeneratorParamsChanged);
       value?._registerOnValueChanged(renderer._onGeneratorParamsChanged);
 
+      this._updateShapeMacro();
       renderer._onGeneratorParamsChanged();
     }
   }
@@ -142,7 +144,8 @@ export class EmissionModule extends ParticleGeneratorModule {
   /**
    * @internal
    */
-  _updateShaderData(shaderData: ShaderData): void {
+  _updateShapeMacro(): void {
+    const shaderData = this._generator._renderer.shaderData;
     const shapeMacro = this._enabled && this._shape ? EmissionModule._emissionShapeMacro : null;
     this._shapeMacro = this._enableMacro(shaderData, this._shapeMacro, shapeMacro);
   }

--- a/tests/src/core/particle/ParticleRenderer.test.ts
+++ b/tests/src/core/particle/ParticleRenderer.test.ts
@@ -1,6 +1,31 @@
-import { Camera, ModelMesh, ParticleRenderer, ParticleRenderMode, PrimitiveMesh, Scene } from "@galacean/engine-core";
+import {
+  Camera,
+  Engine,
+  ModelMesh,
+  ParticleRenderer,
+  ParticleRenderMode,
+  ParticleSimulationSpace,
+  PrimitiveMesh,
+  Scene,
+  ShaderMacro
+} from "@galacean/engine-core";
 import { WebGLEngine } from "@galacean/engine";
 import { beforeAll, describe, expect, it } from "vitest";
+
+function updateEngine(engine: Engine, frames: number, deltaTime = 100) {
+  //@ts-ignore
+  engine._vSyncCount = Infinity;
+  //@ts-ignore
+  engine._time._lastSystemTime = 0;
+  let times = 0;
+  performance.now = function () {
+    times++;
+    return times * deltaTime;
+  };
+  for (let i = 0; i < frames; i++) {
+    engine.update();
+  }
+}
 
 describe("ParticleRenderer", () => {
   let engine: WebGLEngine;
@@ -111,6 +136,38 @@ describe("ParticleRenderer", () => {
     expect(mesh.refCount).to.eq(0);
   });
 
+  it("clone applies render mode macro and mesh layout together", () => {
+    const meshMacro = ShaderMacro.getByName("RENDERER_MODE_MESH");
+    const billboardMacro = ShaderMacro.getByName("RENDERER_MODE_SPHERE_BILLBOARD");
+
+    // Mesh mode + noise triggers buffer reorganization mid-clone, before mesh is applied
+    const entity = scene.createRootEntity("CloneMacroSource");
+    const renderer = entity.addComponent(ParticleRenderer);
+    const mesh = PrimitiveMesh.createCuboid(engine);
+    renderer.renderMode = ParticleRenderMode.Mesh;
+    renderer.mesh = mesh;
+    renderer.generator.noise.enabled = true;
+
+    let cloneEntity: typeof entity;
+    expect(() => {
+      cloneEntity = entity.clone();
+      scene.addRootEntity(cloneEntity);
+    }).not.to.throw();
+
+    const cloneRenderer = cloneEntity.getComponent(ParticleRenderer);
+    expect(cloneRenderer.renderMode).to.eq(ParticleRenderMode.Mesh);
+    expect(cloneRenderer.mesh).to.eq(mesh);
+    expect(mesh.refCount).to.eq(2);
+    // Shader macro must match renderMode, not stay on the constructor's billboard default
+    const macroCollection = cloneRenderer.shaderData["_macroCollection"];
+    expect(macroCollection.isEnable(meshMacro)).to.eq(true);
+    expect(macroCollection.isEnable(billboardMacro)).to.eq(false);
+
+    cloneEntity.destroy();
+    entity.destroy();
+    expect(mesh.refCount).to.eq(0);
+  });
+
   it("clone with mesh render mode but no mesh", () => {
     const entity = scene.createRootEntity("CloneSourceNoMesh");
     const renderer = entity.addComponent(ParticleRenderer);
@@ -138,6 +195,69 @@ describe("ParticleRenderer", () => {
       renderer.generator.noise.enabled = false;
     }).not.to.throw();
 
+    entity.destroy();
+  });
+
+  it("clone a grown particle system keeps capacity consistent", () => {
+    const entity = scene.createRootEntity("GrownSource");
+    const renderer = entity.addComponent(ParticleRenderer);
+    const generator = renderer.generator;
+    generator.main.maxParticles = 1000;
+    generator.main.startLifetime.constant = 100;
+    generator.emission.rateOverTime.constant = 500;
+    generator.play();
+
+    // Drive the simulation so the instance buffer grows well past its initial capacity
+    updateEngine(engine, 30, 100);
+    const sourceCount = generator["_currentParticleCount"];
+    expect(sourceCount).to.be.greaterThan(128);
+
+    const cloneEntity = entity.clone();
+    scene.addRootEntity(cloneEntity);
+    const cloneGenerator = cloneEntity.getComponent(ParticleRenderer).generator;
+
+    // The clone starts with a freshly built buffer; it must not inherit the source's grown count,
+    // otherwise the capacity and the actual buffer length disagree and emitting overflows
+    expect(cloneGenerator["_currentParticleCount"]).to.be.lessThan(sourceCount);
+
+    // The clone can play and grow on its own without crashing on the stale capacity
+    expect(() => {
+      cloneGenerator.play();
+      updateEngine(engine, 30, 100);
+    }).not.to.throw();
+
+    cloneEntity.destroy();
+    entity.destroy();
+  });
+
+  it("clone preserves generator module config", () => {
+    const entity = scene.createRootEntity("ConfigSource");
+    const generator = entity.addComponent(ParticleRenderer).generator;
+
+    // Spread config across several @deepClone modules and value kinds (scalar / bool / enum / curve / module enabled)
+    generator.main.duration = 7.5;
+    generator.main.isLoop = false;
+    generator.main.simulationSpace = ParticleSimulationSpace.World;
+    generator.main.startLifetime.constant = 3;
+    generator.emission.rateOverTime.constant = 42;
+    generator.noise.enabled = true;
+    generator.noise.frequency = 1.5;
+
+    const cloneEntity = entity.clone();
+    const cloneGenerator = cloneEntity.getComponent(ParticleRenderer).generator;
+
+    expect(cloneGenerator.main.duration).to.eq(7.5);
+    expect(cloneGenerator.main.isLoop).to.eq(false);
+    expect(cloneGenerator.main.simulationSpace).to.eq(ParticleSimulationSpace.World);
+    expect(cloneGenerator.main.startLifetime.constant).to.eq(3);
+    expect(cloneGenerator.emission.rateOverTime.constant).to.eq(42);
+    expect(cloneGenerator.noise.enabled).to.eq(true);
+    expect(cloneGenerator.noise.frequency).to.eq(1.5);
+
+    // Cloned config curves must be independent instances, not shared with the source
+    expect(cloneGenerator.main.startLifetime).to.not.eq(generator.main.startLifetime);
+
+    cloneEntity.destroy();
     entity.destroy();
   });
 });

--- a/tests/src/core/particle/ParticleRenderer.test.ts
+++ b/tests/src/core/particle/ParticleRenderer.test.ts
@@ -279,8 +279,9 @@ describe("ParticleRenderer", () => {
     expect(cloneRenderer.generator.emission.shape).to.not.eq(renderer.generator.emission.shape);
     expect(cloneRenderer.generator.emission.shape).to.be.instanceOf(BoxShape);
 
-    // The macro is re-applied once during clone, so the clone's shaderData carries the emission
-    // shape macro immediately instead of staying on the constructor default or needing a frame
+    // The macro is derived every frame from `enabled && shape`, so after a frame the clone's
+    // shaderData carries the emission shape macro instead of staying on the constructor default
+    updateEngine(engine, 2, 100);
     expect(cloneRenderer.shaderData["_macroCollection"].isEnable(emissionShapeMacro)).to.eq(true);
 
     cloneEntity.destroy();

--- a/tests/src/core/particle/ParticleRenderer.test.ts
+++ b/tests/src/core/particle/ParticleRenderer.test.ts
@@ -1,4 +1,4 @@
-import { Camera, ModelMesh, ParticleRenderer, ParticleRenderMode, Scene } from "@galacean/engine-core";
+import { Camera, ModelMesh, ParticleRenderer, ParticleRenderMode, PrimitiveMesh, Scene } from "@galacean/engine-core";
 import { WebGLEngine } from "@galacean/engine";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -87,5 +87,57 @@ describe("ParticleRenderer", () => {
 
     mesh.destroy(true);
     expect(mesh.refCount).to.eq(0);
+  });
+
+  it("clone with mesh render mode", () => {
+    const entity = scene.createRootEntity("CloneSource");
+    const renderer = entity.addComponent(ParticleRenderer);
+    const mesh = PrimitiveMesh.createCuboid(engine);
+    renderer.renderMode = ParticleRenderMode.Mesh;
+    renderer.mesh = mesh;
+    expect(mesh.refCount).to.eq(1);
+
+    const cloneEntity = entity.clone();
+    scene.addRootEntity(cloneEntity);
+    const cloneRenderer = cloneEntity.getComponent(ParticleRenderer);
+    expect(cloneRenderer.renderMode).to.eq(ParticleRenderMode.Mesh);
+    expect(cloneRenderer.mesh).to.eq(mesh);
+    expect(mesh.refCount).to.eq(2);
+
+    // Each renderer holds its own reference, destroying one should not release the other's
+    cloneEntity.destroy();
+    expect(mesh.refCount).to.eq(1);
+    entity.destroy();
+    expect(mesh.refCount).to.eq(0);
+  });
+
+  it("clone with mesh render mode but no mesh", () => {
+    const entity = scene.createRootEntity("CloneSourceNoMesh");
+    const renderer = entity.addComponent(ParticleRenderer);
+    renderer.renderMode = ParticleRenderMode.Mesh;
+
+    expect(() => {
+      const cloneEntity = entity.clone();
+      const cloneRenderer = cloneEntity.getComponent(ParticleRenderer);
+      expect(cloneRenderer.renderMode).to.eq(ParticleRenderMode.Mesh);
+      expect(cloneRenderer.mesh).to.be.undefined;
+      cloneEntity.destroy();
+    }).not.to.throw();
+
+    entity.destroy();
+  });
+
+  it("reorganize geometry buffers with mesh render mode but no mesh", () => {
+    const entity = scene.createRootEntity("NoMeshReorganize");
+    const renderer = entity.addComponent(ParticleRenderer);
+    renderer.renderMode = ParticleRenderMode.Mesh;
+
+    // Toggling noise module triggers buffer reorganization, which must tolerate a null mesh
+    expect(() => {
+      renderer.generator.noise.enabled = true;
+      renderer.generator.noise.enabled = false;
+    }).not.to.throw();
+
+    entity.destroy();
   });
 });

--- a/tests/src/core/particle/ParticleRenderer.test.ts
+++ b/tests/src/core/particle/ParticleRenderer.test.ts
@@ -279,9 +279,8 @@ describe("ParticleRenderer", () => {
     expect(cloneRenderer.generator.emission.shape).to.not.eq(renderer.generator.emission.shape);
     expect(cloneRenderer.generator.emission.shape).to.be.instanceOf(BoxShape);
 
-    // The macro is derived every frame from `enabled && shape`, so after a frame the clone's
-    // shaderData carries the emission shape macro instead of staying on the constructor default
-    updateEngine(engine, 2, 100);
+    // The macro is re-applied once during clone, so the clone's shaderData carries the emission
+    // shape macro immediately instead of staying on the constructor default or needing a frame
     expect(cloneRenderer.shaderData["_macroCollection"].isEnable(emissionShapeMacro)).to.eq(true);
 
     cloneEntity.destroy();

--- a/tests/src/core/particle/ParticleRenderer.test.ts
+++ b/tests/src/core/particle/ParticleRenderer.test.ts
@@ -1,4 +1,5 @@
 import {
+  BoxShape,
   Camera,
   Engine,
   ModelMesh,
@@ -256,6 +257,32 @@ describe("ParticleRenderer", () => {
 
     // Cloned config curves must be independent instances, not shared with the source
     expect(cloneGenerator.main.startLifetime).to.not.eq(generator.main.startLifetime);
+
+    cloneEntity.destroy();
+    entity.destroy();
+  });
+
+  it("clone keeps emission shape macro in sync", () => {
+    const emissionShapeMacro = ShaderMacro.getByName("RENDERER_EMISSION_SHAPE");
+
+    const entity = scene.createRootEntity("EmissionShapeSource");
+    const renderer = entity.addComponent(ParticleRenderer);
+    renderer.generator.emission.shape = new BoxShape();
+    renderer.generator.emission.rateOverTime.constant = 100;
+    renderer.generator.play();
+
+    const cloneEntity = entity.clone();
+    scene.addRootEntity(cloneEntity);
+    const cloneRenderer = cloneEntity.getComponent(ParticleRenderer);
+
+    // Shape value is deep cloned into an independent instance
+    expect(cloneRenderer.generator.emission.shape).to.not.eq(renderer.generator.emission.shape);
+    expect(cloneRenderer.generator.emission.shape).to.be.instanceOf(BoxShape);
+
+    // The macro is derived every frame from `enabled && shape`, so after a frame the clone's
+    // shaderData carries the emission shape macro instead of staying on the constructor default
+    updateEngine(engine, 2, 100);
+    expect(cloneRenderer.shaderData["_macroCollection"].isEnable(emissionShapeMacro)).to.eq(true);
 
     cloneEntity.destroy();
     entity.destroy();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix.

### What is the current behavior? (You can also link to an open issue here)

When cloning an entity with a `ParticleRenderer` in `Mesh` render mode:

1. `_mesh` was an undecorated private field, so the clone system copied it by direct assignment, bypassing the `mesh` setter. As a result the mesh's resource refCount was never incremented for the clone, while `_onDestroy` still decremented it — destroying the clone could release the mesh while the original renderer is still using it. The clone's geometry buffers were also never reorganized for mesh mode.
2. `ParticleGenerator._reorganizeGeometryBuffers()` crashed with a null dereference when invoked in `Mesh` render mode before a mesh is assigned (e.g. triggered by toggling the noise / limit-velocity module via `_setTransformFeedback()`).

### What is the new behavior (if this is a feature change)?

- `_mesh` is marked `@ignoreClone` and `ParticleRenderer._cloneTo` assigns `target.mesh = this._mesh` through the setter — same pattern as `MeshRenderer` — so refCount, sub-mesh validation and geometry buffer reorganization are handled correctly.
- `_reorganizeGeometryBuffers()` early-returns when render mode is `Mesh` but no mesh is assigned (rendering already guards this case in `ParticleRenderer._render`).

Added unit tests covering: mesh-mode clone (mesh reference + refCount lifecycle), mesh-mode clone without mesh, and buffer reorganization with a null mesh. Each test was verified to fail against the unfixed build.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mesh render mode handling when no mesh is assigned, avoiding crashes during render-state transitions.
  * Improved mesh-mode renderer cloning to preserve render mode, mesh identity, and independent cleanup behavior.
  * Ensured cloning is resilient when mesh data is missing.
  * Generator configuration cloning no longer shares nested custom data instances.

* **Refactor**
  * Centralized emission-shape shader macro updates for consistent rendering and clone behavior.

* **Tests**
  * Added deterministic engine stepping and expanded mesh-mode clone regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->