### PR TITLE
feat(particle): support curve modes for emission rateOverTime and rateOverDistance

### DIFF
--- a/packages/core/src/particle/enums/ParticleRandomSubSeeds.ts
+++ b/packages/core/src/particle/enums/ParticleRandomSubSeeds.ts
@@ -19,5 +19,6 @@ export enum ParticleRandomSubSeeds {
   GravityModifier = 0xa47b8c4d,
   ForceOverLifetime = 0xe6fb937c,
   LimitVelocityOverLifetime = 0xb5a21f7e,
-  Noise = 0xf4b2c8a1
+  Noise = 0xf4b2c8a1,
+  EmissionRate = 0x9c83f2d5
 }

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -179,19 +179,16 @@ export class EmissionModule extends ParticleGeneratorModule {
     const { rateOverTime, _generator: generator } = this;
 
     let cumulativeTime = playTime - this._frameRateTime;
-    while (true) {
-      // Re-sample inside the loop so a time-varying curve is integrated at each emit cursor
-      const ratePerSeconds = this._evaluateRate(rateOverTime, this._frameRateTime);
-      if (ratePerSeconds <= 0) {
-        this._frameRateTime = playTime;
-        return;
-      }
+    let ratePerSeconds = this._evaluateRate(rateOverTime, this._frameRateTime);
+    while (ratePerSeconds > 0) {
       const emitInterval = 1.0 / ratePerSeconds;
-      if (cumulativeTime < emitInterval) break;
+      if (cumulativeTime < emitInterval) return;
       cumulativeTime -= emitInterval;
       this._frameRateTime += emitInterval;
       generator._emit(this._frameRateTime, 1);
+      ratePerSeconds = this._evaluateRate(rateOverTime, this._frameRateTime);
     }
+    this._frameRateTime = playTime;
   }
 
   private _emitByRateOverDistance(lastPlayTime: number, playTime: number): void {

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -177,15 +177,12 @@ export class EmissionModule extends ParticleGeneratorModule {
 
   private _emitByRateOverTime(playTime: number): void {
     const { rateOverTime, _generator: generator } = this;
-    const isConstant = rateOverTime.mode === ParticleCurveMode.Constant;
-    const duration = generator.main.duration;
 
     let cumulativeTime = playTime - this._frameRateTime;
     while (true) {
-      const ratePerSeconds = isConstant
-        ? rateOverTime.constant
-        : rateOverTime.evaluate((this._frameRateTime % duration) / duration, this._rateRand.random());
-      if (!(ratePerSeconds > 0)) {
+      // Re-sample inside the loop so a time-varying curve is integrated at each emit cursor
+      const ratePerSeconds = this._evaluateRate(rateOverTime, this._frameRateTime);
+      if (ratePerSeconds <= 0) {
         this._frameRateTime = playTime;
         return;
       }
@@ -199,15 +196,10 @@ export class EmissionModule extends ParticleGeneratorModule {
 
   private _emitByRateOverDistance(lastPlayTime: number, playTime: number): void {
     const { rateOverDistance, _generator: generator } = this;
-    const ratePerUnit =
-      rateOverDistance.mode === ParticleCurveMode.Constant
-        ? rateOverDistance.constant
-        : rateOverDistance.evaluate(
-            (playTime % generator.main.duration) / generator.main.duration,
-            this._rateRand.random()
-          );
+    // Distance rate is sampled once per frame at the current cycle position
+    const ratePerUnit = this._evaluateRate(rateOverDistance, playTime);
 
-    if (!(ratePerUnit > 0)) {
+    if (ratePerUnit <= 0) {
       this._hasLastEmitPosition = false;
       this._distanceAccumulator = 0;
       return;
@@ -257,6 +249,22 @@ export class EmissionModule extends ParticleGeneratorModule {
     }
 
     lastPos.copyFrom(currentPos);
+  }
+
+  private _evaluateRate(rate: ParticleCompositeCurve, cursorTime: number): number {
+    switch (rate.mode) {
+      case ParticleCurveMode.Constant:
+        return rate.constant;
+      case ParticleCurveMode.Curve: {
+        const duration = this._generator.main.duration;
+        return rate.evaluate((cursorTime % duration) / duration, undefined);
+      }
+      default: {
+        // TwoConstants / TwoCurves: lerp between the two values with a per-sample random factor
+        const duration = this._generator.main.duration;
+        return rate.evaluate((cursorTime % duration) / duration, this._rateRand.random());
+      }
+    }
   }
 
   private _emitByBurst(lastPlayTime: number, playTime: number): void {

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -1,6 +1,7 @@
 import { MathUtil, Rand, Vector3 } from "@galacean/engine-math";
 import { deepClone, ignoreClone } from "../../clone/CloneManager";
 import { ShaderMacro } from "../../shader/ShaderMacro";
+import { ParticleCurveMode } from "../enums/ParticleCurveMode";
 import { ParticleRandomSubSeeds } from "../enums/ParticleRandomSubSeeds";
 import { ParticleSimulationSpace } from "../enums/ParticleSimulationSpace";
 import { Burst } from "./Burst";
@@ -29,6 +30,9 @@ export class EmissionModule extends ParticleGeneratorModule {
   /** @internal */
   @ignoreClone
   _shapeRand = new Rand(0, ParticleRandomSubSeeds.Shape);
+  /** @internal */
+  @ignoreClone
+  _rateRand = new Rand(0, ParticleRandomSubSeeds.EmissionRate);
   /** @internal */
   _frameRateTime: number = 0;
 
@@ -153,6 +157,7 @@ export class EmissionModule extends ParticleGeneratorModule {
   _resetRandomSeed(seed: number): void {
     this._burstRand.reset(seed, ParticleRandomSubSeeds.Burst);
     this._shapeRand.reset(seed, ParticleRandomSubSeeds.Shape);
+    this._rateRand.reset(seed, ParticleRandomSubSeeds.EmissionRate);
   }
 
   /** @internal */
@@ -171,16 +176,21 @@ export class EmissionModule extends ParticleGeneratorModule {
   }
 
   private _emitByRateOverTime(playTime: number): void {
-    const ratePerSeconds = this.rateOverTime.evaluate(undefined, undefined);
-    if (ratePerSeconds <= 0) {
-      this._frameRateTime = playTime;
-      return;
-    }
-    const generator = this._generator;
-    const emitInterval = 1.0 / ratePerSeconds;
+    const { rateOverTime, _generator: generator } = this;
+    const isConstant = rateOverTime.mode === ParticleCurveMode.Constant;
+    const duration = generator.main.duration;
 
     let cumulativeTime = playTime - this._frameRateTime;
-    while (cumulativeTime >= emitInterval) {
+    while (true) {
+      const ratePerSeconds = isConstant
+        ? rateOverTime.constant
+        : rateOverTime.evaluate((this._frameRateTime % duration) / duration, this._rateRand.random());
+      if (!(ratePerSeconds > 0)) {
+        this._frameRateTime = playTime;
+        return;
+      }
+      const emitInterval = 1.0 / ratePerSeconds;
+      if (cumulativeTime < emitInterval) break;
       cumulativeTime -= emitInterval;
       this._frameRateTime += emitInterval;
       generator._emit(this._frameRateTime, 1);
@@ -188,10 +198,16 @@ export class EmissionModule extends ParticleGeneratorModule {
   }
 
   private _emitByRateOverDistance(lastPlayTime: number, playTime: number): void {
-    const ratePerUnit = this.rateOverDistance.evaluate(undefined, undefined);
-    const generator = this._generator;
+    const { rateOverDistance, _generator: generator } = this;
+    const ratePerUnit =
+      rateOverDistance.mode === ParticleCurveMode.Constant
+        ? rateOverDistance.constant
+        : rateOverDistance.evaluate(
+            (playTime % generator.main.duration) / generator.main.duration,
+            this._rateRand.random()
+          );
 
-    if (ratePerUnit <= 0) {
+    if (!(ratePerUnit > 0)) {
       this._hasLastEmitPosition = false;
       this._distanceAccumulator = 0;
       return;

--- a/packages/core/src/particle/modules/EmissionModule.ts
+++ b/packages/core/src/particle/modules/EmissionModule.ts
@@ -196,7 +196,7 @@ export class EmissionModule extends ParticleGeneratorModule {
     // Distance rate is sampled once per frame at the current cycle position
     const ratePerUnit = this._evaluateRate(rateOverDistance, playTime);
 
-    if (ratePerUnit <= 0) {
+    if (!(ratePerUnit > 0)) {
       this._hasLastEmitPosition = false;
       this._distanceAccumulator = 0;
       return;

--- a/tests/src/core/particle/RateCurve.test.ts
+++ b/tests/src/core/particle/RateCurve.test.ts
@@ -1,0 +1,228 @@
+import {
+  Camera,
+  CurveKey,
+  Engine,
+  Entity,
+  ParticleCurve,
+  ParticleCurveMode,
+  ParticleMaterial,
+  ParticleRenderer,
+  ParticleStopMode
+} from "@galacean/engine-core";
+import { Color } from "@galacean/engine-math";
+import { WebGLEngine } from "@galacean/engine";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+function tick(engine: Engine, times: { value: number }, deltaMs: number = 100): void {
+  //@ts-ignore
+  engine._vSyncCount = Infinity;
+  // Anchor the last system time to the current mocked clock so each tick
+  // advances exactly `deltaMs` (avoids the 0.333s maximumDeltaTime clamp)
+  //@ts-ignore
+  engine._time._lastSystemTime = times.value / 1000;
+  performance.now = function () {
+    times.value += deltaMs;
+    return times.value;
+  };
+  engine.update();
+}
+
+function buildEmitter(engine: Engine, name: string): { entity: Entity; renderer: ParticleRenderer } {
+  const scene = engine.sceneManager.activeScene;
+  const entity = scene.createRootEntity(name);
+  const renderer = entity.addComponent(ParticleRenderer);
+  const material = new ParticleMaterial(engine);
+  material.baseColor = new Color(1, 1, 1, 1);
+  renderer.setMaterial(material);
+
+  const generator = renderer.generator;
+  generator.useAutoRandomSeed = false;
+  generator.main.maxParticles = 1000;
+  generator.main.startLifetime.constant = 100;
+  generator.main.duration = 1;
+  generator.emission.rateOverTime.constant = 0;
+  generator.emission.rateOverDistance.constant = 0;
+  return { entity, renderer };
+}
+
+describe("EmissionModule rate curve modes", () => {
+  let engine: Engine;
+  let elapsed: { value: number };
+
+  beforeAll(async function () {
+    engine = await WebGLEngine.create({ canvas: document.createElement("canvas") });
+    const scene = engine.sceneManager.activeScene;
+    const cameraEntity = scene.createRootEntity("Camera");
+    cameraEntity.addComponent(Camera);
+    cameraEntity.transform.setPosition(0, 0, 10);
+    engine.run();
+    elapsed = { value: 0 };
+  });
+
+  afterAll(function () {
+    engine.destroy();
+  });
+
+  it("rateOverTime flat curve matches constant rate", () => {
+    const { renderer: constantRenderer } = buildEmitter(engine, "rot-constant");
+    const constantGenerator = constantRenderer.generator;
+    constantGenerator.emission.rateOverTime.constant = 10;
+
+    const { renderer: curveRenderer } = buildEmitter(engine, "rot-flat-curve");
+    const curveGenerator = curveRenderer.generator;
+    const rateOverTime = curveGenerator.emission.rateOverTime;
+    rateOverTime.curve = new ParticleCurve(new CurveKey(0, 10), new CurveKey(1, 10));
+    rateOverTime.mode = ParticleCurveMode.Curve;
+
+    constantGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    curveGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    constantGenerator.play();
+    curveGenerator.play();
+
+    for (let i = 0; i < 10; i++) tick(engine, elapsed);
+
+    const constantCount = constantGenerator._getAliveParticleCount();
+    const curveCount = curveGenerator._getAliveParticleCount();
+    expect(constantCount).to.be.greaterThan(0);
+    expect(curveCount).to.eq(constantCount);
+
+    constantGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    curveGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+
+  it("rateOverTime ramp curve emits between zero and peak rate", () => {
+    const { renderer } = buildEmitter(engine, "rot-ramp-curve");
+    const generator = renderer.generator;
+    const rateOverTime = generator.emission.rateOverTime;
+    rateOverTime.curve = new ParticleCurve(new CurveKey(0, 0), new CurveKey(1, 20));
+    rateOverTime.mode = ParticleCurveMode.Curve;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    // One full cycle (duration = 1s)
+    for (let i = 0; i < 10; i++) tick(engine, elapsed);
+
+    const count = generator._getAliveParticleCount();
+    // Integral of a 0→20 ramp over one cycle is ~10. Without curve-shape support the
+    // last key's value (20) would be treated as a constant and emit ~20.
+    expect(count).to.be.greaterThan(0);
+    expect(count).to.be.lessThanOrEqual(15);
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+
+  it("rateOverTime curve respects curve shape over the cycle", () => {
+    const { renderer } = buildEmitter(engine, "rot-shape-curve");
+    const generator = renderer.generator;
+    const rateOverTime = generator.emission.rateOverTime;
+    // All emission packed into the first half of the cycle; last key is 0
+    rateOverTime.curve = new ParticleCurve(new CurveKey(0, 20), new CurveKey(0.5, 0), new CurveKey(1, 0));
+    rateOverTime.mode = ParticleCurveMode.Curve;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    for (let i = 0; i < 10; i++) tick(engine, elapsed);
+
+    const count = generator._getAliveParticleCount();
+    // Integral of the curve is ~5. Sampling the last key as a constant would emit 0
+    expect(count).to.be.greaterThan(0);
+    expect(count).to.be.lessThan(10);
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+
+  it("rateOverTime two-constants emits within min/max bounds", () => {
+    const { renderer } = buildEmitter(engine, "rot-two-constants");
+    const generator = renderer.generator;
+    const rateOverTime = generator.emission.rateOverTime;
+    rateOverTime.constantMin = 5;
+    rateOverTime.constantMax = 15;
+    rateOverTime.mode = ParticleCurveMode.TwoConstants;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    for (let i = 0; i < 10; i++) tick(engine, elapsed);
+
+    const count = generator._getAliveParticleCount();
+    // Emission intervals are bounded by [1/15, 1/5], so one second yields between ~5 and ~15 particles
+    expect(count).to.be.greaterThanOrEqual(4);
+    expect(count).to.be.lessThanOrEqual(16);
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+
+  it("rateOverTime two-curves emits within min/max curve bounds", () => {
+    const { renderer } = buildEmitter(engine, "rot-two-curves");
+    const generator = renderer.generator;
+    const rateOverTime = generator.emission.rateOverTime;
+    rateOverTime.curveMin = new ParticleCurve(new CurveKey(0, 5), new CurveKey(1, 5));
+    rateOverTime.curveMax = new ParticleCurve(new CurveKey(0, 15), new CurveKey(1, 15));
+    rateOverTime.mode = ParticleCurveMode.TwoCurves;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    for (let i = 0; i < 10; i++) tick(engine, elapsed);
+
+    const count = generator._getAliveParticleCount();
+    expect(count).to.be.greaterThanOrEqual(4);
+    expect(count).to.be.lessThanOrEqual(16);
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+
+  it("rateOverDistance flat curve matches constant rate", () => {
+    const { entity: constantEntity, renderer: constantRenderer } = buildEmitter(engine, "rod-constant");
+    const constantGenerator = constantRenderer.generator;
+    constantGenerator.emission.rateOverDistance.constant = 10;
+
+    const { entity: curveEntity, renderer: curveRenderer } = buildEmitter(engine, "rod-flat-curve");
+    const curveGenerator = curveRenderer.generator;
+    const rateOverDistance = curveGenerator.emission.rateOverDistance;
+    rateOverDistance.curve = new ParticleCurve(new CurveKey(0, 10), new CurveKey(1, 10));
+    rateOverDistance.mode = ParticleCurveMode.Curve;
+
+    constantGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    curveGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    constantGenerator.play();
+    curveGenerator.play();
+    // First tick records the start position
+    tick(engine, elapsed);
+
+    for (let i = 1; i <= 5; i++) {
+      constantEntity.transform.setPosition(i, 0, 0);
+      curveEntity.transform.setPosition(i, 0, 0);
+      tick(engine, elapsed);
+    }
+
+    const constantCount = constantGenerator._getAliveParticleCount();
+    const curveCount = curveGenerator._getAliveParticleCount();
+    expect(constantCount).to.be.greaterThan(0);
+    expect(curveCount).to.eq(constantCount);
+
+    constantGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    curveGenerator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+
+  it("rateOverDistance curve respects cycle position", () => {
+    const { entity, renderer } = buildEmitter(engine, "rod-shape-curve");
+    const generator = renderer.generator;
+    const rateOverDistance = generator.emission.rateOverDistance;
+    // Rate is zero through the first half of the cycle, ramps up afterwards
+    rateOverDistance.curve = new ParticleCurve(new CurveKey(0, 0), new CurveKey(0.5, 0), new CurveKey(1, 10));
+    rateOverDistance.mode = ParticleCurveMode.Curve;
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+    generator.play();
+    // Move only during the first half of the cycle, where the sampled rate is zero
+    for (let i = 1; i <= 5; i++) {
+      entity.transform.setPosition(i, 0, 0);
+      tick(engine, elapsed);
+    }
+
+    // Correctly sampling the curve at the cycle position emits nothing here;
+    // falling back to the last key (10) as a constant would emit ~10 per unit moved
+    expect(generator._getAliveParticleCount()).to.eq(0);
+
+    generator.stop(true, ParticleStopMode.StopEmittingAndClear);
+  });
+});


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature (with a silent-failure bug fix).

### What is the current behavior? (You can also link to an open issue here)

`EmissionModule.rateOverTime` / `rateOverDistance` are typed as `ParticleCompositeCurve`, but both are evaluated with `evaluate(undefined, undefined)`, so only `Constant` mode actually works:

- `Curve` mode silently falls back to the **last key's value as a constant** (`ParticleCurve._evaluate(undefined)` falls through to the last key) — the curve shape is ignored.
- `TwoConstants` / `TwoCurves` produce **NaN**, and since `NaN <= 0` is false the NaN flows into `emitInterval = 1 / NaN`, so the emitter **silently emits nothing** — no warning.

This bites when importing Unity particle assets that use curve-based emission rates.

### What is the new behavior (if this is a feature change)?

- `rateOverTime`: non-constant modes are re-evaluated at each emission cursor using the normalized cycle time (`frameRateTime % duration / duration`), so the emission interval follows the curve while keeping sub-frame emit-time accuracy. `Constant` mode keeps the exact previous fast path (no behavior or random-stream change).
- `rateOverDistance`: non-constant modes are sampled once per frame at the current normalized cycle time.
- A dedicated random sub-seed (`ParticleRandomSubSeeds.EmissionRate`) drives the lerp factor for `TwoConstants` / `TwoCurves`, keeping replay determinism and leaving the Burst/Shape random streams untouched.
- Zero/invalid rates (including NaN from a misconfigured curve) are handled via `!(rate > 0)` and reset the frame cursor, matching the existing constant-mode semantics.

Added 7 unit tests (`RateCurve.test.ts`): flat-curve ≡ constant equality (rateOverTime + rateOverDistance), ramp-curve integral bounds, curve-shape sensitivity (emission packed into half a cycle), and TwoConstants/TwoCurves min/max bounds. Each discriminating test was verified to fail against the previous behavior (constant-last-key → wrong counts, NaN → zero emission).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `Constant` mode behavior and its random streams are byte-identical; non-constant modes previously emitted wrong counts or nothing at all.

### Other information:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new emission-rate random seed to improve deterministic, randomized sampling of particle emission-rate curves.
  * Updated emission-rate calculation to be mode-aware, ensuring emission stays accurate and consistent for both time-based and distance-based emitters.

* **Bug Fixes**
  * Improved how time-varying emission rates are sampled during emission so curves are applied step-by-step and match expected behavior.

* **Tests**
  * Added a new test suite covering emission-rate curve behavior across multiple modes for both rate-over-time and rate-over-distance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->