### PR TITLE
fix(entity): traverse front-to-back in getComponentsInChildren

### DIFF
--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -682,14 +682,16 @@ export class Entity extends EngineObject {
   }
 
   private _getComponentsInChildren<T extends Component>(type: ComponentConstructor<T>, results: T[]): void {
-    for (let i = this._components.length - 1; i >= 0; i--) {
-      const component = this._components[i];
+    const components = this._components;
+    for (let i = 0, n = components.length; i < n; i++) {
+      const component = components[i];
       if (component instanceof type) {
         results.push(component);
       }
     }
-    for (let i = this._children.length - 1; i >= 0; i--) {
-      this._children[i]._getComponentsInChildren<T>(type, results);
+    const children = this._children;
+    for (let i = 0, n = children.length; i < n; i++) {
+      children[i]._getComponentsInChildren<T>(type, results);
     }
   }
 

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -296,9 +296,10 @@ export class Entity extends EngineObject {
 
   /**
    * Get the components which match the type of the entity and it's children.
+   * @remarks The components are returned in depth-first pre-order: the entity itself first, then each child's subtree in sibling order.
    * @param type - The component type
    * @param results - The components collection
-   * @returns	The components collection which match the type
+   * @returns The components collection which match the type
    */
   getComponentsIncludeChildren<T extends Component>(type: ComponentConstructor<T>, results: T[]): T[] {
     results.length = 0;

--- a/tests/src/core/Entity.test.ts
+++ b/tests/src/core/Entity.test.ts
@@ -873,4 +873,46 @@ describe("Entity", async () => {
       expect(order).toEqual(["C", "B", "A"]);
     });
   });
+
+  describe("getComponentsIncludeChildren", () => {
+    class ScriptA extends Script {}
+    class ScriptB extends Script {}
+
+    it("should return components in depth-first front-to-back order", () => {
+      const root = new Entity(engine, "root");
+      root.parent = scene.getRootEntity();
+
+      const child0 = new Entity(engine, "child0");
+      child0.parent = root;
+      const child1 = new Entity(engine, "child1");
+      child1.parent = root;
+
+      const grandchild = new Entity(engine, "grandchild");
+      grandchild.parent = child0;
+
+      const compRoot = root.addComponent(ScriptA);
+      const compChild0 = child0.addComponent(ScriptA);
+      const compGrandchild = grandchild.addComponent(ScriptA);
+      const compChild1 = child1.addComponent(ScriptA);
+
+      const results: ScriptA[] = [];
+      root.getComponentsIncludeChildren(ScriptA, results);
+
+      expect(results).toEqual([compRoot, compChild0, compGrandchild, compChild1]);
+    });
+
+    it("should return multiple components per entity in add order", () => {
+      const root = new Entity(engine, "root");
+      root.parent = scene.getRootEntity();
+
+      const comp1 = root.addComponent(ScriptA);
+      const comp2 = root.addComponent(ScriptB);
+
+      const results: Script[] = [];
+      root.getComponentsIncludeChildren(Script, results);
+
+      expect(results[0]).eq(comp1);
+      expect(results[1]).eq(comp2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `_getComponentsInChildren` previously traversed components and children **back-to-front** (`length-1` → `0`), causing results to be returned in reverse hierarchy order.
- Changed to **front-to-back** (`0` → `N`) depth-first pre-order traversal, which is the industry-standard convention for hierarchy queries.

## Test plan

- [ ] Existing unit tests pass (`pnpm run test`)
- [ ] Verify `getComponentsIncludeChildren` returns components in the expected hierarchy order (parent-first, depth-first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Standardized component retrieval to use depth-first pre-order traversal for consistent result ordering across entity hierarchies.

* **Documentation**
  - Clarified documentation specifying the exact traversal sequence used for component searches.

* **Tests**
  - Added comprehensive test coverage to verify component retrieval order consistency and proper handling of multiple matching components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->