### PR TITLE
fix(loader): prefer virtualPathResourceMap type over URL extension inference

### DIFF
--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -339,7 +339,7 @@ export class ResourceManager {
     this._loadingPromises = null;
   }
 
-  private _assignDefaultOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): void {
+  private _resolveLoadItemOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): void {
     assetInfo.type = remoteConfig?.type ?? assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
@@ -358,7 +358,7 @@ export class ResourceManager {
 
     // Get remote asset base url
     const remoteConfig = this._virtualPathResourceMap[assetBaseURL];
-    this._assignDefaultOptions(item, remoteConfig);
+    this._resolveLoadItemOptions(item, remoteConfig);
 
     // Not absolute and base url is set
     item.url =

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -339,34 +339,31 @@ export class ResourceManager {
     this._loadingPromises = null;
   }
 
-  private _assignDefaultOptions(assetInfo: LoadItem): LoadItem {
-    const assetBaseURL = assetInfo.url?.split("?")[0];
-    const remoteType = assetBaseURL ? this._virtualPathResourceMap[assetBaseURL]?.type : undefined;
-    assetInfo.type = assetInfo.type ?? remoteType ?? ResourceManager._getTypeByUrl(assetInfo.url);
+  private _assignDefaultOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): LoadItem {
+    assetInfo.type ||= remoteConfig?.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }
     assetInfo.retryCount = assetInfo.retryCount ?? this.retryCount;
     assetInfo.timeout = assetInfo.timeout ?? this.timeout;
     assetInfo.retryInterval = assetInfo.retryInterval ?? this.retryInterval;
-    assetInfo.url = assetInfo.url ?? assetInfo.urls.join(",");
     return assetInfo;
   }
 
   private _loadSingleItem<T>(itemOrURL: LoadItem | string): AssetPromise<T> {
-    const item = this._assignDefaultOptions(typeof itemOrURL === "string" ? { url: itemOrURL } : itemOrURL);
-    let { url } = item;
-
-    // Not absolute and base url is set
-    if (!Utils.isAbsoluteUrl(url) && this.baseUrl) url = Utils.resolveAbsoluteUrl(this.baseUrl, url);
-
+    const item = typeof itemOrURL === "string" ? { url: itemOrURL } : itemOrURL;
+    item.url = item.url ?? item.urls.join(",");
     // Parse url
-    const { assetBaseURL, queryPath } = this._parseURL(url);
+    const { url, queryPath } = this._parseURL(item.url);
     const paths = queryPath ? this._parseQueryPath(queryPath) : [];
 
     // Get remote asset base url
-    const remoteConfig = this._virtualPathResourceMap[assetBaseURL];
-    const remoteAssetBaseURL = remoteConfig?.path ?? assetBaseURL;
+    const remoteConfig = this._virtualPathResourceMap[url];
+    this._assignDefaultOptions(item, remoteConfig);
+
+    // Not absolute and base url is set
+    item.url = !Utils.isAbsoluteUrl(url) && this.baseUrl ? Utils.resolveAbsoluteUrl(this.baseUrl, url) : url;
+    const remoteAssetBaseURL = remoteConfig?.path ?? item.url;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];
@@ -415,7 +412,7 @@ export class ResourceManager {
       // Check whether load main asset
       const mainPromise =
         loadingPromises[remoteAssetBaseURL] ||
-        this._loadSubpackageAndMainAsset(loader, item, remoteAssetBaseURL, assetBaseURL, subpackageName);
+        this._loadSubpackageAndMainAsset(loader, item, remoteAssetBaseURL, subpackageName);
       mainPromise.catch((e) => {
         this._onSubAssetFail(remoteAssetBaseURL, queryPath, e);
       });
@@ -423,7 +420,7 @@ export class ResourceManager {
       return this._createSubAssetPromiseCallback<T>(remoteAssetBaseURL, remoteAssetURL, queryPath);
     }
 
-    return this._loadSubpackageAndMainAsset(loader, item, remoteAssetBaseURL, assetBaseURL, subpackageName);
+    return this._loadSubpackageAndMainAsset(loader, item, remoteAssetBaseURL, subpackageName);
   }
 
   // For adapter mini-game platform
@@ -431,19 +428,12 @@ export class ResourceManager {
     loader: Loader<T>,
     item: LoadItem,
     remoteAssetBaseURL: string,
-    assetBaseURL: string,
     subpackageName: string
   ): AssetPromise<T> {
-    return this._loadMainAsset(loader, item, remoteAssetBaseURL, assetBaseURL);
+    return this._loadMainAsset(loader, item, remoteAssetBaseURL);
   }
 
-  private _loadMainAsset<T>(
-    loader: Loader<T>,
-    item: LoadItem,
-    remoteAssetBaseURL: string,
-    assetBaseURL: string
-  ): AssetPromise<T> {
-    item.url = assetBaseURL;
+  private _loadMainAsset<T>(loader: Loader<T>, item: LoadItem, remoteAssetBaseURL: string): AssetPromise<T> {
     const loadingPromises = this._loadingPromises;
     const promise = loader.load(item, this);
     loadingPromises[remoteAssetBaseURL] = promise;
@@ -527,10 +517,10 @@ export class ResourceManager {
     return subResource;
   }
 
-  private _parseURL(path: string): { assetBaseURL: string; queryPath: string } {
+  private _parseURL(path: string): { url: string; queryPath: string } {
     const [baseUrl, searchStr] = path.split("?");
     let queryPath = undefined;
-    let assetBaseURL = baseUrl;
+    let url = baseUrl;
     if (searchStr) {
       const params = searchStr.split("&");
       for (let i = params.length - 1; i >= 0; i--) {
@@ -541,9 +531,9 @@ export class ResourceManager {
           break;
         }
       }
-      assetBaseURL = params.length > 0 ? baseUrl + "?" + params.join("&") : baseUrl;
+      url = params.length > 0 ? baseUrl + "?" + params.join("&") : baseUrl;
     }
-    return { assetBaseURL, queryPath };
+    return { url, queryPath };
   }
 
   private _parseQueryPath(string): string[] {

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -340,12 +340,9 @@ export class ResourceManager {
   }
 
   private _assignDefaultOptions(assetInfo: LoadItem): LoadItem {
-    const remoteConfig = this._virtualPathResourceMap[assetInfo.url];
-    if (remoteConfig) {
-      assetInfo.type = remoteConfig.type;
-    } else {
-      assetInfo.type = assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
-    }
+    const assetBaseURL = assetInfo.url?.split("?")[0];
+    const remoteType = assetBaseURL ? this._virtualPathResourceMap[assetBaseURL]?.type : undefined;
+    assetInfo.type = assetInfo.type ?? remoteType ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -339,7 +339,7 @@ export class ResourceManager {
     this._loadingPromises = null;
   }
 
-  private _assignDefaultOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): LoadItem {
+  private _assignDefaultOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): void {
     assetInfo.type ||= remoteConfig?.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
@@ -347,22 +347,24 @@ export class ResourceManager {
     assetInfo.retryCount = assetInfo.retryCount ?? this.retryCount;
     assetInfo.timeout = assetInfo.timeout ?? this.timeout;
     assetInfo.retryInterval = assetInfo.retryInterval ?? this.retryInterval;
-    return assetInfo;
   }
 
   private _loadSingleItem<T>(itemOrURL: LoadItem | string): AssetPromise<T> {
     const item = typeof itemOrURL === "string" ? { url: itemOrURL } : itemOrURL;
     item.url = item.url ?? item.urls.join(",");
     // Parse url
-    const { url, queryPath } = this._parseURL(item.url);
+    const { assetBaseURL, queryPath } = this._parseURL(item.url);
     const paths = queryPath ? this._parseQueryPath(queryPath) : [];
 
     // Get remote asset base url
-    const remoteConfig = this._virtualPathResourceMap[url];
+    const remoteConfig = this._virtualPathResourceMap[assetBaseURL];
     this._assignDefaultOptions(item, remoteConfig);
 
     // Not absolute and base url is set
-    item.url = !Utils.isAbsoluteUrl(url) && this.baseUrl ? Utils.resolveAbsoluteUrl(this.baseUrl, url) : url;
+    item.url =
+      !Utils.isAbsoluteUrl(assetBaseURL) && this.baseUrl
+        ? Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL)
+        : assetBaseURL;
     const remoteAssetBaseURL = remoteConfig?.path ?? item.url;
 
     // Check cache
@@ -517,10 +519,10 @@ export class ResourceManager {
     return subResource;
   }
 
-  private _parseURL(path: string): { url: string; queryPath: string } {
+  private _parseURL(path: string): { assetBaseURL: string; queryPath: string } {
     const [baseUrl, searchStr] = path.split("?");
     let queryPath = undefined;
-    let url = baseUrl;
+    let assetBaseURL = baseUrl;
     if (searchStr) {
       const params = searchStr.split("&");
       for (let i = params.length - 1; i >= 0; i--) {
@@ -531,9 +533,9 @@ export class ResourceManager {
           break;
         }
       }
-      url = params.length > 0 ? baseUrl + "?" + params.join("&") : baseUrl;
+      assetBaseURL = params.length > 0 ? baseUrl + "?" + params.join("&") : baseUrl;
     }
-    return { url, queryPath };
+    return { assetBaseURL, queryPath };
   }
 
   private _parseQueryPath(string): string[] {

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -339,8 +339,8 @@ export class ResourceManager {
     this._loadingPromises = null;
   }
 
-  private _resolveLoadItemOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): void {
-    assetInfo.type = remoteConfig?.type ?? assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
+  private _resolveLoadItemOptions(assetInfo: LoadItem, virtualResourceEntry?: EditorResourceItem): void {
+    assetInfo.type = virtualResourceEntry?.type ?? assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }
@@ -357,15 +357,15 @@ export class ResourceManager {
     const paths = queryPath ? this._parseQueryPath(queryPath) : [];
 
     // Get remote asset base url
-    const remoteConfig = this._virtualPathResourceMap[assetBaseURL];
-    this._resolveLoadItemOptions(item, remoteConfig);
+    const virtualResourceEntry = this._virtualPathResourceMap[assetBaseURL];
+    this._resolveLoadItemOptions(item, virtualResourceEntry);
 
     // Not absolute and base url is set
     item.url =
       !Utils.isAbsoluteUrl(assetBaseURL) && this.baseUrl
         ? Utils.resolveAbsoluteUrl(this.baseUrl, assetBaseURL)
         : assetBaseURL;
-    const remoteAssetBaseURL = remoteConfig?.path ?? item.url;
+    const remoteAssetBaseURL = virtualResourceEntry?.path ?? item.url;
 
     // Check cache
     const cacheObject = this._assetUrlPool[remoteAssetBaseURL];
@@ -407,7 +407,7 @@ export class ResourceManager {
       throw `loader not found: ${item.type}`;
     }
 
-    const subpackageName = remoteConfig?.subpackageName;
+    const subpackageName = virtualResourceEntry?.subpackageName;
 
     // Check sub asset
     if (queryPath) {

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -340,7 +340,7 @@ export class ResourceManager {
   }
 
   private _assignDefaultOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): void {
-    assetInfo.type ||= remoteConfig?.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
+    assetInfo.type ??= remoteConfig?.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -340,7 +340,12 @@ export class ResourceManager {
   }
 
   private _assignDefaultOptions(assetInfo: LoadItem): LoadItem {
-    assetInfo.type = assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
+    const remoteConfig = this._virtualPathResourceMap[assetInfo.url];
+    if (remoteConfig) {
+      assetInfo.type = remoteConfig.type;
+    } else {
+      assetInfo.type = assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
+    }
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -344,6 +344,7 @@ export class ResourceManager {
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }
+    assetInfo.params ??= virtualResourceEntry?.params;
     assetInfo.retryCount = assetInfo.retryCount ?? this.retryCount;
     assetInfo.timeout = assetInfo.timeout ?? this.timeout;
     assetInfo.retryInterval = assetInfo.retryInterval ?? this.retryInterval;
@@ -589,8 +590,8 @@ export class ResourceManager {
     }
 
     const loadUrl = key ? url + "?q=" + key : url;
-    // type omitted: resolved from the virtualPath map, the single source of truth
-    const promise = this.load<T>({ url: loadUrl, params: mapped.params });
+    // type and params omitted: resolved from the virtualPath map, the single source of truth
+    const promise = this.load<T>({ url: loadUrl });
     return isClone ? promise.then((item) => <T>(<IClone>(<unknown>item)).clone()) : promise;
   }
 

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -340,7 +340,7 @@ export class ResourceManager {
   }
 
   private _assignDefaultOptions(assetInfo: LoadItem, remoteConfig?: EditorResourceItem): void {
-    assetInfo.type ??= remoteConfig?.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
+    assetInfo.type = remoteConfig?.type ?? assetInfo.type ?? ResourceManager._getTypeByUrl(assetInfo.url);
     if (assetInfo.type === undefined) {
       throw `asset type should be specified: ${assetInfo.url}`;
     }
@@ -589,7 +589,8 @@ export class ResourceManager {
     }
 
     const loadUrl = key ? url + "?q=" + key : url;
-    const promise = this.load<T>({ url: loadUrl, type: mapped.type, params: mapped.params });
+    // type is intentionally omitted: `_loadSingleItem` resolves it from the virtualPath map (the single source of truth)
+    const promise = this.load<T>({ url: loadUrl, params: mapped.params });
     return isClone ? promise.then((item) => <T>(<IClone>(<unknown>item)).clone()) : promise;
   }
 

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -589,7 +589,7 @@ export class ResourceManager {
     }
 
     const loadUrl = key ? url + "?q=" + key : url;
-    // type is intentionally omitted: `_loadSingleItem` resolves it from the virtualPath map (the single source of truth)
+    // type omitted: resolved from the virtualPath map, the single source of truth
     const promise = this.load<T>({ url: loadUrl, params: mapped.params });
     return isClone ? promise.then((item) => <T>(<IClone>(<unknown>item)).clone()) : promise;
   }

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -119,5 +119,59 @@ describe("ResourceManager", () => {
       expect(loaderSpy).toHaveBeenCalledTimes(1);
       loaderSpy.mockRestore();
     });
+
+    it("keeps the explicit type over the virtualPath map type", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        { virtualPath: "Assets/explicit", path: "https://cdn.ali.com/x.json", type: AssetType.Texture }
+      ]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.GLTF], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      resourceManager.load({ url: "Assets/explicit", type: AssetType.GLTF });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.GLTF);
+      loaderSpy.mockRestore();
+    });
+
+    it("resolves virtualPath via map even when baseUrl is set", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        { virtualPath: "Assets/withBaseUrl", path: "https://cdn.ali.com/real.json", type: AssetType.Texture }
+      ]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+      resourceManager.baseUrl = "https://base.com/app/";
+
+      try {
+        resourceManager.load({ url: "Assets/withBaseUrl" });
+        expect(loaderSpy).toHaveBeenCalled();
+        expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
+      } finally {
+        resourceManager.baseUrl = null;
+        loaderSpy.mockRestore();
+      }
+    });
+
+    it("merges urls into a single url before parsing", () => {
+      const resourceManager = engine.resourceManager;
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.KTXCube], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      resourceManager.load({
+        type: AssetType.KTXCube,
+        urls: ["px.ktx", "nx.ktx", "py.ktx", "ny.ktx", "pz.ktx", "nz.ktx"]
+      });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      loaderSpy.mockRestore();
+    });
   });
 });

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -106,6 +106,51 @@ describe("ResourceManager", () => {
       loaderSpy.mockRestore();
     });
 
+    it("fills params from virtualPathResourceMap when params is omitted", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        {
+          virtualPath: "Assets/withParams",
+          path: "https://cdn.ali.com/p.json",
+          type: AssetType.Texture,
+          params: { mipmap: false }
+        } as any
+      ]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      resourceManager.load({ url: "Assets/withParams" });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      expect(loaderSpy.mock.calls[0][0].params).deep.equal({ mipmap: false });
+      loaderSpy.mockRestore();
+    });
+
+    it("prefers explicit params over the virtualPath map params", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        {
+          virtualPath: "Assets/overrideParams",
+          path: "https://cdn.ali.com/o.json",
+          type: AssetType.Texture,
+          params: { mipmap: false }
+        } as any
+      ]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      // Explicit params overrides the map params (overwrite, not merge), mirroring type precedence
+      resourceManager.load({ url: "Assets/overrideParams", params: { mipmap: true } });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      expect(loaderSpy.mock.calls[0][0].params).deep.equal({ mipmap: true });
+      loaderSpy.mockRestore();
+    });
+
     it("shares the main asset across sub-asset queries", () => {
       const resourceManager = engine.resourceManager;
       // @ts-ignore

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -1,4 +1,4 @@
-import { AssetType, ResourceManager, Texture2D } from "@galacean/engine";
+import { AssetPromise, AssetType, ResourceManager, Texture2D } from "@galacean/engine";
 import "@galacean/engine-loader";
 import { WebGLEngine } from "@galacean/engine";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -40,24 +40,24 @@ describe("ResourceManager", () => {
   describe("queryPath", () => {
     it("no encode", () => {
       // @ts-ignore
-      const { assetBaseURL } = engine.resourceManager._parseURL(
+      const { url } = engine.resourceManager._parseURL(
         "https://cdn.ali.com/inner.jpg?x-oss-process=image/resize,l_1024"
       );
-      expect(assetBaseURL).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image/resize,l_1024");
+      expect(url).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image/resize,l_1024");
     });
 
     it("encode", () => {
       // @ts-ignore
-      const { assetBaseURL } = engine.resourceManager._parseURL(
+      const { url } = engine.resourceManager._parseURL(
         "https://cdn.ali.com/inner.jpg?x-oss-process=image%25resize,l_1024"
       );
-      expect(assetBaseURL).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image%25resize,l_1024");
+      expect(url).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image%25resize,l_1024");
     });
 
     it("query path", () => {
       // @ts-ignore
-      const { assetBaseURL, queryPath } = engine.resourceManager._parseURL("https://cdn.ali.com/inner.jpg?q=abc");
-      expect(assetBaseURL).equal("https://cdn.ali.com/inner.jpg");
+      const { url, queryPath } = engine.resourceManager._parseURL("https://cdn.ali.com/inner.jpg?q=abc");
+      expect(url).equal("https://cdn.ali.com/inner.jpg");
       expect(queryPath).equal("abc");
     });
   });
@@ -88,35 +88,34 @@ describe("ResourceManager", () => {
     });
   });
 
-  describe("assignDefaultOptions virtualPath type", () => {
-    it("infers type from virtualPathResourceMap for extensionless url", () => {
+  describe("virtualPath loading", () => {
+    it("infers loader type from virtualPathResourceMap when type is omitted", () => {
       const resourceManager = engine.resourceManager;
       resourceManager.initVirtualResources([
         { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: "Texture2D" }
       ]);
       // @ts-ignore
-      const item = resourceManager._assignDefaultOptions({ url: "Assets/extensionless" });
-      expect(item.type).equal("Texture2D");
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders["Texture2D"], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      resourceManager.load({ url: "Assets/extensionless" });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      expect(loaderSpy.mock.calls[0][0].type).equal("Texture2D");
+      loaderSpy.mockRestore();
     });
 
-    it("infers type for sub-asset query path", () => {
+    it("shares the main asset across sub-asset queries", () => {
       const resourceManager = engine.resourceManager;
-      resourceManager.initVirtualResources([
-        { virtualPath: "Assets/withSubAsset", path: "https://cdn.ali.com/b.glb", type: "GLTF" }
-      ]);
       // @ts-ignore
-      const item = resourceManager._assignDefaultOptions({ url: "Assets/withSubAsset?q=materials[0]" });
-      expect(item.type).equal("GLTF");
-    });
+      const loaderSpy = vi.spyOn(ResourceManager._loaders["GLTF"], "load").mockReturnValue(new AssetPromise(() => {}));
 
-    it("keeps explicit type over virtualPathResourceMap type", () => {
-      const resourceManager = engine.resourceManager;
-      resourceManager.initVirtualResources([
-        { virtualPath: "Assets/explicit", path: "https://cdn.ali.com/c.bin", type: "GLTF" }
-      ]);
-      // @ts-ignore
-      const item = resourceManager._assignDefaultOptions({ url: "Assets/explicit", type: "Texture2D" });
-      expect(item.type).equal("Texture2D");
+      resourceManager.load("https://cdn.ali.com/shared.glb?q=materials[0]");
+      resourceManager.load("https://cdn.ali.com/shared.glb?q=materials[1]");
+
+      expect(loaderSpy).toHaveBeenCalledTimes(1);
+      loaderSpy.mockRestore();
     });
   });
 });

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -87,4 +87,36 @@ describe("ResourceManager", () => {
       }
     });
   });
+
+  describe("assignDefaultOptions virtualPath type", () => {
+    it("infers type from virtualPathResourceMap for extensionless url", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: "Texture2D" }
+      ]);
+      // @ts-ignore
+      const item = resourceManager._assignDefaultOptions({ url: "Assets/extensionless" });
+      expect(item.type).equal("Texture2D");
+    });
+
+    it("infers type for sub-asset query path", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        { virtualPath: "Assets/withSubAsset", path: "https://cdn.ali.com/b.glb", type: "GLTF" }
+      ]);
+      // @ts-ignore
+      const item = resourceManager._assignDefaultOptions({ url: "Assets/withSubAsset?q=materials[0]" });
+      expect(item.type).equal("GLTF");
+    });
+
+    it("keeps explicit type over virtualPathResourceMap type", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        { virtualPath: "Assets/explicit", path: "https://cdn.ali.com/c.bin", type: "GLTF" }
+      ]);
+      // @ts-ignore
+      const item = resourceManager._assignDefaultOptions({ url: "Assets/explicit", type: "Texture2D" });
+      expect(item.type).equal("Texture2D");
+    });
+  });
 });

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -40,24 +40,24 @@ describe("ResourceManager", () => {
   describe("queryPath", () => {
     it("no encode", () => {
       // @ts-ignore
-      const { url } = engine.resourceManager._parseURL(
+      const { assetBaseURL } = engine.resourceManager._parseURL(
         "https://cdn.ali.com/inner.jpg?x-oss-process=image/resize,l_1024"
       );
-      expect(url).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image/resize,l_1024");
+      expect(assetBaseURL).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image/resize,l_1024");
     });
 
     it("encode", () => {
       // @ts-ignore
-      const { url } = engine.resourceManager._parseURL(
+      const { assetBaseURL } = engine.resourceManager._parseURL(
         "https://cdn.ali.com/inner.jpg?x-oss-process=image%25resize,l_1024"
       );
-      expect(url).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image%25resize,l_1024");
+      expect(assetBaseURL).equal("https://cdn.ali.com/inner.jpg?x-oss-process=image%25resize,l_1024");
     });
 
     it("query path", () => {
       // @ts-ignore
-      const { url, queryPath } = engine.resourceManager._parseURL("https://cdn.ali.com/inner.jpg?q=abc");
-      expect(url).equal("https://cdn.ali.com/inner.jpg");
+      const { assetBaseURL, queryPath } = engine.resourceManager._parseURL("https://cdn.ali.com/inner.jpg?q=abc");
+      expect(assetBaseURL).equal("https://cdn.ali.com/inner.jpg");
       expect(queryPath).equal("abc");
     });
   });

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -92,24 +92,26 @@ describe("ResourceManager", () => {
     it("infers loader type from virtualPathResourceMap when type is omitted", () => {
       const resourceManager = engine.resourceManager;
       resourceManager.initVirtualResources([
-        { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: "Texture2D" }
+        { virtualPath: "Assets/extensionless", path: "https://cdn.ali.com/a.json", type: AssetType.Texture }
       ]);
       // @ts-ignore
       const loaderSpy = vi
-        .spyOn(ResourceManager._loaders["Texture2D"], "load")
+        .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
         .mockReturnValue(new AssetPromise(() => {}));
 
       resourceManager.load({ url: "Assets/extensionless" });
 
       expect(loaderSpy).toHaveBeenCalled();
-      expect(loaderSpy.mock.calls[0][0].type).equal("Texture2D");
+      expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
       loaderSpy.mockRestore();
     });
 
     it("shares the main asset across sub-asset queries", () => {
       const resourceManager = engine.resourceManager;
       // @ts-ignore
-      const loaderSpy = vi.spyOn(ResourceManager._loaders["GLTF"], "load").mockReturnValue(new AssetPromise(() => {}));
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.GLTF], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
 
       resourceManager.load("https://cdn.ali.com/shared.glb?q=materials[0]");
       resourceManager.load("https://cdn.ali.com/shared.glb?q=materials[1]");

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -120,20 +120,40 @@ describe("ResourceManager", () => {
       loaderSpy.mockRestore();
     });
 
-    it("keeps the explicit type over the virtualPath map type", () => {
+    it("prefers the virtualPath map type over an explicit type", () => {
       const resourceManager = engine.resourceManager;
       resourceManager.initVirtualResources([
         { virtualPath: "Assets/explicit", path: "https://cdn.ali.com/x.json", type: AssetType.Texture }
       ]);
       // @ts-ignore
       const loaderSpy = vi
-        .spyOn(ResourceManager._loaders[AssetType.GLTF], "load")
+        .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
         .mockReturnValue(new AssetPromise(() => {}));
 
+      // A registered virtualPath is the single source of truth for its type;
+      // an explicit type cannot override the type the editor recorded for it.
       resourceManager.load({ url: "Assets/explicit", type: AssetType.GLTF });
 
       expect(loaderSpy).toHaveBeenCalled();
-      expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.GLTF);
+      expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
+      loaderSpy.mockRestore();
+    });
+
+    it("getResourceByRef resolves the type from the map without passing it explicitly", () => {
+      const resourceManager = engine.resourceManager;
+      resourceManager.initVirtualResources([
+        { virtualPath: "Assets/byRef", path: "https://cdn.ali.com/r.json", type: AssetType.Texture }
+      ]);
+      // @ts-ignore
+      const loaderSpy = vi
+        .spyOn(ResourceManager._loaders[AssetType.Texture], "load")
+        .mockReturnValue(new AssetPromise(() => {}));
+
+      // @ts-ignore — getResourceByRef no longer forwards a type; the map must drive loader selection
+      resourceManager.getResourceByRef({ url: "Assets/byRef" });
+
+      expect(loaderSpy).toHaveBeenCalled();
+      expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
       loaderSpy.mockRestore();
     });
 


### PR DESCRIPTION
## Summary

- In `_assignDefaultOptions`, check `_virtualPathResourceMap` first for the asset type before falling back to URL extension inference.
- Ensures editor-registered assets with virtual paths (no file extension) resolve to the correct loader type without requiring the caller to explicitly specify `type`.

## Test plan

- [ ] `pnpm run test` passes
- [ ] Load an asset by virtual path that has no file extension — should resolve via `_virtualPathResourceMap` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource option defaulting and URL/base-URL resolution when remote configuration is present, ensuring asset types and URLs are handled more reliably.
  * Strengthened virtual-path loading so omitted types are correctly inferred.
  * Fixed query-based sub-asset loading so related `?materials[...]` variants reuse a single main asset load and apply consistent fallback behavior.
* **Tests**
  * Added unit coverage for virtual-path type inference and for single main-load behavior across query-based sub-asset variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->