### PR TITLE
fix(core): add @ignoreClone to Transform._parentTransformCache

### DIFF
--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -51,6 +51,7 @@ export class Transform extends Component {
 
   @ignoreClone
   protected _isParentDirty: boolean = true;
+  @ignoreClone
   private _parentTransformCache: Transform = null;
   @ignoreClone
   private _dirtyFlag: number = TransformModifyFlags.LqLmWmWpWeWqWsWus;
@@ -563,19 +564,7 @@ export class Transform extends Component {
    */
   _parentChange(): void {
     this._isParentDirty = true;
-    this._propagateReparentDirty(TransformModifyFlags.WmWpWeWqWsWus);
-  }
-
-  private _propagateReparentDirty(flags: TransformModifyFlags): void {
-    this._worldAssociatedChange(flags);
-    const children = this._entity._children;
-    for (let i = 0, n = children.length; i < n; i++) {
-      const transform = children[i].transform;
-      if (transform) {
-        transform._isParentDirty = true;
-        transform._propagateReparentDirty(flags);
-      }
-    }
+    this._updateAllWorldFlag(TransformModifyFlags.WmWpWeWqWsWus);
   }
 
   /**

--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -563,7 +563,19 @@ export class Transform extends Component {
    */
   _parentChange(): void {
     this._isParentDirty = true;
-    this._updateAllWorldFlag(TransformModifyFlags.WmWpWeWqWsWus);
+    this._propagateReparentDirty(TransformModifyFlags.WmWpWeWqWsWus);
+  }
+
+  private _propagateReparentDirty(flags: TransformModifyFlags): void {
+    this._worldAssociatedChange(flags);
+    const children = this._entity._children;
+    for (let i = 0, n = children.length; i < n; i++) {
+      const transform = children[i].transform;
+      if (transform) {
+        transform._isParentDirty = true;
+        transform._propagateReparentDirty(flags);
+      }
+    }
   }
 
   /**

--- a/packages/ui/src/component/UITransform.ts
+++ b/packages/ui/src/component/UITransform.ts
@@ -251,7 +251,41 @@ export class UITransform extends Transform {
    */
   _parentChange(): void {
     this._isParentDirty = true;
-    this._updateWorldFlagWithParentRectChange(TransformModifyFlags.WmWpWeWqWsWus);
+    this._propagateReparentDirtyUI(TransformModifyFlags.WmWpWeWqWsWus);
+  }
+
+  private _propagateReparentDirtyUI(flags: number): void {
+    let selfChange = false;
+    const { _horizontalAlignment: horizontalAlignment, _verticalAlignment: verticalAlignment } = this;
+    if (horizontalAlignment || verticalAlignment) {
+      if (
+        horizontalAlignment === HorizontalAlignmentMode.LeftAndRight ||
+        verticalAlignment === VerticalAlignmentMode.TopAndBottom
+      ) {
+        this._updateSizeByAlignment();
+        this._updateRectBySizeAndPivot();
+        selfChange = true;
+      }
+      this._updatePositionByAlignment();
+      this._setDirtyFlagTrue(TransformModifyFlags.LocalMatrix);
+      flags |= TransformModifyFlags.WmWp;
+    }
+    this._worldAssociatedChange(flags);
+    const children = this.entity.children;
+    for (let i = 0, n = children.length; i < n; i++) {
+      const transform = children[i].transform as any;
+      if (!transform) continue;
+      transform._isParentDirty = true;
+      if (typeof transform._propagateReparentDirtyUI === "function") {
+        transform._propagateReparentDirtyUI(flags);
+      } else if (typeof transform._propagateReparentDirty === "function") {
+        transform._propagateReparentDirty(flags);
+      }
+    }
+    if (selfChange) {
+      // @ts-ignore
+      this._entity._updateFlagManager.dispatch(UITransformModifyFlags.Size);
+    }
   }
 
   // @ts-ignore

--- a/packages/ui/src/component/UITransform.ts
+++ b/packages/ui/src/component/UITransform.ts
@@ -251,41 +251,7 @@ export class UITransform extends Transform {
    */
   _parentChange(): void {
     this._isParentDirty = true;
-    this._propagateReparentDirtyUI(TransformModifyFlags.WmWpWeWqWsWus);
-  }
-
-  private _propagateReparentDirtyUI(flags: number): void {
-    let selfChange = false;
-    const { _horizontalAlignment: horizontalAlignment, _verticalAlignment: verticalAlignment } = this;
-    if (horizontalAlignment || verticalAlignment) {
-      if (
-        horizontalAlignment === HorizontalAlignmentMode.LeftAndRight ||
-        verticalAlignment === VerticalAlignmentMode.TopAndBottom
-      ) {
-        this._updateSizeByAlignment();
-        this._updateRectBySizeAndPivot();
-        selfChange = true;
-      }
-      this._updatePositionByAlignment();
-      this._setDirtyFlagTrue(TransformModifyFlags.LocalMatrix);
-      flags |= TransformModifyFlags.WmWp;
-    }
-    this._worldAssociatedChange(flags);
-    const children = this.entity.children;
-    for (let i = 0, n = children.length; i < n; i++) {
-      const transform = children[i].transform as any;
-      if (!transform) continue;
-      transform._isParentDirty = true;
-      if (typeof transform._propagateReparentDirtyUI === "function") {
-        transform._propagateReparentDirtyUI(flags);
-      } else if (typeof transform._propagateReparentDirty === "function") {
-        transform._propagateReparentDirty(flags);
-      }
-    }
-    if (selfChange) {
-      // @ts-ignore
-      this._entity._updateFlagManager.dispatch(UITransformModifyFlags.Size);
-    }
+    this._updateWorldFlagWithParentRectChange(TransformModifyFlags.WmWpWeWqWsWus);
   }
 
   // @ts-ignore

--- a/tests/src/core/Transform.test.ts
+++ b/tests/src/core/Transform.test.ts
@@ -1,4 +1,4 @@
-import { deepClone, Entity, Scene, Transform } from "@galacean/engine-core";
+import { deepClone, Entity, Scene, Script, Transform } from "@galacean/engine-core";
 import { Vector2, Vector3 } from "@galacean/engine-math";
 import { WebGLEngine } from "@galacean/engine";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -122,6 +122,35 @@ describe("Transform test", function () {
     expect(preTransform1.destroyed).to.equal(true);
     expect(entity1.transform instanceof Transform).to.equal(true);
     expect(entity1.transform instanceof SubClassOfTransform).to.equal(false);
+  });
+
+  it("clone with worldMatrix listener should not produce stale parent cache after reparent", () => {
+    class WorldMatrixListener extends Script {
+      constructor(entity: Entity) {
+        super(entity);
+        // @ts-ignore
+        entity._updateFlagManager.addListener(() => {
+          entity.transform.worldMatrix;
+        });
+      }
+    }
+
+    const source = new Entity(engine, "source");
+    const child = source.createChild("child");
+    child.transform.setPosition(10, 20, 30);
+    child.addComponent(WorldMatrixListener);
+
+    const clone = source.clone();
+    const cloneChild = clone.findByName("child");
+
+    const root = scene.createRootEntity("root");
+    root.transform.setPosition(1000, 2000, 3000);
+    root.addChild(clone);
+
+    const world = cloneChild.transform.worldMatrix;
+    expect(world.elements[12]).to.equal(1010);
+    expect(world.elements[13]).to.equal(2020);
+    expect(world.elements[14]).to.equal(3030);
   });
 });
 

--- a/tests/src/core/Transform.test.ts
+++ b/tests/src/core/Transform.test.ts
@@ -152,6 +152,39 @@ describe("Transform test", function () {
     expect(world.elements[13]).to.equal(2020);
     expect(world.elements[14]).to.equal(3030);
   });
+
+  it("clone keeps correct world position when a component reads worldMatrix during clone", () => {
+    // A component that reads its (world) transform inside `_cloneTo` — exactly what the engine's own
+    // DynamicCollider does (`_cloneTo` -> `_syncNative` -> `_addNativeShape` reads `lossyWorldScale`).
+    // Clone fills children before the parent's own components, so this read resolves the PARENT's
+    // `_parentTransformCache` (and sets `_isParentDirty = false`) BEFORE the parent transform's
+    // `_parentTransformCache` is cloned. Without `@ignoreClone` that copy overwrites the resolved
+    // value with the source's `null`, leaving `cache === null` while `_isParentDirty === false`
+    // (a stale cache that is never revalidated), so after reparent the node renders at the origin.
+    class WorldReaderOnClone extends Script {
+      _cloneTo(target: any): void {
+        target.entity.transform.worldMatrix;
+      }
+    }
+
+    // Source prefab-like subtree, never read/rendered, so its parent caches stay unresolved.
+    const source = new Entity(engine, "source-cloneto");
+    const layer = source.createChild("layer");
+    layer.transform.setPosition(10, 20, 0);
+    layer.createChild("leaf").addComponent(WorldReaderOnClone);
+
+    const clone = source.clone();
+    const cloneLayer = clone.findByName("layer");
+
+    const holder = scene.createRootEntity("holder-cloneto");
+    holder.transform.setPosition(1000, 2000, 0);
+    holder.addChild(clone);
+
+    // Must follow holder (1000 + 10, 2000 + 20), not fall back to its local position (10, 20).
+    const world = cloneLayer.transform.worldMatrix;
+    expect(world.elements[12]).to.equal(1010);
+    expect(world.elements[13]).to.equal(2020);
+  });
 });
 
 class SubClassOfTransform extends Transform {


### PR DESCRIPTION
## Summary

- `Transform._parentTransformCache` 缺少 `@ignoreClone`，导致 clone 过程中 `cloneProperty` 覆盖了已被 listener resolve 过的 cache，产生 stale state（`_isParentDirty=false`, `_parentTransformCache=null`）。
- 后续 reparent 时 `_getParentTransform` 直接返回 null → `worldMatrix = localMatrix`，不反映新 parent 的偏移。

### Root cause

1. `_createCloneEntity` 创建 clone 树时，Script 构造函数注册了 transform 变化 listener
2. `_parseCloneEntity` clone Transform 属性时，某个属性赋值触发 dirty dispatch → listener 读 `worldMatrix` → `_getParentTransform` resolve → `_isParentDirty=false`
3. `cloneProperty` 继续遍历到 `_parentTransformCache` → 用源的值覆盖 → 写入 null
4. 结果：`_isParentDirty=false` + `_parentTransformCache=null` → stale

### Fix

给 `_parentTransformCache` 加 `@ignoreClone`（一行）。clone 后保持默认值 null + `_isParentDirty=true`（也是 `@ignoreClone`），首次 `_getParentTransform` 调用会正确 resolve。

## Test plan

- [x] `pnpm run test` — Transform tests pass (5/5)
- [x] 单测复现：clone 带 worldMatrix listener 的 entity，reparent 后 child worldMatrix 正确反映新 parent 偏移

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect transform results when cloning and reparenting entity hierarchies, ensuring cached transform data doesn’t cause stale world-matrix values. Cloned children now correctly reflect the new parent/root positioning.
* **Tests**
  * Added coverage for scenarios where world-matrix values are accessed during cloning, validating both clone+reparent and subtree translation correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->