### PR TITLE
fix(audio): fix iOS lifecycle at root cause (defer context creation)

### DIFF
--- a/packages/core/src/Polyfill.ts
+++ b/packages/core/src/Polyfill.ts
@@ -7,6 +7,7 @@ export class Polyfill {
   static registerPolyfill(): void {
     Polyfill._registerMatchAll();
     Polyfill._registerAudioContext();
+    Polyfill._registerOfflineAudioContext();
     Polyfill._registerTextMetrics();
     Polyfill._registerPromiseFinally();
   }
@@ -50,6 +51,41 @@ export class Polyfill {
       ) => void;
 
       AudioContext.prototype.decodeAudioData = function (
+        arrayBuffer: ArrayBuffer,
+        successCallback?: DecodeSuccessCallback | null,
+        errorCallback?: DecodeErrorCallback | null
+      ): Promise<AudioBuffer> {
+        return new Promise<AudioBuffer>((resolve, reject) => {
+          originalDecodeAudioData.call(
+            this,
+            arrayBuffer,
+            (buffer: AudioBuffer) => {
+              successCallback?.(buffer);
+              resolve(buffer);
+            },
+            (error: DOMException) => {
+              errorCallback?.(error);
+              reject(error);
+            }
+          );
+        });
+      };
+    }
+  }
+
+  private static _registerOfflineAudioContext(): void {
+    // iOS 14.0 and earlier expose only webkitOfflineAudioContext, with callback-form decodeAudioData
+    if (!window.OfflineAudioContext && (window as any).webkitOfflineAudioContext) {
+      Logger.info("Polyfill window.OfflineAudioContext");
+      window.OfflineAudioContext = (window as any).webkitOfflineAudioContext;
+
+      const originalDecodeAudioData = OfflineAudioContext.prototype.decodeAudioData as (
+        audioData: ArrayBuffer,
+        successCallback?: DecodeSuccessCallback | null,
+        errorCallback?: DecodeErrorCallback | null
+      ) => void;
+
+      OfflineAudioContext.prototype.decodeAudioData = function (
         arrayBuffer: ArrayBuffer,
         successCallback?: DecodeSuccessCallback | null,
         errorCallback?: DecodeErrorCallback | null

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -45,7 +45,7 @@ export class AudioManager {
     let context = AudioManager._context;
     if (!context) {
       AudioManager._context = context = new window.AudioContext();
-      document.addEventListener("visibilitychange", AudioManager._recoverPlaybackContext);
+      document.addEventListener("visibilitychange", AudioManager._onVisibilityChange);
       // bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
       window.addEventListener("pageshow", AudioManager._onPageShow);
       // iOS Safari requires user gesture to resume AudioContext
@@ -76,6 +76,16 @@ export class AudioManager {
     return AudioManager.getContext().state === "running";
   }
 
+  private static _onVisibilityChange(): void {
+    if (document.hidden) {
+      // Desktop/Android don't auto-suspend a running WebAudio context when backgrounded (only iOS does),
+      // so suspend here to stop audio in the background; only if a context already exists (don't create one)
+      AudioManager._context?.suspend().catch(() => {});
+    } else {
+      AudioManager._recoverPlaybackContext();
+    }
+  }
+
   private static _recoverPlaybackContext(): void {
     // Returning to foreground with a non-running context (and not a deliberate pause): iOS leaves it
     // "interrupted", which cannot be resumed directly; suspend() first transitions it to "suspended",
@@ -100,6 +110,10 @@ export class AudioManager {
     // 100ms is an empirical delay; resuming too soon after suspend is unreliable.
     setTimeout(() => {
       AudioManager._recovering = false;
+      // Hidden again during the delay, or a deliberate pause landed: don't resume on a backgrounded page
+      if (document.hidden || AudioManager._suspendedByCaller) {
+        return;
+      }
       context
         .resume()
         .then(() => {

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -17,10 +17,14 @@ export class AudioManager {
    * @returns A promise that resolves when the audio context is suspended
    */
   static suspend(): Promise<void> {
-    AudioManager._suspendedByCaller = true;
-    // No context yet means nothing is playing; don't create a (cold) one just to suspend it
+    // No context means nothing is playing: suspending is a no-op and must NOT flag a caller-suspend
+    // (a ghost flag would later block foreground recovery), and don't create a cold context just to suspend
     const context = AudioManager._context;
-    return context ? context.suspend() : Promise.resolve();
+    if (!context) {
+      return Promise.resolve();
+    }
+    AudioManager._suspendedByCaller = true;
+    return context.suspend();
   }
 
   /**

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -120,12 +120,10 @@ export class AudioManager {
       if (document.hidden || AudioManager._suspendedByCaller) {
         return;
       }
-      context
-        .resume()
-        .then(() => {
-          AudioManager._needsUserGestureResume = false;
-        })
-        .catch(() => {});
+      // Go through AudioManager.resume() so its _resumePromise coalesces any user-gesture resume that
+      // races us during the slow iOS interrupted->running transition (~300-400ms); otherwise a bare
+      // context.resume() here would not occupy the promise and a gesture would issue a second call
+      AudioManager.resume().catch(() => {});
     }, 100);
   }
 
@@ -137,11 +135,14 @@ export class AudioManager {
   }
 
   private static _resumeAfterInterruption(): void {
-    // iOS Safari fallback: when auto-resume is blocked, resume on the next user gesture
-    if (!AudioManager._suspendedByCaller && AudioManager._needsUserGestureResume) {
-      AudioManager.resume().catch((e) => {
-        console.warn("Failed to resume AudioContext:", e);
-      });
+    // iOS Safari fallback: when auto-resume is blocked, resume on the next user gesture.
+    // Skip while _recovering: the recovery timer still owns the resume, and resuming now would both
+    // double-call context.resume() and fire before the suspend has settled (the empirical delay)
+    if (AudioManager._recovering || AudioManager._suspendedByCaller || !AudioManager._needsUserGestureResume) {
+      return;
     }
+    AudioManager.resume().catch((e) => {
+      console.warn("Failed to resume AudioContext:", e);
+    });
   }
 }

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -2,27 +2,23 @@
  * Audio Manager for managing global audio context and settings.
  */
 export class AudioManager {
+  /** @internal */
+  static _playingCount = 0;
+
   private static _context: AudioContext;
   private static _gainNode: GainNode;
+  private static _resumePromise: Promise<void> = null;
   private static _needsUserGestureResume = false;
-  private static _hidden = false;
-  private static _foregroundResumeTimer: ReturnType<typeof setTimeout> | null = null;
   private static _suspendedByCaller = false;
+  private static _recovering = false;
 
   /**
    * Suspend the audio context.
    * @returns A promise that resolves when the audio context is suspended
    */
   static suspend(): Promise<void> {
-    const context = AudioManager._context;
-    if (!context) {
-      return Promise.resolve();
-    }
     AudioManager._suspendedByCaller = true;
-    AudioManager._needsUserGestureResume = false;
-    AudioManager._clearForegroundResumeTimer();
-    AudioManager._removeGestureListeners();
-    return context.suspend();
+    return AudioManager.getContext().suspend();
   }
 
   /**
@@ -32,25 +28,14 @@ export class AudioManager {
    */
   static resume(): Promise<void> {
     AudioManager._suspendedByCaller = false;
-    AudioManager._clearForegroundResumeTimer();
-    if (document.hidden) {
-      AudioManager._onHidden();
-    }
-
-    if (AudioManager._hidden) {
-      return Promise.resolve();
-    }
-
-    const context = AudioManager.getContext();
-    if (context.state === "running") {
-      AudioManager._needsUserGestureResume = false;
-      AudioManager._removeGestureListeners();
-      return Promise.resolve();
-    }
-    return context.resume().then(() => {
-      AudioManager._needsUserGestureResume = false;
-      AudioManager._removeGestureListeners();
-    });
+    return (AudioManager._resumePromise ??= AudioManager.getContext()
+      .resume()
+      .then(() => {
+        AudioManager._needsUserGestureResume = false;
+      })
+      .finally(() => {
+        AudioManager._resumePromise = null;
+      }));
   }
 
   /**
@@ -60,11 +45,13 @@ export class AudioManager {
     let context = AudioManager._context;
     if (!context) {
       AudioManager._context = context = new window.AudioContext();
-      AudioManager._hidden = document.hidden;
-      context.onstatechange = AudioManager._onContextStateChange;
-      document.addEventListener("visibilitychange", AudioManager._onVisibilityChange);
-      window.addEventListener("pagehide", AudioManager._onHidden);
-      window.addEventListener("pageshow", AudioManager._onShown);
+      document.addEventListener("visibilitychange", AudioManager._recoverPlaybackContext);
+      // bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
+      window.addEventListener("pageshow", AudioManager._onPageShow);
+      // iOS Safari requires user gesture to resume AudioContext
+      document.addEventListener("touchstart", AudioManager._resumeAfterInterruption, { passive: true });
+      document.addEventListener("touchend", AudioManager._resumeAfterInterruption, { passive: true });
+      document.addEventListener("click", AudioManager._resumeAfterInterruption);
     }
     return context;
   }
@@ -89,111 +76,51 @@ export class AudioManager {
     return AudioManager.getContext().state === "running";
   }
 
-  /**
-   * @internal
-   */
-  static _canStartPlayback(): boolean {
-    if (document.hidden) {
-      AudioManager._onHidden();
-      return false;
-    }
-    if (AudioManager._hidden) {
-      return false;
-    }
-    return AudioManager.getContext().state === "running";
-  }
-
-  private static _onContextStateChange(): void {
-    const state = AudioManager._context?.state;
-    if (state === "running" && !AudioManager._hidden) {
-      AudioManager._suspendedByCaller = false;
-      AudioManager._needsUserGestureResume = false;
-      AudioManager._removeGestureListeners();
-    } else if (
-      state &&
-      state !== "running" &&
-      !AudioManager._hidden &&
-      !AudioManager._suspendedByCaller &&
-      !AudioManager._foregroundResumeTimer
+  private static _recoverPlaybackContext(): void {
+    // Returning to foreground with a non-running context (and not a deliberate pause): iOS leaves it
+    // "interrupted", which cannot be resumed directly; suspend() first transitions it to "suspended",
+    // then resume() restarts the pipeline https://bugs.webkit.org/show_bug.cgi?id=263627
+    // _recovering guards re-entry: a bfcache restore fires both visibilitychange and pageshow
+    if (
+      AudioManager._recovering ||
+      document.hidden ||
+      AudioManager._suspendedByCaller ||
+      AudioManager._playingCount <= 0 ||
+      AudioManager.isAudioContextRunning()
     ) {
-      AudioManager._needsUserGestureResume = true;
-      AudioManager._addGestureListeners();
-    }
-  }
-
-  private static _onVisibilityChange(): void {
-    document.hidden ? AudioManager._onHidden() : AudioManager._onShown();
-  }
-
-  private static _onHidden(): void {
-    const context = AudioManager._context;
-    if (AudioManager._hidden && context?.state !== "running") {
       return;
     }
-    AudioManager._hidden = true;
-    AudioManager._clearForegroundResumeTimer();
-    context?.suspend().catch(() => {});
-  }
-
-  private static _onShown(): void {
-    if (!AudioManager._hidden) {
-      return;
-    }
-    AudioManager._hidden = false;
-
-    const context = AudioManager._context;
-    if (!context || AudioManager._suspendedByCaller) {
-      return;
-    }
-    const isForegroundResumeStale = (): boolean =>
-      AudioManager._hidden || AudioManager._suspendedByCaller || AudioManager._context !== context;
-    // iOS WKWebView zombie fix (https://bugs.webkit.org/show_bug.cgi?id=263627):
-    // force suspend then resume after a short delay to reset the audio rendering pipeline.
+    AudioManager._recovering = true;
+    AudioManager._needsUserGestureResume = true; // fallback if the auto-resume below is rejected
+    const context = AudioManager.getContext();
     context.suspend().catch(() => {});
-    AudioManager._foregroundResumeTimer = setTimeout(() => {
-      AudioManager._foregroundResumeTimer = null;
-      if (isForegroundResumeStale()) {
-        return;
-      }
+    // Clear _recovering on the timer itself, NOT off a promise: suspending/resuming an "interrupted"
+    // context on iOS may never settle, which would leave _recovering stuck true and block all later
+    // recovery. The timer always fires, and 100ms already covers the bfcache double-dispatch window.
+    // 100ms is an empirical delay; resuming too soon after suspend is unreliable.
+    setTimeout(() => {
+      AudioManager._recovering = false;
       context
         .resume()
         .then(() => {
-          if (isForegroundResumeStale()) {
-            return;
-          }
           AudioManager._needsUserGestureResume = false;
-          AudioManager._removeGestureListeners();
         })
-        .catch(() => {
-          if (isForegroundResumeStale()) {
-            return;
-          }
-          AudioManager._needsUserGestureResume = true;
-          AudioManager._addGestureListeners();
-        });
+        .catch(() => {});
     }, 100);
+  }
+
+  private static _onPageShow(event: PageTransitionEvent): void {
+    // Only a bfcache restore needs handling here; a normal load has no suspended context to recover
+    if (event.persisted) {
+      AudioManager._recoverPlaybackContext();
+    }
   }
 
   private static _resumeAfterInterruption(): void {
     if (!AudioManager._suspendedByCaller && AudioManager._needsUserGestureResume) {
-      AudioManager.resume().catch(() => {});
+      AudioManager.resume().catch((e) => {
+        console.warn("Failed to resume AudioContext:", e);
+      });
     }
-  }
-
-  private static _clearForegroundResumeTimer(): void {
-    if (AudioManager._foregroundResumeTimer !== null) {
-      clearTimeout(AudioManager._foregroundResumeTimer);
-      AudioManager._foregroundResumeTimer = null;
-    }
-  }
-
-  private static _addGestureListeners(): void {
-    document.addEventListener("pointerup", AudioManager._resumeAfterInterruption, { passive: true });
-    document.addEventListener("click", AudioManager._resumeAfterInterruption, { passive: true });
-  }
-
-  private static _removeGestureListeners(): void {
-    document.removeEventListener("pointerup", AudioManager._resumeAfterInterruption);
-    document.removeEventListener("click", AudioManager._resumeAfterInterruption);
   }
 }

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -110,19 +110,15 @@ export class AudioManager {
     AudioManager._needsUserGestureResume = true; // fallback if the auto-resume below is rejected
     const context = AudioManager.getContext();
     context.suspend().catch(() => {});
-    // Clear _recovering on the timer itself, NOT off a promise: suspending/resuming an "interrupted"
-    // context on iOS may never settle, which would leave _recovering stuck true and block all later
-    // recovery. The timer always fires, and 100ms already covers the bfcache double-dispatch window.
-    // 100ms is an empirical delay; resuming too soon after suspend is unreliable.
+    // 100ms empirical delay (resume too soon after suspend is unreliable on iOS); _recovering is cleared
+    // on the timer rather than off a promise because iOS may never settle suspend/resume in interrupted
     setTimeout(() => {
       AudioManager._recovering = false;
-      // Hidden again during the delay, or a deliberate pause landed: don't resume on a backgrounded page
       if (document.hidden || AudioManager._suspendedByCaller) {
         return;
       }
-      // Go through AudioManager.resume() so its _resumePromise coalesces any user-gesture resume that
-      // races us during the slow iOS interrupted->running transition (~300-400ms); otherwise a bare
-      // context.resume() here would not occupy the promise and a gesture would issue a second call
+      // Go through AudioManager.resume() so _resumePromise coalesces any gesture-resume racing us during
+      // the slow iOS interrupted->running transition; a bare context.resume() here wouldn't dedupe
       AudioManager.resume().catch(() => {});
     }, 100);
   }
@@ -135,9 +131,8 @@ export class AudioManager {
   }
 
   private static _resumeAfterInterruption(): void {
-    // iOS Safari fallback: when auto-resume is blocked, resume on the next user gesture.
-    // Skip while _recovering: the recovery timer still owns the resume, and resuming now would both
-    // double-call context.resume() and fire before the suspend has settled (the empirical delay)
+    // iOS Safari gesture fallback for when auto-resume is blocked.
+    // _recovering: don't bypass the 100ms delay (would resume on a still-interrupted context)
     if (AudioManager._recovering || AudioManager._suspendedByCaller || !AudioManager._needsUserGestureResume) {
       return;
     }

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -18,7 +18,9 @@ export class AudioManager {
    */
   static suspend(): Promise<void> {
     AudioManager._suspendedByCaller = true;
-    return AudioManager.getContext().suspend();
+    // No context yet means nothing is playing; don't create a (cold) one just to suspend it
+    const context = AudioManager._context;
+    return context ? context.suspend() : Promise.resolve();
   }
 
   /**

--- a/packages/core/src/audio/AudioManager.ts
+++ b/packages/core/src/audio/AudioManager.ts
@@ -48,9 +48,9 @@ export class AudioManager {
     if (!context) {
       AudioManager._context = context = new window.AudioContext();
       document.addEventListener("visibilitychange", AudioManager._onVisibilityChange);
-      // bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
+      // iOS Safari bfcache restore fires pageshow (persisted) but NOT visibilitychange, so recover here too
       window.addEventListener("pageshow", AudioManager._onPageShow);
-      // iOS Safari requires user gesture to resume AudioContext
+      // iOS Safari requires a user gesture to resume the AudioContext
       document.addEventListener("touchstart", AudioManager._resumeAfterInterruption, { passive: true });
       document.addEventListener("touchend", AudioManager._resumeAfterInterruption, { passive: true });
       document.addEventListener("click", AudioManager._resumeAfterInterruption);
@@ -126,13 +126,14 @@ export class AudioManager {
   }
 
   private static _onPageShow(event: PageTransitionEvent): void {
-    // Only a bfcache restore needs handling here; a normal load has no suspended context to recover
+    // iOS Safari bfcache restore (persisted) needs recovery; a normal load has no suspended context
     if (event.persisted) {
       AudioManager._recoverPlaybackContext();
     }
   }
 
   private static _resumeAfterInterruption(): void {
+    // iOS Safari fallback: when auto-resume is blocked, resume on the next user gesture
     if (!AudioManager._suspendedByCaller && AudioManager._needsUserGestureResume) {
       AudioManager.resume().catch((e) => {
         console.warn("Failed to resume AudioContext:", e);

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -196,12 +196,13 @@ export class AudioSource extends Component {
 
     if (this._isPlaying) {
       this._clearSourceNode();
-
       this._isPlaying = false;
-      this._pausedTime = -1;
-      this._playTime = -1;
       AudioManager._playingCount--;
     }
+
+    // stop() always resets to the start, including from a paused state (where _isPlaying is already false)
+    this._pausedTime = -1;
+    this._playTime = -1;
   }
 
   /**
@@ -278,15 +279,19 @@ export class AudioSource extends Component {
   private _initSourceNode(startTime: number): void {
     const context = AudioManager.getContext();
     const sourceNode = context.createBufferSource();
+    const buffer = this._clip._getAudioSource();
 
-    sourceNode.buffer = this._clip._getAudioSource();
+    sourceNode.buffer = buffer;
     sourceNode.playbackRate.value = this._playbackRate;
     sourceNode.loop = this._loop;
     sourceNode.onended = this._onPlayEnd;
     this._sourceNode = sourceNode;
 
     sourceNode.connect(this._ensureGainNode());
-    sourceNode.start(0, startTime);
+    // startTime is total elapsed time; for a looping clip wrap it into the buffer to keep the loop phase
+    // (start()'s offset clamps past the end, it does not wrap)
+    const offset = this._loop && buffer.duration > 0 ? startTime % buffer.duration : startTime;
+    sourceNode.start(0, offset);
   }
 
   private _clearSourceNode(): void {

--- a/packages/core/src/audio/AudioSource.ts
+++ b/packages/core/src/audio/AudioSource.ts
@@ -72,7 +72,8 @@ export class AudioSource extends Component {
   set volume(value: number) {
     value = Math.min(Math.max(0, value), 1.0);
     this._volume = value;
-    this._gainNode.gain.setValueAtTime(value, AudioManager.getContext().currentTime);
+    // No node yet -> _ensureGainNode() applies _volume on first play
+    this._gainNode?.gain.setValueAtTime(value, AudioManager.getContext().currentTime);
   }
 
   /**
@@ -143,9 +144,9 @@ export class AudioSource extends Component {
   constructor(entity: Entity) {
     super(entity);
     this._onPlayEnd = this._onPlayEnd.bind(this);
-
-    this._gainNode = AudioManager.getContext().createGain();
-    this._gainNode.connect(AudioManager.getGainNode());
+    // Gain node is created lazily on first play, not here: creating it would spin up the AudioContext
+    // before any user gesture, and on iOS such a pre-gesture context never recovers from a phone-call
+    // interruption (stays a silent zombie)
   }
 
   /**
@@ -155,18 +156,26 @@ export class AudioSource extends Component {
     if (!this._clip?._getAudioSource() || this._isPlaying || this._pendingPlay) {
       return;
     }
+    // Hidden page: don't start (would leak a sound) and don't pend (would replay out of sync) -> drop
+    if (document.hidden) {
+      return;
+    }
 
-    if (AudioManager._canStartPlayback()) {
+    if (AudioManager.isAudioContextRunning()) {
       this._startPlayback();
     } else {
+      // iOS Safari requires resume() to be called within the same user gesture callback that triggers playback.
+      // Document-level events won't work - must call resume() directly here in play().
       this._pendingPlay = true;
       AudioManager.resume().then(
         () => {
+          // Check if cancelled by stop()/pause()
           if (!this._pendingPlay) {
             return;
           }
           this._pendingPlay = false;
-          if (this._destroyed || !this.enabled || !this._clip?._getAudioSource() || !AudioManager._canStartPlayback()) {
+          // Check if still valid to play after async resume (page may have been hidden meanwhile)
+          if (this._destroyed || !this.enabled || !this._clip || document.hidden) {
             return;
           }
           this._startPlayback();
@@ -183,27 +192,30 @@ export class AudioSource extends Component {
    * Stops playing the clip.
    */
   stop(): void {
-    this._cancelPendingPlayback();
+    this._pendingPlay = false;
 
     if (this._isPlaying) {
       this._clearSourceNode();
-      this._isPlaying = false;
-    }
 
-    this._pausedTime = -1;
-    this._playTime = -1;
+      this._isPlaying = false;
+      this._pausedTime = -1;
+      this._playTime = -1;
+      AudioManager._playingCount--;
+    }
   }
 
   /**
    * Pauses playing the clip.
    */
   pause(): void {
-    this._cancelPendingPlayback();
+    this._pendingPlay = false;
 
     if (this._isPlaying) {
       this._clearSourceNode();
+
       this._pausedTime = AudioManager.getContext().currentTime;
       this._isPlaying = false;
+      AudioManager._playingCount--;
     }
   }
 
@@ -212,7 +224,7 @@ export class AudioSource extends Component {
    */
   _cloneTo(target: AudioSource): void {
     target._clip?._addReferCount(1);
-    target._gainNode.gain.setValueAtTime(target._volume, AudioManager.getContext().currentTime);
+    // _volume is field-cloned; its gain node is applied lazily on first play
   }
 
   /**
@@ -243,60 +255,44 @@ export class AudioSource extends Component {
     this.stop();
   }
 
+  private _ensureGainNode(): GainNode {
+    let gainNode = this._gainNode;
+    if (!gainNode) {
+      this._gainNode = gainNode = AudioManager.getContext().createGain();
+      gainNode.connect(AudioManager.getGainNode());
+      gainNode.gain.setValueAtTime(this._volume, AudioManager.getContext().currentTime);
+    }
+    return gainNode;
+  }
+
   private _startPlayback(): void {
     const startTime = this._pausedTime > 0 ? this._pausedTime - this._playTime : 0;
-    if (!this._initSourceNode(startTime)) {
-      this._pausedTime = -1;
-      this._playTime = -1;
-      return;
-    }
+    this._initSourceNode(startTime);
 
     this._playTime = AudioManager.getContext().currentTime - startTime;
     this._pausedTime = -1;
     this._isPlaying = true;
+    AudioManager._playingCount++;
   }
 
-  private _initSourceNode(startTime: number): boolean {
+  private _initSourceNode(startTime: number): void {
     const context = AudioManager.getContext();
     const sourceNode = context.createBufferSource();
-    const audioBuffer = this._clip._getAudioSource();
-    const duration = audioBuffer.duration;
-    let offset = Math.max(0, startTime);
 
-    if (duration > 0) {
-      if (this._loop) {
-        offset %= duration;
-      } else if (offset >= duration) {
-        return false;
-      }
-    }
-
-    sourceNode.buffer = audioBuffer;
+    sourceNode.buffer = this._clip._getAudioSource();
     sourceNode.playbackRate.value = this._playbackRate;
     sourceNode.loop = this._loop;
     sourceNode.onended = this._onPlayEnd;
     this._sourceNode = sourceNode;
 
-    sourceNode.connect(this._gainNode);
-    sourceNode.start(0, offset);
-    return true;
+    sourceNode.connect(this._ensureGainNode());
+    sourceNode.start(0, startTime);
   }
 
   private _clearSourceNode(): void {
-    const sourceNode = this._sourceNode;
-    if (!sourceNode) {
-      return;
-    }
-
-    sourceNode.onended = null;
-    try {
-      sourceNode.stop();
-    } catch {}
-    sourceNode.disconnect();
+    this._sourceNode.stop();
+    this._sourceNode.disconnect();
+    this._sourceNode.onended = null;
     this._sourceNode = null;
-  }
-
-  private _cancelPendingPlayback(): void {
-    this._pendingPlay = false;
   }
 }

--- a/packages/loader/src/AudioLoader.ts
+++ b/packages/loader/src/AudioLoader.ts
@@ -53,9 +53,8 @@ class AudioLoader extends Loader<AudioClip> {
   }
 
   private static _getDecodeContext(): OfflineAudioContext {
-    // length/channels unused (decode only); decodeAudioData resamples to this rate, then the buffer is
-    // resampled again to the playback rate at play time, so pitch/duration are unaffected; 44100 is the
-    // safest rate across browsers; unprefixed OfflineAudioContext requires iOS >= 14.5
+    // length/channels are decode-only placeholders; 44100 is the safest cross-browser rate.
+    // decodeAudioData resamples once to this rate then again to the playback rate, so pitch/duration are unaffected
     return (AudioLoader._decodeContext ||= new OfflineAudioContext(1, 1, 44100));
   }
 }

--- a/packages/loader/src/AudioLoader.ts
+++ b/packages/loader/src/AudioLoader.ts
@@ -2,15 +2,20 @@ import {
   AssetPromise,
   AssetType,
   AudioClip,
-  AudioManager,
   LoadItem,
   Loader,
   RequestConfig,
   ResourceManager,
   resourceLoader
 } from "@galacean/engine-core";
+
 @resourceLoader(AssetType.Audio, ["mp3", "ogg", "wav", "m4a", "aac", "flac"])
 class AudioLoader extends Loader<AudioClip> {
+  // Decode here instead of the playback AudioContext: decoding happens at load time (before any user
+  // gesture), and creating the playback context that early breaks iOS phone-call recovery; the offline
+  // context decodes without touching the playback context
+  private static _decodeContext: OfflineAudioContext;
+
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<AudioClip> {
     return new AssetPromise((resolve, reject) => {
       const { url } = item;
@@ -24,8 +29,7 @@ class AudioLoader extends Loader<AudioClip> {
         ._request<ArrayBuffer>(url, requestConfig)
         .then((arrayBuffer) => {
           const audioClip = new AudioClip(resourceManager.engine);
-          // @ts-ignore
-          AudioManager.getContext()
+          AudioLoader._getDecodeContext()
             .decodeAudioData(arrayBuffer)
             .then((result: AudioBuffer) => {
               // @ts-ignore
@@ -46,5 +50,12 @@ class AudioLoader extends Loader<AudioClip> {
           reject(e);
         });
     });
+  }
+
+  private static _getDecodeContext(): OfflineAudioContext {
+    // length/channels unused (decode only); decodeAudioData resamples to this rate, then the buffer is
+    // resampled again to the playback rate at play time, so pitch/duration are unaffected; 44100 is the
+    // safest rate across browsers; unprefixed OfflineAudioContext requires iOS >= 14.5
+    return (AudioLoader._decodeContext ||= new OfflineAudioContext(1, 1, 44100));
   }
 }

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -32,7 +32,6 @@ class MockAudioContext {
 
   currentTime = 0;
   destination = {};
-  onstatechange: (() => void) | null = null;
   state: AudioContextState = "suspended";
 
   createBufferSource(): AudioBufferSourceNode {
@@ -48,8 +47,6 @@ class MockAudioContext {
     if (queuedResult instanceof Promise) {
       return queuedResult.then(() => {
         this.state = "running";
-        const cb = this.onstatechange;
-        cb?.();
       });
     }
     if (queuedResult instanceof Error) {
@@ -59,10 +56,7 @@ class MockAudioContext {
       return Promise.reject(new Error("autoplay blocked"));
     }
     this.state = "running";
-    const cb = this.onstatechange;
-    return Promise.resolve().then(() => {
-      cb?.();
-    });
+    return Promise.resolve();
   }
 
   suspend(): Promise<void> {
@@ -70,16 +64,14 @@ class MockAudioContext {
       return Promise.reject(new Error("suspend blocked"));
     }
     this.state = "suspended";
-    const cb = this.onstatechange;
-    return Promise.resolve().then(() => {
-      cb?.();
-    });
+    return Promise.resolve();
   }
 }
 
 async function flushAsync(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let i = 0; i < 4; i++) {
+    await Promise.resolve();
+  }
 }
 
 function createAudioSource(): AudioSource {
@@ -101,23 +93,19 @@ function createAudioSource(): AudioSource {
 }
 
 function resetAudioManagerState(): void {
-  document.removeEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
-  window.removeEventListener("pagehide", (AudioManager as any)._onHidden);
-  window.removeEventListener("pageshow", (AudioManager as any)._onShown);
-  document.removeEventListener("pointerup", (AudioManager as any)._resumeAfterInterruption);
+  document.removeEventListener("visibilitychange", (AudioManager as any)._recoverPlaybackContext);
+  window.removeEventListener("pageshow", (AudioManager as any)._onPageShow);
+  document.removeEventListener("touchstart", (AudioManager as any)._resumeAfterInterruption);
+  document.removeEventListener("touchend", (AudioManager as any)._resumeAfterInterruption);
   document.removeEventListener("click", (AudioManager as any)._resumeAfterInterruption);
-
-  const foregroundResumeTimer = (AudioManager as any)._foregroundResumeTimer;
-  if (foregroundResumeTimer !== null && foregroundResumeTimer !== undefined) {
-    clearTimeout(foregroundResumeTimer);
-  }
 
   (AudioManager as any)._context = null;
   (AudioManager as any)._gainNode = null;
+  (AudioManager as any)._resumePromise = null;
   (AudioManager as any)._needsUserGestureResume = false;
-  (AudioManager as any)._hidden = false;
-  (AudioManager as any)._foregroundResumeTimer = null;
   (AudioManager as any)._suspendedByCaller = false;
+  (AudioManager as any)._recovering = false;
+  (AudioManager as any)._playingCount = 0;
 }
 
 function captureScheduledTimers(): Array<() => void> {
@@ -168,8 +156,149 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
   });
 
+  it("defers AudioContext creation until first play", () => {
+    const audioSource = createAudioSource();
+
+    // setting clip must not have created the context
+    expect((AudioManager as any)._context == null).to.be.true;
+
+    const context = new MockAudioContext();
+    context.state = "running";
+    (AudioManager as any)._context = context;
+
+    audioSource.play();
+
+    expect((AudioManager as any)._context != null).to.be.true;
+  });
+
+  it("applies a pre-play volume lazily on first play", () => {
+    const audioSource = createAudioSource();
+
+    audioSource.volume = 0.3;
+
+    // no node and no context created by the volume setter alone
+    expect((audioSource as any)._gainNode == null).to.be.true;
+    expect((AudioManager as any)._context == null).to.be.true;
+    expect(audioSource.volume).to.equal(0.3);
+
+    const context = new MockAudioContext();
+    context.state = "running";
+    (AudioManager as any)._context = context;
+
+    audioSource.play();
+
+    const gainNode = (audioSource as any)._gainNode as MockGainNode;
+    expect(gainNode != null).to.be.true;
+    expect(gainNode.gain.setValueAtTime).toHaveBeenCalledWith(0.3, context.currentTime);
+  });
+
+  it("starts immediately when the context is already running", () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    const before = (AudioManager as any)._playingCount;
+    audioSource.play();
+
+    expect(audioSource.isPlaying).to.be.true;
+    expect((AudioManager as any)._playingCount).to.equal(before + 1);
+  });
+
+  it("guards play re-entrancy", () => {
+    // (a) no clip -> noop
+    const noClip = new AudioSource({
+      _isActiveInHierarchy: true,
+      _isActiveInScene: true,
+      _removeComponent() {},
+      engine: {}
+    } as any);
+    noClip.play();
+    expect(noClip.isPlaying).to.be.false;
+    expect((AudioManager as any)._context == null).to.be.true;
+
+    // (b) already playing -> second play is a noop
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    audioSource.play();
+    expect(audioSource.isPlaying).to.be.true;
+    const count = (AudioManager as any)._playingCount;
+
+    audioSource.play();
+    expect((AudioManager as any)._playingCount).to.equal(count);
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    // (c) pending play -> noop
+    audioSource.stop();
+    context.state = "suspended";
+    (audioSource as any)._pendingPlay = true;
+    audioSource.play();
+    expect(audioSource.isPlaying).to.be.false;
+  });
+
+  // KEY divergence: hidden play is dropped, never suspends
+  it("drops a play requested while hidden without pending or suspending", async () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    const ctxSuspendSpy = vi.spyOn(context, "suspend");
+    const managerSuspendSpy = vi.spyOn(AudioManager, "suspend");
+
+    const documentHidden = mockDocumentHidden(true);
+    audioSource.play();
+    documentHidden.restore();
+    await flushAsync();
+
+    expect(audioSource.isPlaying).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(ctxSuspendSpy).not.toHaveBeenCalled();
+    expect(managerSuspendSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not replay a hidden-dropped play after returning to foreground", () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    const documentHidden = mockDocumentHidden(true);
+    audioSource.play();
+    expect(audioSource.isPlaying).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.false;
+
+    documentHidden.set(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(Object.assign(new Event("pageshow"), { persisted: true }));
+    vi.advanceTimersByTime(100);
+    documentHidden.restore();
+
+    expect(audioSource.isPlaying).to.be.false;
+    expect((audioSource as any)._pendingPlay).to.be.false;
+  });
+
+  it("replays the pending play on the resume it triggered", async () => {
+    const audioSource = createAudioSource();
+    const documentHidden = mockDocumentHidden(false);
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    audioSource.play();
+    expect((audioSource as any)._pendingPlay).to.be.true;
+
+    await flushAsync();
+    documentHidden.restore();
+
+    expect((audioSource as any)._pendingPlay).to.be.false;
+    expect(audioSource.isPlaying).to.be.true;
+  });
+
+  // HEADLINE
   it("drops playback after autoplay-blocked resume instead of replaying on a later gesture", async () => {
     const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
 
     vi.spyOn(console, "warn").mockImplementation(() => {});
     MockAudioContext.shouldResumeSucceed = false;
@@ -187,8 +316,12 @@ describe("AudioSource playback lifecycle", () => {
     expect(audioSource.isPlaying).to.be.false;
   });
 
-  it("cancels one-shot pending playback before resume resolves", async () => {
+  it("cancels a one-shot pending play before resume resolves", async () => {
     const audioSource = createAudioSource();
+    const documentHidden = mockDocumentHidden(false);
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
     let resolveResume: () => void;
     MockAudioContext.resumeResultQueue = [
       new Promise<void>((resolve) => {
@@ -197,202 +330,23 @@ describe("AudioSource playback lifecycle", () => {
     ];
 
     audioSource.play();
-    await flushAsync();
     expect((audioSource as any)._pendingPlay).to.be.true;
 
     audioSource.stop();
     expect((audioSource as any)._pendingPlay).to.be.false;
+
     resolveResume!();
     await flushAsync();
+    documentHidden.restore();
 
     expect(audioSource.isPlaying).to.be.false;
-  });
-
-  it("resume() unlocks a suspended context", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    expect(context.state).to.equal("suspended");
-
-    await AudioManager.resume();
-
-    expect(context.state).to.equal("running");
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
-  });
-
-  it("suspends context when hidden", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const suspendSpy = vi.spyOn(context, "suspend");
-
-    context.state = "running";
-
-    const documentHidden = mockDocumentHidden(true);
-    document.dispatchEvent(new Event("visibilitychange"));
-    documentHidden.restore();
-    await flushAsync();
-
-    expect(suspendSpy).toHaveBeenCalledTimes(1);
-    expect((AudioManager as any)._hidden).to.be.true;
-  });
-
-  it("resumes context on visibilitychange shown via iOS zombie fix", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
-
-    context.state = "running";
-    const suspendSpy = vi.spyOn(context, "suspend");
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    const documentHidden = mockDocumentHidden(true);
-    document.dispatchEvent(new Event("visibilitychange"));
-    expect(suspendSpy).toHaveBeenCalledTimes(1);
-
-    documentHidden.set(false);
-    document.dispatchEvent(new Event("visibilitychange"));
-    documentHidden.restore();
-    // _onShown calls context.suspend() synchronously then schedules resume after 100ms
-    expect(suspendSpy).toHaveBeenCalledTimes(2);
-    expect(scheduledTimers).to.have.lengthOf(1);
-
-    scheduledTimers[0]();
-    await flushAsync();
-
-    expect(resumeSpy).toHaveBeenCalled();
-  });
-
-  it("does not run the delayed foreground resume after hiding again", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
-
-    context.state = "running";
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    const documentHidden = mockDocumentHidden(true);
-    document.dispatchEvent(new Event("visibilitychange"));
-    documentHidden.set(false);
-    document.dispatchEvent(new Event("visibilitychange"));
-    expect(scheduledTimers).to.have.lengthOf(1);
-
-    documentHidden.set(true);
-    document.dispatchEvent(new Event("visibilitychange"));
-    documentHidden.restore();
-
-    scheduledTimers[0]();
-    await flushAsync();
-
-    expect(resumeSpy).not.toHaveBeenCalled();
-    expect(context.state).to.equal("suspended");
-  });
-
-  it("does not resume the context while hidden", async () => {
-    const audioSource = createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    context.state = "running";
-    audioSource.play();
-    expect(audioSource.isPlaying).to.be.true;
-
-    window.dispatchEvent(new Event("pagehide"));
-    await flushAsync();
-
-    await AudioManager.resume();
-    await flushAsync();
-
-    expect(resumeSpy).not.toHaveBeenCalled();
-    expect(context.state).to.equal("suspended");
-    expect(audioSource.isPlaying).to.be.true;
-  });
-
-  it("suspends the context when resume runs after document becomes hidden but before hidden handler", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const suspendSpy = vi.spyOn(context, "suspend");
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    context.state = "running";
-    const documentHidden = mockDocumentHidden(true);
-
-    await AudioManager.resume();
-    documentHidden.restore();
-    await flushAsync();
-
-    expect(resumeSpy).not.toHaveBeenCalled();
-    expect(suspendSpy).toHaveBeenCalledTimes(1);
-    expect((AudioManager as any)._hidden).to.be.true;
-
-    window.dispatchEvent(new Event("pagehide"));
-    await flushAsync();
-
-    expect(context.state).to.equal("suspended");
-  });
-
-  it("does not start playback while document is hidden even if context is still running", async () => {
-    const audioSource = createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const suspendSpy = vi.spyOn(context, "suspend");
-
-    context.state = "running";
-    const documentHidden = mockDocumentHidden(true);
-
-    audioSource.play();
-    documentHidden.restore();
-    await flushAsync();
-
-    expect(suspendSpy).toHaveBeenCalledTimes(1);
-    expect(audioSource.isPlaying).to.be.false;
-    expect((audioSource as any)._pendingPlay).to.be.false;
-  });
-
-  it("drops playback requested while hidden instead of replaying after show", async () => {
-    const audioSource = createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
-
-    context.state = "running";
-    window.dispatchEvent(new Event("pagehide"));
-    await flushAsync();
-
-    audioSource.play();
-    await flushAsync();
-
-    expect((audioSource as any)._pendingPlay).to.be.false;
-    expect(audioSource.isPlaying).to.be.false;
-
-    window.dispatchEvent(new Event("pageshow"));
-    expect(scheduledTimers).to.have.lengthOf(1);
-    scheduledTimers[0]();
-    await flushAsync();
-
-    expect(context.state).to.equal("running");
-    expect(audioSource.isPlaying).to.be.false;
-  });
-
-  it("does not auto-resume a caller-controlled suspend on the next gesture", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    context.state = "running";
-    await AudioManager.suspend();
-    await flushAsync();
-
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
-
-    document.dispatchEvent(new Event("click"));
-    await flushAsync();
-
-    expect(resumeSpy).not.toHaveBeenCalled();
-    expect(context.state).to.equal("suspended");
   });
 
   it("drops playback after explicit suspend when resume is autoplay-blocked", async () => {
     const audioSource = createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "running";
+
     await AudioManager.suspend();
     await flushAsync();
 
@@ -412,11 +366,253 @@ describe("AudioSource playback lifecycle", () => {
     expect(audioSource.isPlaying).to.be.false;
   });
 
-  it("does not act on visibilitychange shown without prior hide", async () => {
+  it("resume() unlocks a suspended context and clears the gesture flag", async () => {
     createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+    (AudioManager as any)._needsUserGestureResume = true;
+
+    await AudioManager.resume();
+
+    expect(context.state).to.equal("running");
+    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+  });
+
+  it("coalesces overlapping resume() calls and re-issues a later resume", async () => {
+    createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "suspended";
+
+    let resolveFirst: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      })
+    ];
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    AudioManager.resume().catch(() => {});
+    AudioManager.resume().catch(() => {});
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+
+    resolveFirst!();
+    await flushAsync();
+
+    await AudioManager.resume();
+    expect(resumeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not auto-resume a caller-controlled suspend on a later gesture", async () => {
+    createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    await AudioManager.suspend();
+    await flushAsync();
+
+    document.dispatchEvent(new Event("click"));
+    document.dispatchEvent(new Event("touchend"));
+    await flushAsync();
+
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(context.state).to.equal("suspended");
+    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+  });
+
+  it("keeps a playing source playing across a hide without tearing down the node", async () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    expect(audioSource.isPlaying).to.be.true;
+    const count = (AudioManager as any)._playingCount;
+
+    const documentHidden = mockDocumentHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    documentHidden.restore();
+    await flushAsync();
+
+    expect(audioSource.isPlaying).to.be.true;
+    expect((AudioManager as any)._playingCount).to.equal(count);
+  });
+
+  it("performs the foreground zombie reset: suspend, 100ms, resume", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    expect((AudioManager as any)._playingCount > 0).to.be.true;
+
+    // simulate iOS leaving the context non-running after the interruption
+    context.state = "suspended";
+    const suspendSpy = vi.spyOn(context, "suspend");
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(suspendSpy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((AudioManager as any)._recovering).to.be.false;
+    expect(context.state).to.equal("running");
+  });
+
+  it("runs a single recovery cycle for back-to-back visibilitychange and pageshow", () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    context.state = "suspended";
+
+    const scheduledTimers = captureScheduledTimers();
+    const suspendSpy = vi.spyOn(context, "suspend");
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(Object.assign(new Event("pageshow"), { persisted: true }));
+    documentHidden.restore();
+
+    // _recovering guards the 2nd dispatch between the synchronous events
+    expect(suspendSpy).toHaveBeenCalledTimes(1);
+    expect(scheduledTimers).to.have.lengthOf(1);
+  });
+
+  it("skips recovery when nothing is playing", () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    audioSource.stop();
+    expect((AudioManager as any)._playingCount).to.equal(0);
+
+    context.state = "suspended";
+    const suspendSpy = vi.spyOn(context, "suspend");
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(Object.assign(new Event("pageshow"), { persisted: true }));
+    vi.advanceTimersByTime(100);
+    documentHidden.restore();
+
+    expect(suspendSpy).not.toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips recovery after a caller suspend across a hide/show", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    await AudioManager.suspend();
+
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(Object.assign(new Event("pageshow"), { persisted: true }));
+    vi.advanceTimersByTime(100);
+    documentHidden.restore();
+
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(context.state).to.equal("suspended");
+  });
+
+  it("falls back to a gesture when the foreground resume fails, then a click resumes", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    context.state = "suspended";
+
+    // the timer's auto-resume rejects, leaving the gesture fallback armed
+    MockAudioContext.resumeResultQueue = [new Error("autoplay blocked")];
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+
+    expect((AudioManager as any)._needsUserGestureResume).to.be.true;
+    expect(context.state).to.equal("suspended");
+
+    vi.useRealTimers();
+    MockAudioContext.resumeResultQueue = null;
+    MockAudioContext.shouldResumeSucceed = true;
+    document.dispatchEvent(new Event("click"));
+    await flushAsync();
+    documentHidden.restore();
+
+    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
+    expect(context.state).to.equal("running");
+  });
+
+  it("still resumes when the zombie-reset suspend rejects", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    context.state = "suspended";
+
+    MockAudioContext.shouldSuspendSucceed = false;
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).to.equal("running");
+    expect((AudioManager as any)._recovering).to.be.false;
+  });
+
+  it("treats a non-persisted pageshow as a no-op", () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    context.state = "suspended";
+
+    const scheduledTimers = captureScheduledTimers();
+    const suspendSpy = vi.spyOn(context, "suspend");
+
+    window.dispatchEvent(Object.assign(new Event("pageshow"), { persisted: false }));
+
+    expect(suspendSpy).not.toHaveBeenCalled();
+    expect(scheduledTimers).to.have.lengthOf(0);
+  });
+
+  it("does nothing on a spurious visibilitychange-shown with a running context", async () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
 
     const suspendSpy = vi.spyOn(context, "suspend");
+    const resumeSpy = vi.spyOn(context, "resume");
 
     const documentHidden = mockDocumentHidden(false);
     document.dispatchEvent(new Event("visibilitychange"));
@@ -424,138 +620,30 @@ describe("AudioSource playback lifecycle", () => {
     await flushAsync();
 
     expect(suspendSpy).not.toHaveBeenCalled();
+    expect(resumeSpy).not.toHaveBeenCalled();
   });
 
-  it("handles pagehide/pageshow lifecycle", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
-    context.state = "running";
-
-    window.dispatchEvent(new Event("pagehide"));
-    expect((AudioManager as any)._hidden).to.be.true;
-    expect(context.state).to.equal("suspended");
-
-    window.dispatchEvent(new Event("pageshow"));
-    expect((AudioManager as any)._hidden).to.be.false;
-    expect(scheduledTimers).to.have.lengthOf(1);
-
-    // iOS zombie fix uses window.setTimeout(100ms)
-    scheduledTimers[0]();
-    await flushAsync();
-    await flushAsync();
-
-    expect(context.state).to.equal("running");
-  });
-
-  it("sets gesture resume flag when foreground resume fails", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
-    context.state = "running";
-
-    window.dispatchEvent(new Event("pagehide"));
-
-    // Show, but resume will fail
-    MockAudioContext.shouldResumeSucceed = false;
-    window.dispatchEvent(new Event("pageshow"));
-    expect(scheduledTimers).to.have.lengthOf(1);
-
-    scheduledTimers[0]();
-    await flushAsync();
-
-    expect((AudioManager as any)._needsUserGestureResume).to.be.true;
-
-    // Gesture succeeds
-    MockAudioContext.shouldResumeSucceed = true;
-    document.dispatchEvent(new Event("click"));
-    await flushAsync();
-
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
-    expect(context.state).to.equal("running");
-  });
-
-  it("continues foreground resume when the zombie-reset suspend rejects", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
-    const resumeSpy = vi.spyOn(context, "resume");
-    context.state = "running";
-
-    window.dispatchEvent(new Event("pagehide"));
-    MockAudioContext.shouldSuspendSucceed = false;
-    window.dispatchEvent(new Event("pageshow"));
-    expect(scheduledTimers).to.have.lengthOf(1);
-
-    scheduledTimers[0]();
-    await flushAsync();
-
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
-    expect(context.state).to.equal("running");
-  });
-
-  it("retries context.resume inside a later user gesture even if an earlier resume is still pending", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const firstResume = new Promise<void>(() => {});
-
-    MockAudioContext.resumeResultQueue = [firstResume];
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    AudioManager.resume().catch(() => {});
-    await flushAsync();
-
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
-
-    MockAudioContext.resumeResultQueue = [Promise.resolve()];
-    context.onstatechange?.();
-    await flushAsync();
-
-    document.dispatchEvent(new Event("click"));
-    await flushAsync();
-
-    expect(resumeSpy).toHaveBeenCalledTimes(2);
-    expect(context.state).to.equal("running");
-    expect((AudioManager as any)._needsUserGestureResume).to.be.false;
-  });
-
-  it("does not resume a stopped source after hide/show cycle", async () => {
+  it("keeps stop()/pause() bookkeeping consistent", () => {
     const audioSource = createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const scheduledTimers = captureScheduledTimers();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
     context.state = "running";
+    context.currentTime = 5;
 
     audioSource.play();
-    expect(audioSource.isPlaying).to.be.true;
+    const playingCount = (AudioManager as any)._playingCount;
+
+    audioSource.pause();
+    expect((AudioManager as any)._playingCount).to.equal(playingCount - 1);
+    expect(audioSource.isPlaying).to.be.false;
+    expect((audioSource as any)._pausedTime > 0).to.be.true;
+
+    audioSource.play();
+    const playingCount2 = (AudioManager as any)._playingCount;
 
     audioSource.stop();
-    expect(audioSource.isPlaying).to.be.false;
-
-    // hide → show cycle
-    window.dispatchEvent(new Event("pagehide"));
-    window.dispatchEvent(new Event("pageshow"));
-    expect(scheduledTimers).to.have.lengthOf(1);
-    scheduledTimers[0]();
-    await flushAsync();
-
-    // Source stays stopped — context resume does not restart stopped sources
-    expect(audioSource.isPlaying).to.be.false;
-  });
-
-  it("marks external context interruption as gesture-retryable", async () => {
-    createAudioSource();
-    const context = (AudioManager as any)._context as MockAudioContext;
-    const resumeSpy = vi.spyOn(context, "resume");
-
-    context.state = "suspended";
-    context.onstatechange?.();
-    await flushAsync();
-
-    MockAudioContext.shouldResumeSucceed = true;
-    document.dispatchEvent(new Event("pointerup"));
-    await flushAsync();
-
-    expect(resumeSpy).toHaveBeenCalledTimes(1);
-    expect(context.state).to.equal("running");
+    expect((audioSource as any)._pausedTime).to.equal(-1);
+    expect((audioSource as any)._playTime).to.equal(-1);
+    expect((AudioManager as any)._playingCount).to.equal(playingCount2 - 1);
+    expect((audioSource as any)._pendingPlay).to.be.false;
   });
 });

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -587,6 +587,78 @@ describe("AudioSource playback lifecycle", () => {
     expect((AudioManager as any)._recovering).to.be.false;
   });
 
+  // a gesture landing inside the 100ms recovery window must NOT resume: the timer still owns it, and
+  // a gesture resume here would both double-call context.resume() and fire before the suspend settled
+  it("ignores a gesture while recovery is in flight, leaving the single timer resume", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    context.state = "suspended";
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    // recovery in flight: _recovering true, gesture-fallback armed, timer not yet fired
+    expect((AudioManager as any)._recovering).to.be.true;
+
+    const resumeSpy = vi.spyOn(context, "resume");
+    document.dispatchEvent(new Event("click")); // gesture inside the 100ms window
+    await flushAsync();
+    expect(resumeSpy).not.toHaveBeenCalled(); // gesture did NOT resume (recovery owns it)
+
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    // exactly one resume, from the timer; gesture did not double-call it
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).to.equal("running");
+  });
+
+  // a storm of clicks AFTER the 100ms guard window but BEFORE the resume settles must coalesce via
+  // _resumePromise into the timer's resume (the timer goes through AudioManager.resume() now)
+  it("coalesces a click-storm during the slow iOS resume settle into a single context.resume()", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    audioSource.play();
+    context.state = "suspended";
+
+    // hold resume unresolved to simulate the slow iOS interrupted->running transition
+    let releaseResume: () => void;
+    MockAudioContext.resumeResultQueue = [
+      new Promise<void>((resolve) => {
+        releaseResume = resolve;
+      })
+    ];
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    // 100ms timer fires -> timer calls AudioManager.resume() which sets _resumePromise
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect((AudioManager as any)._recovering).to.be.false;
+    expect((AudioManager as any)._resumePromise).to.not.be.null;
+
+    // storm of clicks while the resume is still pending -> _resumePromise coalesces them
+    for (let i = 0; i < 10; i++) {
+      document.dispatchEvent(new Event("click"));
+    }
+    await flushAsync();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+
+    releaseResume!();
+    await flushAsync();
+    documentHidden.restore();
+  });
+
   it("treats a non-persisted pageshow as a no-op", () => {
     const audioSource = createAudioSource();
     const context = AudioManager.getContext() as unknown as MockAudioContext;

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -647,6 +647,45 @@ describe("AudioSource playback lifecycle", () => {
     expect((audioSource as any)._pendingPlay).to.be.false;
   });
 
+  // stop() from a PAUSED state must reset the offset so the next play() starts from 0, not the pause point
+  it("stop() resets the paused offset (play -> pause -> stop -> play starts from 0)", () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    context.currentTime = 5;
+
+    audioSource.play();
+    context.currentTime = 8;
+    audioSource.pause();
+    expect((audioSource as any)._pausedTime > 0).to.be.true;
+
+    // stop() while paused (_isPlaying already false) must still clear the offset
+    audioSource.stop();
+    expect((audioSource as any)._pausedTime).to.equal(-1);
+    expect((audioSource as any)._playTime).to.equal(-1);
+
+    context.currentTime = 12;
+    audioSource.play();
+    expect(audioSource.time).to.equal(0);
+  });
+
+  // a looping clip resumed past one full loop must start from the loop phase, not a clamped offset
+  it("wraps the resume offset into the loop for a looping clip", () => {
+    const audioSource = createAudioSource();
+    audioSource.loop = true;
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+
+    // simulate resuming at 35s elapsed on a 10s clip (duration from the clip mock)
+    (audioSource as any)._pausedTime = 35;
+    (audioSource as any)._playTime = 0;
+    audioSource.play();
+
+    const sourceNode = (audioSource as any)._sourceNode;
+    // start(0, offset): 35 % 10 = 5, not the clamped 35
+    expect(sourceNode.start).toHaveBeenCalledWith(0, 5);
+  });
+
   // suspend() must not create a context just to suspend it (would be the cold-ctx iOS zombie we avoid)
   // suspend() with no context is a no-op: it must NOT create a context AND must NOT flag a caller-suspend
   // (a ghost flag would later block foreground recovery once playback starts)

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -648,11 +648,36 @@ describe("AudioSource playback lifecycle", () => {
   });
 
   // suspend() must not create a context just to suspend it (would be the cold-ctx iOS zombie we avoid)
-  it("does not create a context when suspend() is called before any playback", async () => {
+  // suspend() with no context is a no-op: it must NOT create a context AND must NOT flag a caller-suspend
+  // (a ghost flag would later block foreground recovery once playback starts)
+  it("does not create a context or flag a caller-suspend when suspend() runs before any playback", async () => {
     await AudioManager.suspend();
 
     expect((AudioManager as any)._context == null).to.be.true;
-    expect((AudioManager as any)._suspendedByCaller).to.be.true;
+    expect((AudioManager as any)._suspendedByCaller).to.be.false;
+  });
+
+  // root cause regression: suspend() before first play (no ctx) must not leave a ghost flag that blocks
+  // foreground recovery after the page is later backgrounded and restored
+  it("recovers after suspend()-before-first-play then a hide/show cycle", async () => {
+    vi.useFakeTimers();
+    AudioManager.suspend();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    audioSource.play();
+    expect((AudioManager as any)._suspendedByCaller).to.be.false;
+
+    context.state = "suspended";
+    const resumeSpy = vi.spyOn(context, "resume");
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).to.equal("running");
   });
 
   // hide-suspend: desktop/Android don't auto-suspend WebAudio when backgrounded, so we suspend on hide

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -647,6 +647,14 @@ describe("AudioSource playback lifecycle", () => {
     expect((audioSource as any)._pendingPlay).to.be.false;
   });
 
+  // suspend() must not create a context just to suspend it (would be the cold-ctx iOS zombie we avoid)
+  it("does not create a context when suspend() is called before any playback", async () => {
+    await AudioManager.suspend();
+
+    expect((AudioManager as any)._context == null).to.be.true;
+    expect((AudioManager as any)._suspendedByCaller).to.be.true;
+  });
+
   // hide-suspend: desktop/Android don't auto-suspend WebAudio when backgrounded, so we suspend on hide
   it("suspends the context when the page is hidden", () => {
     const audioSource = createAudioSource();

--- a/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
+++ b/tests/src/core/audio/AudioSourcePendingPlayback.test.ts
@@ -93,7 +93,7 @@ function createAudioSource(): AudioSource {
 }
 
 function resetAudioManagerState(): void {
-  document.removeEventListener("visibilitychange", (AudioManager as any)._recoverPlaybackContext);
+  document.removeEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
   window.removeEventListener("pageshow", (AudioManager as any)._onPageShow);
   document.removeEventListener("touchstart", (AudioManager as any)._resumeAfterInterruption);
   document.removeEventListener("touchend", (AudioManager as any)._resumeAfterInterruption);
@@ -645,5 +645,77 @@ describe("AudioSource playback lifecycle", () => {
     expect((audioSource as any)._playTime).to.equal(-1);
     expect((AudioManager as any)._playingCount).to.equal(playingCount2 - 1);
     expect((audioSource as any)._pendingPlay).to.be.false;
+  });
+
+  // hide-suspend: desktop/Android don't auto-suspend WebAudio when backgrounded, so we suspend on hide
+  it("suspends the context when the page is hidden", () => {
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    audioSource.play();
+    const suspendSpy = vi.spyOn(context, "suspend");
+
+    const documentHidden = mockDocumentHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    documentHidden.restore();
+
+    expect(suspendSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // hide-suspend must not create a context (would break the deferred-creation root-cause fix)
+  it("does not create a context on hide when none exists", () => {
+    document.removeEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
+    document.addEventListener("visibilitychange", (AudioManager as any)._onVisibilityChange);
+
+    const documentHidden = mockDocumentHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    documentHidden.restore();
+
+    expect((AudioManager as any)._context == null).to.be.true;
+  });
+
+  // hide-suspend uses the bare context.suspend(), so a return to foreground still recovers
+  it("recovers after a hide-suspend (hide does not flag _suspendedByCaller)", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    audioSource.play();
+
+    const documentHidden = mockDocumentHidden(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect((AudioManager as any)._suspendedByCaller).to.be.false;
+
+    const resumeSpy = vi.spyOn(context, "resume");
+    documentHidden.set(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).to.equal("running");
+  });
+
+  // staleness guard: hidden again during the 100ms recovery delay must not resume on a backgrounded page
+  it("does not resume if hidden again during the recovery delay", async () => {
+    vi.useFakeTimers();
+    const audioSource = createAudioSource();
+    const context = AudioManager.getContext() as unknown as MockAudioContext;
+    context.state = "running";
+    audioSource.play();
+    context.state = "suspended";
+
+    const documentHidden = mockDocumentHidden(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    const resumeSpy = vi.spyOn(context, "resume");
+
+    // hidden again before the 100ms timer fires
+    documentHidden.set(true);
+    vi.advanceTimersByTime(100);
+    await flushAsync();
+    documentHidden.restore();
+
+    expect(resumeSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 背景

本 PR 提交到 #3026（`fix/audio-shaderlab-split`），用**根因治本**的方案替换本分支当前基于 `onstatechange` / 显式 hide-suspend 的 audio 生命周期修复。

所有问题都在**真机 iOS / Android**上逐个复现并验证修复——每条修复都对应一个实测能复现的问题，不是推测。

## 根因（当前分支方案未触及）

iOS audio 各种"中断后起不来"的表现，根子是 **AudioContext 在任何用户手势之前就被创建了**：

- `AudioSource` 构造时就 `createGain()` → 拉起 AudioContext；
- `AudioLoader` 用**播放用的** AudioContext 解码 → 加载期就拉起 AudioContext。

这种在手势前创建的"冷"上下文，在 **iOS 中断**后无法自愈——表现为 `state === "running"` 但 `currentTime` 冻结的**僵尸态**（参考 WebKit 同区域 bug，详见下文）。而在用户手势内创建的"热"上下文，中断后 iOS 会自己恢复——这一点连**前台中断**（小窗来电横幅 / Siri / 闹钟，页面仍可见、ctx 走 `running → interrupted`）也成立：中断结束后热 ctx 由 iOS 自行 `interrupted → running` 复位，无需任何监听器介入。

> 实测对照：同一份纯净页面，ctx 在手势前创建 → 中断后僵尸；推迟到首次 `play()`（手势内）创建 → 中断后自愈。

## 改动

### `AudioSource` — 延迟创建上下文（根因修复）
- 构造期不再建 gainNode；改为首次 `play()` 时 `_ensureGainNode()` 懒建。
- 因此 AudioContext 推迟到首次 `play()`（在用户手势回调内）才创建 → "热"上下文 → 中断后 iOS 自愈。
- `play()` 在 `document.hidden` 时**直接丢弃**（不启动、也不挂起 pending）：后台启动会漏出声音，pending 到回前台又会错位重放——SFX 宁可丢也不能对不上。

### `AudioLoader` — 用 OfflineAudioContext 解码
- 解码改用专用 `OfflineAudioContext(1, 1, 44100)`，不再用播放 ctx 解码（这是第二个过早创建点）。
- OfflineAudioContext 只渲染到内存、不碰硬件音频单元，天然在 iOS 中断机制之外，可安全地在加载期（手势前）创建。
- 无前缀 `OfflineAudioContext` 自 **iOS 14.1+**；老 iOS 由 Polyfill 接管：在缺无前缀 API 时为 `webkitOfflineAudioContext`（自 iOS 7）做别名 + 把其 callback 形式的 `decodeAudioData` 包成 Promise（对齐既有 `_registerAudioContext` 的处理）。

### `AudioManager` — 切后台静音、恢复与守卫
- **hide → suspend（全平台对齐）**：`visibilitychange` 挂分派器 `_onVisibilityChange`——`hidden` 时 `_context?.suspend()`，`visible` 时 `_recoverPlaybackContext`。
  - 桌面 Chrome/Firefox、Android Chrome **不会**自动 suspend 后台运行中的 WebAudio ctx（只有 iOS Safari 会），覆盖版连带删掉 hide→suspend 曾导致这些平台切后台 BGM 继续出声。这里显式补回，让全平台行为对齐 iOS。
  - 用可选链 `_context?.suspend()`：**仅在 ctx 已存在时挂起**，绝不为了 suspend 去创建一个手势前的冷 ctx（那正是本 PR 要规避的 zombie 来源）；也**不污染** `_suspendedByCaller`，故回前台仍正常恢复。
  - **不加 opt-out 开关**：iOS Safari 由系统强制后台 suspend、开发者无法绕过，"后台继续放"的开关在 iOS 上必然是个失效的承诺。引擎行业默认也是切后台静音（Unity `runInBackground=false`、Unreal `UnfocusedVolumeMultiplier=0`、Phaser `pauseOnBlur=true`、Cocos `visibilitychange` 硬挂起），故硬编码默认 hide→suspend。
  - hide→suspend 与延迟创建 ctx（iOS 中断根因）是**正交两件事**，分开处理。
- `_recoverPlaybackContext`：切后台/锁屏回前台且 ctx 非 running 时，做 `suspend → 100ms → resume` 唤醒僵尸 ctx（iOS 的 `interrupted` 态不能直接 resume，必须先 suspend 转 suspended）。
- **恢复定时器 staleness 检查**：回前台触发 `suspend → 100ms → resume` 的窗口内，若页面又被切回后台（`document.hidden`）或期间发生过显式 `suspend()`（`_suspendedByCaller`），则**不在隐藏页/已主动暂停态上 resume**（对齐 `play()` 对 `document.hidden` 的 drop 语义）。
- **bfcache**：back/forward cache 恢复只派发 `pageshow`（`persisted=true`）、**不派发** `visibilitychange`，故 `_onPageShow` 在 persisted 时同走恢复。（隔离实测：停用 visibilitychange、仅 pageshow 命中仍能恢复循环音。）
- `_recovering` 重入守卫：bfcache 恢复会**同时**派发 visibilitychange 和 pageshow，无守卫会让 suspend→resume 跑两遍（浪费 + 第二个 resume 打在未落地的 suspend 上）。守卫在定时器里无条件清除，不依赖 suspend/resume promise settle（iOS 在 interrupted 态下该 promise 可能永不 settle，会卡死恢复）。
- `_suspendedByCaller`：用户显式 `suspend()` 不被手势/可见性自动唤醒（公开 API 语义：主动暂停不该被自动恢复）。
- **`suspend()` 无 ctx 时是纯 no-op**（公开 API 硬化，两处真机 bug 修复）：
  - **不为 suspend 创建 ctx**：原先无条件 `getContext().suspend()`，用户在任何播放前调一次 `suspend()` 就会凭空创建一个手势前冷 ctx——正是本 PR 要规避的 zombie 来源。加 `!_context` 守卫，无 ctx 直接 resolve。
  - **不置幽灵标志**：无 ctx 时仍 `_suspendedByCaller = true` 会留下一个"幽灵"标志——首次 `play()`（手势内建 ctx 并播放）后，它会让回前台的 `_recoverPlaybackContext` 守卫短路、阻断恢复。这是 **Android 专属**症状：iOS 新建 ctx 默认 suspended → `play()` 走 resume 分支（resume 清标志）；Android 手势内新建 ctx 立即 running → `play()` 走 `_startPlayback` 直播、跳过 resume → 标志残留。修复：`suspend()` 无 ctx 时不触碰 `_suspendedByCaller`（状态标志只应在它镜像的动作真实发生过时为真）。

### 平台归属注释
音频生命周期里多处是平台专属处理（bfcache `pageshow`、手势 resume、`_resumeAfterInterruption` 都只为 iOS Safari）。注释明确标注 "iOS Safari"，避免后人误当通用逻辑删掉。

### 移除 `onstatechange`
实测确认 onstatechange 驱动的恢复无可挽回的场景，且它本身正是冷 ctx 僵尸态的来源之一：
- **独占中断**（来电）由根因（延迟创建 → 热 ctx）覆盖，iOS 自愈；
- **前台中断**（小窗来电横幅 / Siri，页面仍可见）实测同样由热 ctx 自愈（iOS 自行 `interrupted → running`），无需监听器；
- **来电之外的纯外部中断**在 iOS 上没有可触发场景（放音乐/视频是叠加混播、不打断）。

故删除不漏任何可复现场景。

## 测试

重写为 `AudioSourcePendingPlayback.test.ts`（mock AudioContext，无需真引擎，browser-mode vitest 全绿）覆盖：延迟创建 / 懒 gainNode / pre-play volume 首播生效；play 守卫（无 clip / 已播 / 已 pending no-op，running 立即播）；hidden 丢弃（不 pend、不 suspend，丢弃后回前台不重放）；pending 重放与取消、autoplay-blocked 丢弃；resume 解锁与重叠合并；hide→suspend 与 staleness（隐藏页/主动暂停不 resume）；显式 suspend 不自动唤醒、suspend 无 ctx 不创建/不置标志；僵尸态 `suspend → 100ms → resume`、suspend reject 不阻断 scheduled resume；bfcache pageshow（persisted）恢复与 `_recovering` 重入守卫；记账（`_playingCount` / 偏移）。

**真机验证矩阵：**

| 验证项 | 平台 | 结果 |
|---|---|---|
| 切后台 hide→suspend 静音 | Android Chrome | ctx `running → suspended`，后台静音生效 |
| 回前台恢复出声（未主动 suspend） | iOS + Android | 回前台恢复出声 |
| 幽灵标志修复（先 `suspend()` 无 ctx → play → 切后台 → 回前台） | Android Chrome | 修复后回前台恢复出声（修复前无声） |
| 前台中断自愈（小窗来电横幅 / Siri / 闹钟） | iOS Safari | 页面可见时 ctx `running → interrupted`，中断结束 iOS 自行 `interrupted → running`，无需 onstatechange |

另：来电独占中断自愈、bfcache 恢复（隔离验证 pageshow 独立有效）、后台 play 漏音丢弃、`_recovering` 连续切后台多次每次恢复，均已真机验证（见下方复现/修复对比页面）。

## 兼容性
- 功能可用下限 **iOS ≥ 9**：`AudioContext.suspend()/resume()` 返回 Promise 自 iOS 9 起；`OfflineAudioContext` 自 iOS 14.1+，老 iOS 经 Polyfill 接到 `webkitOfflineAudioContext`（自 iOS 7）。
- `document.hidden` / `visibilitychange` / `pageshow` 均为已广泛支持的标准 API。

## 真机复现 / 修复对比（iOS Safari）

每个问题都提供「复现版」与「修复版」两个可直接在 iOS Safari 打开的页面（均打包真实引擎）：

| 问题 | 复现版（修复前） | 修复版（修复后） | 操作 & 判定 |
|---|---|---|---|
| 切后台/锁屏回前台不出声 | [q1-norescue](https://mdn.alipayobjects.com/rms/afts/file/A*PK7YTZ1KyXQAAAAAgCAAAAgAehQnAQ/q1-norescue.html) | [q1-minfix](https://mdn.alipayobjects.com/rms/afts/file/A*k7AxSZLgTwkAAAAAgCAAAAgAehQnAQ/q1-minfix.html) | 播放循环音 → 切后台/锁屏数秒 → 回前台。复现版无声，修复版恢复 |
| 显式 suspend 被手势误唤醒 | [q2-repro](https://mdn.alipayobjects.com/rms/afts/file/A*H2oQR5vWkO4AAAAAgCAAAAgAehQnAQ/q2-repro.html) | [q2-fixed](https://mdn.alipayobjects.com/rms/afts/file/A*awuIQo4O5GQAAAAAgCAAAAgAehQnAQ/q2-fixed.html) | 播放 → 主动 suspend → 点屏幕。复现版被误唤醒，修复版保持暂停 |
| 来电中断后僵尸态（根因） | [q3-repro](https://mdn.alipayobjects.com/rms/afts/file/A*BEfhR65M1m4AAAAAgCAAAAgAehQnAQ/q3-repro.html) | [q3-loaderfix2](https://mdn.alipayobjects.com/rms/afts/file/A*d_EwTb38MSIAAAAAgCAAAAgAehQnAQ/q3-loaderfix2.html) | 播放 → 接打一通电话 → 挂断。复现版 state=running 但无声（僵尸），修复版 iOS 自愈出声 |
| 后台 play 漏音 | [b-gate-test](https://mdn.alipayobjects.com/rms/afts/file/A*liW3Sq2lsFgAAAAAgCAAAAgAehQnAQ/b-gate-test.html) | [b-gate-fixed](https://mdn.alipayobjects.com/rms/afts/file/A*7XxrSKb7oIgAAAAAgCAAAAgAehQnAQ/b-gate-fixed.html) | 切后台时触发 play。复现版后台漏出一声，修复版静默丢弃 |
| bfcache 恢复不出声 | [bfcache-test](https://mdn.alipayobjects.com/rms/afts/file/A*ZeFFSrx3SGcAAAAAgCAAAAgAehQnAQ/bfcache-test.html) | [bfcache-fixed](https://mdn.alipayobjects.com/rms/afts/file/A*eiWSSqkdOyMAAAAAgCAAAAgAehQnAQ/bfcache-fixed.html) | 播放 → 导航到别的页 → 后退（bfcache 命中 persisted=true）。复现版无声，修复版恢复 |

> 页面顶部实时显示 AudioContext 的 `state` / `currentTime`（是否在走）等内部状态，便于对照「复现 vs 修复」的差异。

### 后续修复的真机验证（单页 + 操作，均用本 PR 最终引擎）

以下三处问题（hide→suspend、幽灵标志、前台中断自愈）的验证页用最终引擎打包，靠操作 + 页面实时状态判定（不是修复前/后两版对照）：

| 验证项 | 页面 | 操作 & 判定 |
|---|---|---|
| 切后台静音（hide→suspend，桌面/Android WebAudio 后台不自停） | [bg-suspend-probe](https://mdn.alipayobjects.com/rms/afts/file/A*F388RIBhp1UAAAAAQDAAAAgAehQnAQ/bg-suspend-probe.html)（纯 WebAudio 探针，证明平台不自动 suspend）/ [fg-interrupt-test](https://mdn.alipayobjects.com/rms/afts/file/A*zu9VQKV91QgAAAAAgCAAAAgAehQnAQ/fg-interrupt-test.html)（真引擎） | 桌面 Chrome / Android：播放 → 切 tab/最小化。纯 WebAudio 探针证明平台不自停（一直响）；真引擎修复后 ctx `running → suspended`、后台静音 |
| 幽灵标志（先 `suspend()` 无 ctx → play → 切后台 → 回前台） | [fix-a-verify](https://mdn.alipayobjects.com/rms/afts/file/A*OGgdTJRRSpoAAAAAgCAAAAgAehQnAQ/fix-a-verify.html) | Android：点按钮（先 suspend 无 ctx → 立即 play）→ 看 `_suspendedByCaller` 应为 false → 切后台 → 回前台恢复出声（修复前 Android 残留 true、不恢复） |
| 前台中断自愈（小窗来电横幅 / Siri，页面仍可见） | [fg-interrupt-test](https://mdn.alipayobjects.com/rms/afts/file/A*zu9VQKV91QgAAAAAgCAAAAgAehQnAQ/fg-interrupt-test.html) | iOS：前台播放 → 制造小窗来电/Siri → ctx `running → interrupted`（页面仍 visible）→ 挂断后什么都不点，ctx 自行 `interrupted → running`、BGM 自响（热 ctx 自愈，无需 onstatechange） |

## 与原方案 #3026 的逐项对比

作者 #3026 **在出口处打补丁**：用 `onstatechange` + 动态挂/摘手势监听 + `_hidden` 镜像 + `_foregroundResumeTimer` 一整套状态机去追逐已损坏的 AudioContext 状态，但没碰**根因**——`AudioSource` 构造函数和 `AudioLoader` 解码都在任何用户手势之前就创建了播放 ctx，iOS 上这种 pre-gesture 冷 ctx 中断后会永久停在静音 zombie 态，再多恢复逻辑也救不回。本 PR **从输入端修根因**，并覆盖作者全部场景：

| 关切点 | 作者 #3026 | 本 PR | 判定 |
|---|---|---|---|
| **上下文创建时机（根因）** | `AudioSource` 构造即 `getContext().createGain()` → ctx 在手势前冷创建，iOS 中断后永久 zombie | gainNode 首次 `play()` 时 `_ensureGainNode()` 懒建，构造不碰 ctx → ctx 必在手势内热创建 | **更优（修了作者没碰的根因）** |
| **解码上下文** | `AudioLoader` 复用播放 ctx 解码 → 加载期就把播放 ctx 拉起，同样踩 zombie | 独立 `OfflineAudioContext(1,1,44100)` 解码，完全不触播放 ctx | **更优** |
| **独占中断（来电）后恢复** | 恢复动作机制相近，但作用在冷 ctx 上——iOS 来电后冷 ctx 已 zombie，恢复失效 | 根因修复后 ctx 是热的，iOS 来电后自愈；手势 resume 仅作兜底 | **更优（同样的恢复动作，热 ctx 才真生效）** |
| **切后台/锁屏回前台恢复** | `_onShown` → `suspend → 100ms → resume`，`_foregroundResumeTimer` 守 staleness | `_recoverPlaybackContext` → 同样 `suspend → 100ms → resume`，`_recovering` 守重入 + 隐藏页/主动暂停 staleness 检查 | 同等 |
| **切后台静音（hide→suspend）** | hide 时 suspend | `_onVisibilityChange` hidden 分支 `_context?.suspend()`（仅在 ctx 已存在时，不创建、不污染 `_suspendedByCaller`）；Android 真机验证后台静音 | 同等（覆盖版误删后已补回，并避免为 suspend 创建冷 ctx） |
| **bfcache 恢复** | `_onShown` 第一行 `if (!_hidden) return`；bfcache 只发 pageshow 不发 visibilitychange，从未置 `_hidden` → **恢复不了** | `_onPageShow` 显式判 `event.persisted` 走恢复，`_recovering` 防双触发 | **更优（作者此路不通）** |
| **后台 play（hidden）** | `_canStartPlayback` 在 hidden 时先 `_onHidden` 再 return → 走 pending，回前台异步补播 | `play()` 首行 `if (document.hidden) return` 直接丢弃（不漏音、不乱序补播） | **更优** |
| **主动 suspend 不被误唤醒** | `_suspendedByCaller`，散布 5 处判 | `_suspendedByCaller`，集中收口；且 `suspend()` 无 ctx 时纯 no-op、不置幽灵标志（修 Android 回前台不恢复的真机 bug） | **更优（标志只在动作真实发生时置位）** |
| **外部中断（onstatechange）** | `context.onstatechange` 检测翻转挂手势监听 | 移除——独占中断由根因覆盖；**前台中断（小窗来电/Siri）实测由热 ctx 自行 `interrupted → running` 自愈，iOS 真机验证**；来电之外的纯外部中断在 iOS 无可触发场景 | **有意移除（无功能回退，前台中断已经真机验证由热 ctx 兜住）** |
| **可见性状态** | `_hidden` 布尔镜像，多处读写易与 `document.hidden` 漂移 | 无镜像，直接读 `document.hidden`（单一事实源） | **更优** |

**移除的作者机制**（已逐一核对作者代码确实存在，本 PR 全部移除且无功能回退）：`_onContextStateChange`(onstatechange) / `_canStartPlayback` / `_hidden` / `_foregroundResumeTimer` / `_addGestureListeners` / `_removeGestureListeners` / `_onHidden` / `_onShown`。根因修复后这些追逐损坏状态的机制不再需要，常驻可见性监听 + 直接读 `document.hidden` 即等价覆盖。

**净效果**：覆盖作者全部场景（无一遗漏），修了他没触及的 iOS zombie 根因，删掉一整套易漂移的可见性状态机；同时补回全平台 hide→suspend 静音、硬化公开 `suspend()`、修复 Android 幽灵标志 bug。净 diff `+539 / -391`（含重写的测试）。

> **关于移除 onstatechange 的取舍**：onstatechange 在 #3026 中用于追踪外部中断，但实测它能覆盖的场景已被根因（热 ctx）全部接管——独占来电中断、前台中断（小窗来电横幅/Siri，已 iOS 真机验证）均由 iOS 对热 ctx 自行 `interrupted → running` 复位，而"不触发 visibility/pageshow 的纯外部中断"在 iOS 上无法触发（放音乐/视频是叠加混播）。故移除无实际功能损失。

