### PR TITLE
refactor: convert string enums to const objects with type extraction

### DIFF
--- a/packages/core/src/EngineEventType.ts
+++ b/packages/core/src/EngineEventType.ts
@@ -1,13 +1,15 @@
 /**
  * Engine event type.
  */
-export enum EngineEventType {
+export const EngineEventType = {
   /** Dispatched when the engine starts running. */
-  Run = "run",
+  Run: "run",
   /** Dispatched when the engine shuts down. */
-  Shutdown = "shutdown",
+  Shutdown: "shutdown",
   /** Dispatched when the graphic device is lost. */
-  DeviceLost = "devicelost",
+  DeviceLost: "devicelost",
   /** Dispatched when the graphic device is restored. */
-  DeviceRestored = "devicerestored"
-}
+  DeviceRestored: "devicerestored"
+} as const;
+
+export type EngineEventType = (typeof EngineEventType)[keyof typeof EngineEventType];

--- a/packages/core/src/RenderPipeline/enums/PipelineStage.ts
+++ b/packages/core/src/RenderPipeline/enums/PipelineStage.ts
@@ -1,11 +1,13 @@
 /**
  * Pipeline stage.
  */
-export enum PipelineStage {
+export const PipelineStage = {
   /** DepthOnly stage. */
-  DepthOnly = "DepthOnly",
+  DepthOnly: "DepthOnly",
   /** Shadow caster stage. */
-  ShadowCaster = "ShadowCaster",
+  ShadowCaster: "ShadowCaster",
   /** Forward shading stage. */
-  Forward = "Forward"
-}
+  Forward: "Forward"
+} as const;
+
+export type PipelineStage = (typeof PipelineStage)[keyof typeof PipelineStage];

--- a/packages/core/src/asset/AssetType.ts
+++ b/packages/core/src/asset/AssetType.ts
@@ -1,55 +1,57 @@
 /**
  * Asset Type.
  */
-export enum AssetType {
+export const AssetType = {
   /** Plain text. */
-  Text = "Text",
+  Text: "Text",
   /** JSON. */
-  JSON = "JSON",
+  JSON: "JSON",
   /** ArrayBuffer. */
-  Buffer = "Buffer",
+  Buffer: "Buffer",
   /** Texture. */
-  Texture = "Texture",
+  Texture: "Texture",
   /** Material. */
-  Material = "Material",
+  Material: "Material",
   /** Shader. */
-  Shader = "Shader",
+  Shader: "Shader",
   /** Mesh. */
-  Mesh = "Mesh",
+  Mesh: "Mesh",
   /** AnimationClip. */
-  AnimationClip = "AnimationClip",
+  AnimationClip: "AnimationClip",
   /** AnimatorController. */
-  AnimatorController = "AnimatorController",
+  AnimatorController: "AnimatorController",
   /** Prefab.*/
-  Prefab = "Prefab",
+  Prefab: "Prefab",
   /** GLTF.*/
-  GLTF = "GLTF",
+  GLTF: "GLTF",
   /** Compress Texture. */
-  KTX = "KTX",
+  KTX: "KTX",
   /** Cube Compress Texture. */
-  KTXCube = "KTXCube",
+  KTXCube: "KTXCube",
   /** KTX2 Compress Texture */
-  KTX2 = "KTX2",
+  KTX2: "KTX2",
   /** Sprite. */
-  Sprite = "Sprite",
+  Sprite: "Sprite",
   /** PrimitiveMesh. */
-  PrimitiveMesh = "PrimitiveMesh",
+  PrimitiveMesh: "PrimitiveMesh",
   /** Sprite Atlas. */
-  SpriteAtlas = "SpriteAtlas",
+  SpriteAtlas: "SpriteAtlas",
   /** Ambient light. */
-  AmbientLight = "AmbientLight",
+  AmbientLight: "AmbientLight",
   /** Scene. */
-  Scene = "Scene",
+  Scene: "Scene",
   /** Font. */
-  Font = "Font",
+  Font: "Font",
   /** Source Font, include ttf, otf and woff. */
-  SourceFont = "SourceFont",
+  SourceFont: "SourceFont",
   /** AudioClip, include ogg, wav, mp3, m4a, aac and flac. */
-  Audio = "Audio",
+  Audio: "Audio",
   /** Project asset. */
-  Project = "project",
+  Project: "project",
   /** PhysicsMaterial. */
-  PhysicsMaterial = "PhysicsMaterial",
+  PhysicsMaterial: "PhysicsMaterial",
   /** RenderTarget. */
-  RenderTarget = "RenderTarget"
-}
+  RenderTarget: "RenderTarget"
+} as const;
+
+export type AssetType = (typeof AssetType)[keyof typeof AssetType];

--- a/packages/core/src/base/Constant.ts
+++ b/packages/core/src/base/Constant.ts
@@ -87,46 +87,48 @@ export enum DataType {
  * GL Capabilities
  * Some capabilities can be smoothed out by extension, and some capabilities must use WebGL 2.0.
  * */
-export enum GLCapabilityType {
-  shaderVertexID = "shaderVertexID",
-  standardDerivatives = "OES_standard_derivatives",
-  shaderTextureLod = "EXT_shader_texture_lod",
-  elementIndexUint = "OES_element_index_uint",
-  depthTexture = "WEBGL_depth_texture",
-  drawBuffers = "WEBGL_draw_buffers",
-  vertexArrayObject = "OES_vertex_array_object",
-  instancedArrays = "ANGLE_instanced_arrays",
-  multipleSample = "multipleSampleOnlySupportedInWebGL2",
-  textureFloat = "OES_texture_float",
-  textureFloatLinear = "OES_texture_float_linear",
-  textureHalfFloat = "OES_texture_half_float",
-  textureHalfFloatLinear = "OES_texture_half_float_linear",
-  WEBGL_colorBufferFloat = "WEBGL_color_buffer_float",
-  colorBufferFloat = "EXT_color_buffer_float",
-  colorBufferHalfFloat = "EXT_color_buffer_half_float",
-  textureFilterAnisotropic = "EXT_texture_filter_anisotropic",
-  blendMinMax = "EXT_blend_minmax",
-  fragDepth = "EXT_frag_depth",
+export const GLCapabilityType = {
+  shaderVertexID: "shaderVertexID",
+  standardDerivatives: "OES_standard_derivatives",
+  shaderTextureLod: "EXT_shader_texture_lod",
+  elementIndexUint: "OES_element_index_uint",
+  depthTexture: "WEBGL_depth_texture",
+  drawBuffers: "WEBGL_draw_buffers",
+  vertexArrayObject: "OES_vertex_array_object",
+  instancedArrays: "ANGLE_instanced_arrays",
+  multipleSample: "multipleSampleOnlySupportedInWebGL2",
+  textureFloat: "OES_texture_float",
+  textureFloatLinear: "OES_texture_float_linear",
+  textureHalfFloat: "OES_texture_half_float",
+  textureHalfFloatLinear: "OES_texture_half_float_linear",
+  WEBGL_colorBufferFloat: "WEBGL_color_buffer_float",
+  colorBufferFloat: "EXT_color_buffer_float",
+  colorBufferHalfFloat: "EXT_color_buffer_half_float",
+  textureFilterAnisotropic: "EXT_texture_filter_anisotropic",
+  blendMinMax: "EXT_blend_minmax",
+  fragDepth: "EXT_frag_depth",
 
-  astc = "WEBGL_compressed_texture_astc",
-  astc_webkit = "WEBKIT_WEBGL_compressed_texture_astc",
-  astc_hdr = "WEBGL_compressed_texture_astc_hdr",
-  etc = "WEBGL_compressed_texture_etc",
-  etc_webkit = "WEBKIT_WEBGL_compressed_texture_etc",
-  etc1 = "WEBGL_compressed_texture_etc1",
-  etc1_webkit = "WEBKIT_WEBGL_compressed_texture_etc1",
-  pvrtc = "WEBGL_compressed_texture_pvrtc",
-  pvrtc_webkit = "WEBKIT_WEBGL_compressed_texture_pvrtc",
-  s3tc = "WEBGL_compressed_texture_s3tc",
-  s3tc_webkit = "WEBKIT_WEBGL_compressed_texture_s3tc",
-  s3tc_srgb = "WEBGL_compressed_texture_s3tc_srgb",
+  astc: "WEBGL_compressed_texture_astc",
+  astc_webkit: "WEBKIT_WEBGL_compressed_texture_astc",
+  astc_hdr: "WEBGL_compressed_texture_astc_hdr",
+  etc: "WEBGL_compressed_texture_etc",
+  etc_webkit: "WEBKIT_WEBGL_compressed_texture_etc",
+  etc1: "WEBGL_compressed_texture_etc1",
+  etc1_webkit: "WEBKIT_WEBGL_compressed_texture_etc1",
+  pvrtc: "WEBGL_compressed_texture_pvrtc",
+  pvrtc_webkit: "WEBKIT_WEBGL_compressed_texture_pvrtc",
+  s3tc: "WEBGL_compressed_texture_s3tc",
+  s3tc_webkit: "WEBKIT_WEBGL_compressed_texture_s3tc",
+  s3tc_srgb: "WEBGL_compressed_texture_s3tc_srgb",
 
-  bptc = "EXT_texture_compression_bptc",
+  bptc: "EXT_texture_compression_bptc",
 
-  WEBGL_lose_context = "WEBGL_lose_context",
+  WEBGL_lose_context: "WEBGL_lose_context",
 
-  sRGB = "EXT_sRGB"
-}
+  sRGB: "EXT_sRGB"
+} as const;
+
+export type GLCapabilityType = (typeof GLCapabilityType)[keyof typeof GLCapabilityType];
 
 export type TypedArray =
   | Int8Array

--- a/packages/core/src/mesh/enums/VertexAttribute.ts
+++ b/packages/core/src/mesh/enums/VertexAttribute.ts
@@ -1,33 +1,35 @@
 /**
  * Vertex attribute types of a vertex in a ModelMesh.
  */
-export enum VertexAttribute {
+export const VertexAttribute = {
   /** Vertex position. */
-  Position = "POSITION",
+  Position: "POSITION",
   /** Vertex normal. */
-  Normal = "NORMAL",
+  Normal: "NORMAL",
   /** Vertex color. */
-  Color = "COLOR_0",
+  Color: "COLOR_0",
   /** Vertex tangent. */
-  Tangent = "TANGENT",
+  Tangent: "TANGENT",
   /** Vertex bone weight. */
-  BoneWeight = "WEIGHTS_0",
+  BoneWeight: "WEIGHTS_0",
   /** Vertex bone index. */
-  BoneIndex = "JOINTS_0",
+  BoneIndex: "JOINTS_0",
   /** Vertex UV. */
-  UV = "TEXCOORD_0",
+  UV: "TEXCOORD_0",
   /** Vertex UV1. */
-  UV1 = "TEXCOORD_1",
+  UV1: "TEXCOORD_1",
   /** Vertex UV2. */
-  UV2 = "TEXCOORD_2",
+  UV2: "TEXCOORD_2",
   /** Vertex UV3. */
-  UV3 = "TEXCOORD_3",
+  UV3: "TEXCOORD_3",
   /** Vertex UV4. */
-  UV4 = "TEXCOORD_4",
+  UV4: "TEXCOORD_4",
   /** Vertex UV5. */
-  UV5 = "TEXCOORD_5",
+  UV5: "TEXCOORD_5",
   /** Vertex UV6. */
-  UV6 = "TEXCOORD_6",
+  UV6: "TEXCOORD_6",
   /** Vertex UV7. */
-  UV7 = "TEXCOORD_7"
-}
+  UV7: "TEXCOORD_7"
+} as const;
+
+export type VertexAttribute = (typeof VertexAttribute)[keyof typeof VertexAttribute];

--- a/packages/loader/src/gltf/GLTFSchema.ts
+++ b/packages/loader/src/gltf/GLTFSchema.ts
@@ -37,122 +37,135 @@ export enum AccessorComponentType {
 /**
  * Specifies if the attirbute is a scalar, vector, or matrix
  */
-export enum AccessorType {
+export const AccessorType = {
   /**
    * Scalar
    */
-  SCALAR = "SCALAR",
+  SCALAR: "SCALAR",
   /**
    * Vector2
    */
-  VEC2 = "VEC2",
+  VEC2: "VEC2",
   /**
    * Vector3
    */
-  VEC3 = "VEC3",
+  VEC3: "VEC3",
   /**
    * Vector4
    */
-  VEC4 = "VEC4",
+  VEC4: "VEC4",
   /**
    * Matrix2x2
    */
-  MAT2 = "MAT2",
+  MAT2: "MAT2",
   /**
    * Matrix3x3
    */
-  MAT3 = "MAT3",
+  MAT3: "MAT3",
   /**
    * Matrix4x4
    */
-  MAT4 = "MAT4"
-}
+  MAT4: "MAT4"
+} as const;
+
+export type AccessorType = (typeof AccessorType)[keyof typeof AccessorType];
 
 /**
  * The name of the node's TRS property to modify, or the weights of the Morph Targets it instantiates
  */
-export enum AnimationChannelTargetPath {
+export const AnimationChannelTargetPath = {
   /**
    * Translation
    */
-  TRANSLATION = "translation",
+  TRANSLATION: "translation",
   /**
    * Rotation
    */
-  ROTATION = "rotation",
+  ROTATION: "rotation",
   /**
    * Scale
    */
-  SCALE = "scale",
+  SCALE: "scale",
   /**
    * Weights
    */
-  WEIGHTS = "weights"
-}
+  WEIGHTS: "weights"
+} as const;
+
+export type AnimationChannelTargetPath = (typeof AnimationChannelTargetPath)[keyof typeof AnimationChannelTargetPath];
 
 /**
  * Interpolation algorithm
  */
-export enum AnimationSamplerInterpolation {
+export const AnimationSamplerInterpolation = {
   /**
    * The animated values are linearly interpolated between keyframes
    */
-  Linear = "LINEAR",
+  Linear: "LINEAR",
   /**
    * The animated values remain constant to the output of the first keyframe, until the next keyframe
    */
-  Step = "STEP",
+  Step: "STEP",
   /**
    * The animation's interpolation is computed using a cubic spline with specified tangents
    */
-  CubicSpine = "CUBICSPLINE"
-}
+  CubicSpine: "CUBICSPLINE"
+} as const;
+
+export type AnimationSamplerInterpolation =
+  (typeof AnimationSamplerInterpolation)[keyof typeof AnimationSamplerInterpolation];
 
 /**
  * A camera's projection.  A node can reference a camera to apply a transform to place the camera in the scene
  */
-export enum CameraType {
+export const CameraType = {
   /**
    * A perspective camera containing properties to create a perspective projection matrix
    */
-  PERSPECTIVE = "perspective",
+  PERSPECTIVE: "perspective",
   /**
    * An orthographic camera containing properties to create an orthographic projection matrix
    */
-  ORTHOGRAPHIC = "orthographic"
-}
+  ORTHOGRAPHIC: "orthographic"
+} as const;
+
+export type CameraType = (typeof CameraType)[keyof typeof CameraType];
 
 /**
  * The mime-type of the image
  */
-export enum ImageMimeType {
+export const ImageMimeType = {
   /**
    * JPEG Mime-type
    */
-  JPEG = "image/jpeg",
+  JPEG: "image/jpeg",
   /**
    * PNG Mime-type
    */
-  PNG = "image/png"
-}
+  PNG: "image/png"
+} as const;
+
+export type ImageMimeType = (typeof ImageMimeType)[keyof typeof ImageMimeType];
 
 /**
  * The alpha rendering mode of the material
  */
-export enum MaterialAlphaMode {
+export const MaterialAlphaMode = {
   /**
    * The alpha value is ignored and the rendered output is fully opaque
    */
-  OPAQUE = "OPAQUE",
+  OPAQUE: "OPAQUE",
   /**
    * The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value
    */
-  MASK = "MASK",
+  MASK: "MASK",
   /**
    * The alpha value is used to composite the source and destination areas. The rendered output is combined with the background using the normal painting operation (i.e. the Porter and Duff over operator)
    */
-  BLEND = "BLEND"
-}
+  BLEND: "BLEND"
+} as const;
+
+export type MaterialAlphaMode = (typeof MaterialAlphaMode)[keyof typeof MaterialAlphaMode];
 
 /**
  * Magnification filter.  Valid values correspond to WebGL enums: 9728 (NEAREST) and 9729 (LINEAR)

--- a/packages/loader/src/schema/MaterialSchema.ts
+++ b/packages/loader/src/schema/MaterialSchema.ts
@@ -14,13 +14,15 @@ export interface IMaterialSchema {
   shaderRef: RefItem;
 }
 
-export enum MaterialLoaderType {
-  Vector2 = "Vector2",
-  Vector3 = "Vector3",
-  Vector4 = "Vector4",
-  Color = "Color",
-  Float = "Float",
-  Texture = "Texture",
-  Boolean = "Boolean",
-  Integer = "Integer"
-}
+export const MaterialLoaderType = {
+  Vector2: "Vector2",
+  Vector3: "Vector3",
+  Vector4: "Vector4",
+  Color: "Color",
+  Float: "Float",
+  Texture: "Texture",
+  Boolean: "Boolean",
+  Integer: "Integer"
+} as const;
+
+export type MaterialLoaderType = (typeof MaterialLoaderType)[keyof typeof MaterialLoaderType];


### PR DESCRIPTION
- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

未来node会原生支持ts的可擦除特性，这样写可以适配tsconfig.json的 `"erasableSyntaxOnly": true` 。目前仅对EngineEventType做了这种修改，如果接受这种方案，后续提交commit统一enum样式。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced multiple exported TypeScript enums with `as const` constant objects, while preserving the same underlying string values.
  * Updated the related exported TypeScript types to be derived from those constant values across engine events, pipeline/asset/vertex options, and glTF/material schema string definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->