### PR TITLE
fix(ui): correct root-canvas demotion state and listener bookkeeping

### DIFF
--- a/packages/ui/src/Utils.ts
+++ b/packages/ui/src/Utils.ts
@@ -139,6 +139,12 @@ export class Utils {
       entity = entity.parent;
       count++;
     }
+    // A shorter chain drops tail entries — they must release the listener, or the bound
+    // element stays reachable from (and invocable by) entities it no longer tracks.
+    for (let i = count, n = listeningEntities.length; i < n; i++) {
+      // @ts-ignore
+      listeningEntities[i]._unRegisterModifyListener(listener);
+    }
     listeningEntities.length = count;
   }
 

--- a/packages/ui/src/component/UICanvas.ts
+++ b/packages/ui/src/component/UICanvas.ts
@@ -412,7 +412,9 @@ export class UICanvas extends Component implements IElement {
         this._setIsRootCanvas(!rootCanvas);
         Utils.setRootCanvas(this, rootCanvas);
       } else if (flag === EntityUIModifyFlags.CanvasEnableInScene) {
-        this._setIsRootCanvas(false);
+        // The enabling canvas has not claimed root status at dispatch time, so searches
+        // inside the demote cascade cannot find it — hand it down as the successor.
+        this._setIsRootCanvas(false, <UICanvas>param);
         Utils.setRootCanvas(this, <UICanvas>param);
       }
     } else {
@@ -632,7 +634,7 @@ export class UICanvas extends Component implements IElement {
     }
   }
 
-  private _setIsRootCanvas(isRootCanvas: boolean): void {
+  private _setIsRootCanvas(isRootCanvas: boolean, successor: UICanvas = null): void {
     if (this._isRootCanvas !== isRootCanvas) {
       this._isRootCanvas = isRootCanvas;
       this._updateCameraObserver();
@@ -643,11 +645,16 @@ export class UICanvas extends Component implements IElement {
         const { _disorderedElements: disorderedElements } = this;
         disorderedElements.forEach((element: IElement) => {
           if (element instanceof UICanvas) {
-            const rootCanvas = Utils.searchRootCanvasInParents(element);
-            element._setIsRootCanvas(!rootCanvas);
+            // `successor` covers the enable-driven demote, where the search cannot see the
+            // enabling canvas yet (it claims root status only after its dispatch returns).
+            const rootCanvas = Utils.searchRootCanvasInParents(element) ?? successor;
+            element._setIsRootCanvas(!rootCanvas, successor);
             Utils.setRootCanvas(element, rootCanvas);
           } else {
-            Utils.setRootCanvasDirty(this);
+            // Reset the element's own canvas state (stale _rootCanvas/_indexInRootCanvas and
+            // the dirty flag the new root's walk re-assignment is gated on) — the bulk
+            // clear below only empties this canvas's list.
+            Utils.setRootCanvasDirty(element);
             Utils.setGroupDirty(<IGroupAble>element);
           }
         });

--- a/tests/src/ui/UICanvas.test.ts
+++ b/tests/src/ui/UICanvas.test.ts
@@ -1,7 +1,7 @@
 import { Camera } from "@galacean/engine-core";
 import { Vector2 } from "@galacean/engine-math";
 import { WebGLEngine } from "@galacean/engine";
-import { CanvasRenderMode, ResolutionAdaptationMode, UICanvas, UITransform } from "@galacean/engine-ui";
+import { CanvasRenderMode, Image, ResolutionAdaptationMode, UICanvas, UITransform } from "@galacean/engine-ui";
 import { describe, expect, it } from "vitest";
 
 describe("UICanvas", async () => {
@@ -350,5 +350,68 @@ describe("UICanvas", async () => {
     camera.enabled = true;
     // @ts-ignore
     expect(rootCanvas._canDispatchEvent(camera2)).to.be.false;
+  });
+  it("re-homes elements to the new root canvas when theirs loses root status", () => {
+    const outerEntity = root.createChild("outer");
+    const innerEntity = outerEntity.createChild("inner");
+    const innerCanvas = innerEntity.addComponent(UICanvas);
+    const imageEntity = innerEntity.createChild("image");
+    const image = imageEntity.addComponent(Image);
+
+    // Collected by the inner canvas while it is the root.
+    // @ts-ignore
+    innerCanvas._getRenderers();
+    // @ts-ignore
+    expect(image._getRootCanvas()).to.eq(innerCanvas);
+    // @ts-ignore
+    expect(innerCanvas._disorderedElements.length).to.be.greaterThan(0);
+
+    // Enabling a canvas on an ancestor demotes the inner one.
+    const outerCanvas = outerEntity.addComponent(UICanvas);
+    // @ts-ignore
+    expect(innerCanvas._isRootCanvas).to.be.false;
+    // @ts-ignore
+    expect(outerCanvas._isRootCanvas).to.be.true;
+    // The element's canvas state must be reset (the walk's re-assignment is gated on the
+    // dirty flag), otherwise it keeps rendering into the demoted canvas's dead queue.
+    // @ts-ignore
+    expect(image._isRootCanvasDirty).to.be.true;
+    // @ts-ignore
+    expect(image._rootCanvas).to.be.null;
+
+    // The new root adopts it on its next walk.
+    // @ts-ignore
+    outerCanvas._getRenderers();
+    // @ts-ignore
+    expect(image._getRootCanvas()).to.eq(outerCanvas);
+
+    outerEntity.destroy();
+  });
+  it("re-roots nested canvases to the enabling ancestor canvas", () => {
+    const outerEntity = root.createChild("outer");
+    const midEntity = outerEntity.createChild("mid");
+    const midCanvas = midEntity.addComponent(UICanvas);
+    const innerEntity = midEntity.createChild("inner");
+    const innerCanvas = innerEntity.addComponent(UICanvas);
+    // @ts-ignore
+    expect(midCanvas._isRootCanvas).to.be.true;
+    // @ts-ignore
+    expect(innerCanvas._isRootCanvas).to.be.false;
+
+    // The enabling canvas claims root status only after its enable dispatch returns, so the
+    // demote cascade must hand it down instead of searching for it.
+    const outerCanvas = outerEntity.addComponent(UICanvas);
+    // @ts-ignore
+    expect(outerCanvas._isRootCanvas).to.be.true;
+    // @ts-ignore
+    expect(midCanvas._isRootCanvas).to.be.false;
+    // @ts-ignore
+    expect(innerCanvas._isRootCanvas).to.be.false;
+    // @ts-ignore
+    expect(midCanvas._getRootCanvas()).to.eq(outerCanvas);
+    // @ts-ignore
+    expect(innerCanvas._getRootCanvas()).to.eq(outerCanvas);
+
+    outerEntity.destroy();
   });
 });


### PR DESCRIPTION
## Summary

Ports three coupled `packages/ui` fixes from #3068 (fix/shaderlab) to `dev/2.0` — all three bug sites are byte-identical here.

1. **Demote loop dirtied the wrong object**: `UICanvas._setIsRootCanvas(false)` called `Utils.setRootCanvasDirty(this)` instead of `(element)`, so demoted elements kept a stale `_rootCanvas`/`_indexInRootCanvas` and a clean dirty flag — but the new root's walk re-assignment is *gated on the element's dirty flag*, so they kept rendering into the demoted canvas's dead queue and never re-homed.
2. **Listener leak on chain shrink**: `Utils._registerListener` truncated a shrinking listening chain (`listeningEntities.length = count`) without unregistering the dropped tail, permanently leaking listeners on ex-ancestor entities.
3. **Nested-canvas demotion relied on that leak**: `UpdateFlagManager.dispatch` iterates a backward snapshot (a listener appended mid-dispatch is never invoked by that dispatch), and the enabling canvas claims root status only *after* its `CanvasEnableInScene` dispatch returns — so the demote cascade's `searchRootCanvasInParents` could not find it and promoted nested canvases to root. Convergence previously depended on a leaked listener happening to sit at a low index of the backward iteration. The cascade now receives the enabling canvas as an explicit `successor` (`_setIsRootCanvas(false, successor)`).

(2) and (3) must land together: fixing the leak alone breaks nested-canvas re-rooting.

## Tests

Two regression tests added to `tests/src/ui/UICanvas.test.ts`:

- `re-homes elements to the new root canvas when theirs loses root status` — pins (1)
- `re-roots nested canvases to the enabling ancestor canvas` — pins (3), exercised through (2)

Negative validation: on unfixed `dev/2.0` (rebuilt dist without the source fixes) both new tests fail and all 6 existing tests pass; with the fixes the full ui suite is green (66/66, node22 `b:module` + `b:types`, vitest from `tests/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI canvas transitions when enabling ancestor canvases.
  * Ensured nested UI elements and canvases are correctly reassigned to the new root canvas during rendering.
  * Prevented stale event listeners from remaining active after UI hierarchy changes.

* **Tests**
  * Added coverage for canvas re-rooting and nested canvas behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->