### PR TITLE
fix(loader): decouple shader format from physical path

### DIFF
--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -631,7 +631,9 @@ const rePropName = RegExp(
 
 type VirtualPath = string;
 export interface VirtualResource {
+  /** Stable project-facing asset path, independent of build encoding and deployment. */
   virtualPath: string;
+  /** Physical load path or URL for the current build. */
   path: string;
   type: string;
   dependentAssetMap?: { [key: string]: string };

--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -631,9 +631,7 @@ const rePropName = RegExp(
 
 type VirtualPath = string;
 export interface VirtualResource {
-  /** Stable project-facing asset path, independent of build encoding and deployment. */
   virtualPath: string;
-  /** Physical load path or URL for the current build. */
   path: string;
   type: string;
   dependentAssetMap?: { [key: string]: string };

--- a/packages/loader/src/ShaderLoader.ts
+++ b/packages/loader/src/ShaderLoader.ts
@@ -14,22 +14,13 @@ class ShaderLoader extends Loader<Shader> {
     const url = item.url!;
     // @ts-expect-error _request is @internal
     return resourceManager._request<string>(url, { ...item, type: "text" }).then((code) => {
-      const precompiled = parsePrecompiledShader(code);
-      if (precompiled) {
+      const source = code.trimStart();
+      if (source.startsWith("{")) {
         // @ts-expect-error _createFromPrecompiled is @internal
-        return Shader._createFromPrecompiled(precompiled);
+        return Shader._createFromPrecompiled(JSON.parse(source));
       }
 
       return Shader.create(code, undefined, url);
     });
   }
-}
-
-function parsePrecompiledShader(code: string): object | undefined {
-  const source = code.trimStart();
-  if (!source.startsWith("{")) {
-    return undefined;
-  }
-
-  return JSON.parse(source);
 }

--- a/packages/loader/src/ShaderLoader.ts
+++ b/packages/loader/src/ShaderLoader.ts
@@ -12,18 +12,24 @@ import {
 class ShaderLoader extends Loader<Shader> {
   load(item: LoadItem, resourceManager: ResourceManager): AssetPromise<Shader> {
     const url = item.url!;
+    // @ts-expect-error _request is @internal
+    return resourceManager._request<string>(url, { ...item, type: "text" }).then((code) => {
+      const precompiled = parsePrecompiledShader(code);
+      if (precompiled) {
+        // @ts-expect-error _createFromPrecompiled is @internal
+        return Shader._createFromPrecompiled(precompiled);
+      }
 
-    if (url.endsWith(".shaderc")) {
-      // @ts-ignore
-      return resourceManager._request(url, { ...item, type: "json" }).then((data) => {
-        // @ts-ignore - _createFromPrecompiled is @internal
-        return Shader._createFromPrecompiled(data);
-      });
-    }
-
-    // @ts-ignore
-    return resourceManager._request<string>(url, { ...item, type: "text" }).then((code: string) => {
       return Shader.create(code, undefined, url);
     });
   }
+}
+
+function parsePrecompiledShader(code: string): object | undefined {
+  const source = code.trimStart();
+  if (!source.startsWith("{")) {
+    return undefined;
+  }
+
+  return JSON.parse(source);
 }

--- a/packages/loader/src/schema/ProjectSchema.ts
+++ b/packages/loader/src/schema/ProjectSchema.ts
@@ -1,4 +1,6 @@
+import type { VirtualResource } from "@galacean/engine-core";
+
 export interface IProject {
   scene: string;
-  files: { virtualPath: string; path: string; type: string; id: string; params?: Record<string, any> }[];
+  files: (VirtualResource & { id: string })[];
 }

--- a/tests/src/core/resource/ResourceManager.test.ts
+++ b/tests/src/core/resource/ResourceManager.test.ts
@@ -1,4 +1,4 @@
-import { AssetPromise, AssetType, ResourceManager, Texture2D } from "@galacean/engine";
+import { AssetPromise, AssetType, ResourceManager, Shader, Texture2D } from "@galacean/engine";
 import "@galacean/engine-loader";
 import { WebGLEngine } from "@galacean/engine";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -104,6 +104,61 @@ describe("ResourceManager", () => {
       expect(loaderSpy).toHaveBeenCalled();
       expect(loaderSpy.mock.calls[0][0].type).equal(AssetType.Texture);
       loaderSpy.mockRestore();
+    });
+
+    it("detects precompiled shader content behind an opaque physical path", async () => {
+      const resourceManager = engine.resourceManager;
+      const physicalPath = "https://cdn.ali.com/assets/8fca12?version=1";
+      resourceManager.registerVirtualResources([
+        {
+          virtualPath: "Shaders/custom.shader",
+          path: physicalPath,
+          type: AssetType.Shader
+        }
+      ]);
+      // @ts-ignore
+      const requestSpy = vi
+        .spyOn(resourceManager, "_requestByRemoteUrl")
+        .mockReturnValue(
+          AssetPromise.resolve(JSON.stringify({ name: "custom", platformTarget: 0, subShaders: [] })) as any
+        );
+      // @ts-ignore
+      const createSpy = vi.spyOn(Shader, "_createFromPrecompiled").mockReturnValue({ name: "custom" } as Shader);
+      try {
+        await resourceManager.load("Shaders/custom.shader");
+
+        expect(requestSpy).toHaveBeenCalledWith(physicalPath, expect.objectContaining({ type: "text" }));
+        expect(createSpy).toHaveBeenCalled();
+      } finally {
+        requestSpy.mockRestore();
+        createSpy.mockRestore();
+      }
+    });
+
+    it("keeps ordinary shader source on the source parser path", async () => {
+      const resourceManager = engine.resourceManager;
+      const physicalPath = "https://cdn.ali.com/assets/source-8fca12";
+      const source = 'Shader "Custom/Source" {}';
+      resourceManager.registerVirtualResources([
+        {
+          virtualPath: "Shaders/source.shader",
+          path: physicalPath,
+          type: AssetType.Shader
+        }
+      ]);
+      // @ts-ignore
+      const requestSpy = vi.spyOn(resourceManager, "_requestByRemoteUrl").mockReturnValue(AssetPromise.resolve(source));
+      const createSpy = vi.spyOn(Shader, "create").mockReturnValue({ name: "source" } as Shader);
+
+      try {
+        await resourceManager.load("Shaders/source.shader");
+
+        expect(requestSpy).toHaveBeenCalledWith(physicalPath, expect.objectContaining({ type: "text" }));
+        expect(createSpy).toHaveBeenCalledWith(source, undefined, "Shaders/source.shader");
+      } finally {
+        requestSpy.mockRestore();
+        createSpy.mockRestore();
+      }
     });
 
     it("fills params from virtualPathResourceMap when params is omitted", () => {


### PR DESCRIPTION
## Summary

- Document the stable logical asset path and build-specific physical load path contract on `VirtualResource`
- Reuse that contract from the project schema instead of maintaining a duplicate resource shape
- Let `ShaderLoader` distinguish ShaderLab source from precompiled shader JSON by payload content, so a stable `.shader` logical path can map to an opaque or rewritten build URL
- Add regressions for both precompiled and source shaders behind opaque physical paths

## Root cause

The resource map already owns asset identity and type: `virtualPath` is the stable project-facing key, while `path` is only the current build's fetch address. `ShaderLoader` still inferred source versus precompiled representation from the logical URL suffix, coupling user-visible identity to a deployment/build detail. A compiled shader behind a stable `.shader` path was therefore routed through the source parser.

After this change, the authoritative resource map continues to choose the Shader loader. The loader fetches the mapped physical payload once and chooses the matching parser from the payload itself; it does not rewrite the logical identity or introduce a second asset catalog.

## Validation

- `pnpm build`
- `pnpm exec vitest run tests/src/core/resource/ResourceManager.test.ts` — 20/20 passed in Chromium
- Changed-file ESLint — 0 errors
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader loading by detecting precompiled shader content directly, regardless of file extension.
  * Preserved correct handling of regular shader source files and virtual paths.
  * Improved project file typing for more consistent resource handling.

* **Tests**
  * Added coverage for precompiled and standard shader loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->