### PR TITLE
docs: cherry-pick documentation fixes to dev/2.0

### DIFF
--- a/docs/en/UI/system.mdx
+++ b/docs/en/UI/system.mdx
@@ -101,8 +101,8 @@ classDiagram
 
 | Package                                                                 | Description     | Related Documentation   |
 | :--------------------------------------------------------------------- | :------------- | ----------------------- |
-| [@galacean/engine-ui](https://www.npmjs.com/package/@galacean/engine-xr) | Core architecture logic | [API](/apis/galacean)    |
+| [@galacean/engine-ui](https://www.npmjs.com/package/@galacean/engine-ui) | Core architecture logic | [API](/apis/galacean)    |
 
 > `@galacean/engine-ui` is a dependency that must be included to implement **UI**.
 
-> The [version dependency rules](/en/docs/basics/version/#version-dependency) must be followed, meaning the version of `@galacean/engine-ui` should match the version of `@galacean/engine`.
+> The [version dependency rules](/en/docs/basics/version/#version-dependencies) must be followed, meaning the version of `@galacean/engine-ui` should match the version of `@galacean/engine`.

--- a/docs/en/script/attributes.mdx
+++ b/docs/en/script/attributes.mdx
@@ -46,7 +46,7 @@ Currently supported parameter types are:
 
 ## Parameter Configuration
 
-The second parameter of the `@inspect` decorator is an object used to configure various properties of the corresponding type parameter. Different parameter types have different options. For example, `Number` and `Slider` have `min` and `max` configurations, and `Select` has `options` configuration. For more configurable properties, you can check [@galaean/editor-decorators](https://www.npmjs.com/package/@galacean/editor-decorators?activeTab=readme). Below, taking the number selector as an example, we introduce the meaning of each configuration.
+The second parameter of the `@inspect` decorator is an object used to configure various properties of the corresponding type parameter. Different parameter types have different options. For example, `Number` and `Slider` have `min` and `max` configurations, and `Select` has `options` configuration. For more configurable properties, you can check [@galacean/editor-decorators](https://www.npmjs.com/package/@galacean/editor-decorators?activeTab=readme). Below, taking the number selector as an example, we introduce the meaning of each configuration.
 
 ```typescript
 import { Script } from '@galacean/engine';

--- a/docs/en/xr/overall.mdx
+++ b/docs/en/xr/overall.mdx
@@ -26,13 +26,13 @@ Galacean provides a clean and flexible design for XR:
 | Package                             | Description                          | Related Documentation |  
 | :---------------------------------- | :----------------------------------- | :-------------------- |  
 | `@galacean/engine-xr`               | Core architecture logic              | [API](/apis/galacean) |  
-| `@galacean/engine-web-xr`           | Backend package                      | [Doc](/en/docs/physics/overall) |  
+| `@galacean/engine-xr-webxr`         | Backend package                      | [Doc](/en/docs/xr/overall) |  
 | `@galacean/engine-toolkit-xr`       | Advanced tool components             | [Doc](/en/docs/xr/toolkit) |  
 
-> `@galacean/engine-xr` and `@galacean/engine-web-xr` are mandatory dependencies for implementing **WebXR**. In contrast, `@galacean/engine-toolkit-xr` is not required but simplifies XR development in the editor.  
+> `@galacean/engine-xr` and `@galacean/engine-xr-webxr` are mandatory dependencies for implementing **WebXR**. In contrast, `@galacean/engine-toolkit-xr` is not required but simplifies XR development in the editor.  
 
-> The dependency rules between XR packages follow the [version dependency rules](/en/docs/basics/version/#版本依赖):  
-> - The versions of `@galacean/engine-xr` and `@galacean/engine-web-xr` must match the version of `@galacean/engine`.  
+> The dependency rules between XR packages follow the [version dependency rules](/en/docs/basics/version/#version-dependencies):
+> - The versions of `@galacean/engine-xr` and `@galacean/engine-xr-webxr` must match the version of `@galacean/engine`.  
 > - The **major version** of `@galacean/engine-toolkit-xr` must match that of `@galacean/engine`.  
 
 ---

--- a/docs/zh/UI/system.mdx
+++ b/docs/zh/UI/system.mdx
@@ -101,7 +101,7 @@ classDiagram
 
 | 包                                                                       | 解释         | 相关文档              |
 | :----------------------------------------------------------------------- | :----------- | --------------------- |
-| [@galacean/engine-ui](https://www.npmjs.com/package/@galacean/engine-xr) | 核心架构逻辑 | [API](/apis/galacean) |
+| [@galacean/engine-ui](https://www.npmjs.com/package/@galacean/engine-ui) | 核心架构逻辑 | [API](/apis/galacean) |
 
 > `@galacean/engine-ui` 是实现 **UI** 必须引入的依赖
 

--- a/docs/zh/script/attributes.mdx
+++ b/docs/zh/script/attributes.mdx
@@ -46,7 +46,7 @@ export default class extends Script {
 
 ## 参数配置
 
-`@inspect` 装饰器的第二个参数是一个对象，用于配置所对应类型参数的各项属性。不同的参数类型对应的选项是不同的。比如 `Number` 和 `Slider` 具有 `min` `max` 配置，`Select` 有 `options` 配置。 想要了解更多的可配置属性可以查看 [@galaean/editor-decorators](https://www.npmjs.com/package/@galacean/editor-decorators?activeTab=readme) 。下面以数字选择器为例，介绍一下各项配置的含义。
+`@inspect` 装饰器的第二个参数是一个对象，用于配置所对应类型参数的各项属性。不同的参数类型对应的选项是不同的。比如 `Number` 和 `Slider` 具有 `min` `max` 配置，`Select` 有 `options` 配置。 想要了解更多的可配置属性可以查看 [@galacean/editor-decorators](https://www.npmjs.com/package/@galacean/editor-decorators?activeTab=readme) 。下面以数字选择器为例，介绍一下各项配置的含义。
 
 ```typescript
 import { Script } from '@galacean/engine';

--- a/docs/zh/xr/overall.mdx
+++ b/docs/zh/xr/overall.mdx
@@ -22,12 +22,12 @@ Galacean 对 XR 做了干净灵活的设计：
 | 包 | 解释 | 相关文档 |
 | :-- | :-- | --- |
 | [@galacean/engine-xr](https://www.npmjs.com/package/@galacean/engine-xr) | 核心架构逻辑 | [API](/apis/galacean) |
-| [@galacean/engine-web-xr](https://www.npmjs.com/package/@galacean/engine-web-xr) | 后端包 | [Doc](/docs/physics/overall) |
+| [@galacean/engine-xr-webxr](https://www.npmjs.com/package/@galacean/engine-xr-webxr) | 后端包 | [Doc](/docs/xr/overall) |
 | [@galacean/engine-toolkit-xr](https://www.npmjs.com/package/@galacean/engine-toolkit-xr) | 高级工具组件 | [Doc](/docs/xr/toolkit) |
 
-> `@galacean/engine-xr` 和 `@galacean/engine-web-xr`是实现 **WebXR** 必须引入的依赖，相较于上述两个包，`@galacean/engine-toolkit-xr` 则不是必须的，但它的存在可以让编辑器开发 XR 变得更加简单。
+> `@galacean/engine-xr` 和 `@galacean/engine-xr-webxr`是实现 **WebXR** 必须引入的依赖，相较于上述两个包，`@galacean/engine-toolkit-xr` 则不是必须的，但它的存在可以让编辑器开发 XR 变得更加简单。
 
-> XR 包之间的依赖规则遵守[版本依赖规则](/docs/basics/version/#版本依赖)，即 `@galacean/engine-xr` 和 `@galacean/engine-web-xr` 的版本需与 `@galacean/engine` 保持一致，`@galacean/engine-toolkit-xr` 的大版本需要与 `@galacean/engine` 保持一致。
+> XR 包之间的依赖规则遵守[版本依赖规则](/docs/basics/version/#版本依赖)，即 `@galacean/engine-xr` 和 `@galacean/engine-xr-webxr` 的版本需与 `@galacean/engine` 保持一致，`@galacean/engine-toolkit-xr` 的大版本需要与 `@galacean/engine` 保持一致。
 
 ## 快速上手
 


### PR DESCRIPTION
## Summary

- Cherry-pick galacean/engine#3080 into `dev/2.0`.
- Correct package names, npm links, XR documentation routes, and English version-dependency anchors.

## Impact

Keeps the 2.0 documentation consistent with the fixes already merged to `main`.

## Validation

- Confirmed the English links target `#version-dependencies`.
- No documentation build was run; this PR contains documentation-only changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected package names and links in UI, scripting, and WebXR documentation.
  * Updated UI and WebXR dependency guidance to reflect current package requirements.
  * Fixed version dependency references in English documentation.
  * Corrected a package-name typo in the editor decorators documentation.
  * Improved the placement of an XR compatibility item in the quick-start guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->